### PR TITLE
Connect mission list selection signal to handler

### DIFF
--- a/models/qmlwindow.py
+++ b/models/qmlwindow.py
@@ -61,4 +61,6 @@ def open_mission_list(main_window=None):
             "missionModel": model,
             "missionHandler": handler
         })
+        root = win.qml_widget.rootObject()
+        root.missionSelected.connect(handler.select_mission)
         win.exec()


### PR DESCRIPTION
## Summary
- Connect mission list's `missionSelected` signal to `MissionHandler.select_mission` so double-clicking a mission triggers selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68997a41dd38832bbf32d808c8c8270b