### PR TITLE
Fix mission title string formatting

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,7 +26,8 @@ class MainWindow(QMainWindow):
         if active_id:
             mission = get_mission_by_id(active_id)
             if mission:
-                title = "SARApp - {mission['number']} | {mission['name']}"
+                # Use an f-string so the mission details appear in the title
+                title = f"SARApp - {mission['number']} | {mission['name']}"
             else:
                 title = "SARApp - Incident Management Assistant"
         else:


### PR DESCRIPTION
## Summary
- Use f-string for mission title in main window so mission details display correctly

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_68996e5eb1ac832b86adcc13bf6313a2