### PR TITLE
Fix liaison spelling in main menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -202,12 +202,12 @@ class MainWindow(QMainWindow):
         pio_menu.addSeparator()
         pio_menu.addAction(QAction("Comms Log (ICS-309)", self))
 
-        # Liason Menu
-        liason_menu = menu_bar.addMenu("Liason")
-        liason_menu.addAction(QAction("Liason Officer Unit Log (ICS-214)", self))
-        liason_menu.addSeparator()
-        liason_menu.addAction(QAction("Agency Contacts", self))
-        liason_menu.addAction(QAction("Customer Requests", self))
+        # Liaison Menu
+        liaison_menu = menu_bar.addMenu("Liaison")
+        liaison_menu.addAction(QAction("Liaison Officer Unit Log (ICS-214)", self))
+        liaison_menu.addSeparator()
+        liaison_menu.addAction(QAction("Agency Contacts", self))
+        liaison_menu.addAction(QAction("Customer Requests", self))
 
         # Toolkits Menu
         toolkits_menu = menu_bar.addMenu("Toolkits")


### PR DESCRIPTION
## Summary
- Correct Liaison spelling across menu comment, label, action text and variable name

## Testing
- `flake8 main.py`
- `python -m py_compile main.py`
- `QT_QPA_PLATFORM=offscreen python main.py` *(fails: This plugin does not support propagateSizeHints())*


------
https://chatgpt.com/codex/tasks/task_b_68996f5ab6ac832b8f67c17abc522eac