### PR TITLE
Add safety module scaffolding

### DIFF
--- a/modules/safety/__init__.py
+++ b/modules/safety/__init__.py
@@ -1,0 +1,9 @@
+from .api import router
+from .panels.safety_dashboard import SafetyDashboard
+
+
+def get_safety_panel(mission_id: str):
+    """Return an instance of the SafetyDashboard panel."""
+    return SafetyDashboard(mission_id)
+
+__all__ = ["router", "get_safety_panel"]

--- a/modules/safety/api.py
+++ b/modules/safety/api.py
@@ -1,0 +1,74 @@
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter
+
+from . import services
+from .models import schemas
+
+router = APIRouter()
+
+
+@router.get("/api/safety/reports", response_model=List[schemas.SafetyReportRead])
+def get_reports(
+    mission_id: str,
+    severity: Optional[str] = None,
+    flagged: Optional[bool] = None,
+    q: Optional[str] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+):
+    return services.list_safety_reports(
+        mission_id,
+        severity=severity,
+        flagged=flagged,
+        q=q,
+        start=start,
+        end=end,
+    )
+
+
+@router.post("/api/safety/reports", response_model=schemas.SafetyReportRead)
+def create_report(mission_id: str, report: schemas.SafetyReportCreate):
+    return services.create_safety_report(mission_id, report)
+
+
+@router.get("/api/medical/incidents", response_model=List[schemas.MedicalIncidentRead])
+def get_incidents(mission_id: str):
+    return services.list_medical_incidents(mission_id)
+
+
+@router.post("/api/medical/incidents", response_model=schemas.MedicalIncidentRead)
+def create_incident(mission_id: str, incident: schemas.MedicalIncidentCreate):
+    return services.create_medical_incident(mission_id, incident)
+
+
+@router.get("/api/medical/triage", response_model=List[schemas.TriageEntryRead])
+def get_triage(mission_id: str):
+    return services.list_triage_entries(mission_id)
+
+
+@router.post("/api/medical/triage", response_model=schemas.TriageEntryRead)
+def create_triage(mission_id: str, entry: schemas.TriageEntryCreate):
+    return services.create_triage_entry(mission_id, entry)
+
+
+@router.get("/api/safety/zones", response_model=List[schemas.HazardZoneRead])
+def get_zones(mission_id: str):
+    return services.list_hazard_zones(mission_id)
+
+
+@router.post("/api/safety/zones", response_model=schemas.HazardZoneRead)
+def create_zone(mission_id: str, zone: schemas.HazardZoneCreate):
+    return services.create_hazard_zone(mission_id, zone)
+
+
+@router.post("/api/safety/caporm", response_model=schemas.CapOrmRead)
+def create_cap_orm(mission_id: str, payload: schemas.CapOrmCreate):
+    return services.create_cap_orm(mission_id, payload)
+
+
+@router.post("/api/safety/ics206/build", response_model=schemas.ICS206Read)
+def build_ics206(mission_id: str, payload: schemas.ICS206Create):
+    return services.build_ics206(mission_id, payload)
+

--- a/modules/safety/models/__init__.py
+++ b/modules/safety/models/__init__.py
@@ -1,0 +1,4 @@
+from .schemas import *  # noqa: F401,F403
+from .safety_models import *  # noqa: F401,F403
+
+__all__ = []

--- a/modules/safety/models/safety_models.py
+++ b/modules/safety/models/safety_models.py
@@ -1,0 +1,68 @@
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()
+
+
+class MedicalIncident(Base):
+    __tablename__ = "medical_incidents"
+
+    id = Column(Integer, primary_key=True)
+    person_id = Column(String, index=True)
+    type = Column(String)
+    time = Column(DateTime)
+    description = Column(Text)
+    treatment_given = Column(Text)
+    evac_required = Column(Boolean, default=False)
+    reported_by = Column(String)
+
+
+class SafetyReport(Base):
+    __tablename__ = "safety_reports"
+
+    id = Column(Integer, primary_key=True)
+    time = Column(DateTime)
+    location = Column(String)
+    severity = Column(String)
+    notes = Column(Text)
+    flagged = Column(Boolean, default=False)
+    reported_by = Column(String)
+
+
+class TriageEntry(Base):
+    __tablename__ = "triage_entries"
+
+    id = Column(Integer, primary_key=True)
+    patient_tag = Column(String, index=True)
+    location = Column(String)
+    triage_level = Column(String)
+    time_found = Column(DateTime)
+    treated_by = Column(String)
+    notes = Column(Text)
+    disposition = Column(String)
+
+
+class HazardZone(Base):
+    __tablename__ = "hazard_zones"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    coordinates_json = Column(Text)
+    severity = Column(String)
+    description = Column(Text)
+
+
+class CapOrmForm(Base):
+    __tablename__ = "cap_orm_forms"
+
+    id = Column(Integer, primary_key=True)
+    mission_id = Column(String, index=True)
+    form_type = Column(String)
+    activity = Column(String)
+    participants_json = Column(Text)
+    hazards_json = Column(Text)
+    mitigations_json = Column(Text)
+    residual_risk = Column(String)
+    created_by = Column(String)
+    created_at = Column(DateTime)
+    updated_at = Column(DateTime)

--- a/modules/safety/models/schemas.py
+++ b/modules/safety/models/schemas.py
@@ -1,0 +1,160 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+# ----------------------------------------------------------------------------
+# Shared schemas
+# ----------------------------------------------------------------------------
+
+
+class PermissionOut(BaseModel):
+    can_view: bool
+    can_edit: bool
+    can_publish: bool
+
+
+# ----------------------------------------------------------------------------
+# Safety Report
+# ----------------------------------------------------------------------------
+
+
+class SafetyReportBase(BaseModel):
+    time: datetime
+    location: Optional[str] = None
+    severity: Optional[str] = None
+    notes: Optional[str] = None
+    flagged: bool = False
+    reported_by: Optional[str] = None
+
+
+class SafetyReportCreate(SafetyReportBase):
+    pass
+
+
+class SafetyReportRead(SafetyReportBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+# ----------------------------------------------------------------------------
+# Medical Incident
+# ----------------------------------------------------------------------------
+
+
+class MedicalIncidentBase(BaseModel):
+    person_id: Optional[str] = None
+    type: Optional[str] = None
+    time: Optional[datetime] = None
+    description: Optional[str] = None
+    treatment_given: Optional[str] = None
+    evac_required: bool = False
+    reported_by: Optional[str] = None
+
+
+class MedicalIncidentCreate(MedicalIncidentBase):
+    pass
+
+
+class MedicalIncidentRead(MedicalIncidentBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+# ----------------------------------------------------------------------------
+# Triage Entry
+# ----------------------------------------------------------------------------
+
+
+class TriageEntryBase(BaseModel):
+    patient_tag: Optional[str] = None
+    location: Optional[str] = None
+    triage_level: Optional[str] = None
+    time_found: Optional[datetime] = None
+    treated_by: Optional[str] = None
+    notes: Optional[str] = None
+    disposition: Optional[str] = None
+
+
+class TriageEntryCreate(TriageEntryBase):
+    pass
+
+
+class TriageEntryRead(TriageEntryBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+# ----------------------------------------------------------------------------
+# Hazard Zone
+# ----------------------------------------------------------------------------
+
+
+class HazardZoneBase(BaseModel):
+    name: Optional[str] = None
+    coordinates_json: Optional[str] = None
+    severity: Optional[str] = None
+    description: Optional[str] = None
+
+
+class HazardZoneCreate(HazardZoneBase):
+    pass
+
+
+class HazardZoneRead(HazardZoneBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+# ----------------------------------------------------------------------------
+# CAP ORM
+# ----------------------------------------------------------------------------
+
+
+class CapOrmBase(BaseModel):
+    form_type: Optional[str] = None
+    activity: Optional[str] = None
+    participants_json: Optional[str] = None
+    hazards_json: Optional[str] = None
+    mitigations_json: Optional[str] = None
+    residual_risk: Optional[str] = None
+    created_by: Optional[str] = None
+
+
+class CapOrmCreate(CapOrmBase):
+    pass
+
+
+class CapOrmRead(CapOrmBase):
+    id: int
+    mission_id: str
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    class Config:
+        orm_mode = True
+
+
+# ----------------------------------------------------------------------------
+# ICS-206
+# ----------------------------------------------------------------------------
+
+
+class ICS206Create(BaseModel):
+    contacts: List[str] = []
+    hospitals: List[str] = []
+    med_evacs: List[str] = []
+    comms: List[str] = []
+
+
+class ICS206Read(ICS206Create):
+    pass

--- a/modules/safety/panels/__init__.py
+++ b/modules/safety/panels/__init__.py
@@ -1,0 +1,18 @@
+# Panel exports
+from .safety_dashboard import SafetyDashboard
+from .safety_report_dialog import SafetyReportDialog
+from .injury_log_dialog import InjuryLogDialog
+from .ics206_builder import ICS206Builder
+from .cap_orm_builder import CapOrmBuilder
+from .hazard_map_panel import HazardMapPanel
+from .triage_tracker import TriageTracker
+
+__all__ = [
+    "SafetyDashboard",
+    "SafetyReportDialog",
+    "InjuryLogDialog",
+    "ICS206Builder",
+    "CapOrmBuilder",
+    "HazardMapPanel",
+    "TriageTracker",
+]

--- a/modules/safety/panels/cap_orm_builder.py
+++ b/modules/safety/panels/cap_orm_builder.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from PySide6.QtCore import QObject
+from PySide6.QtQml import QQmlApplicationEngine
+
+QML_PATH = Path(__file__).resolve().parent.parent / "qml" / "CAPORMBuilder.qml"
+
+
+class CapOrmBuilder(QObject):
+    def __init__(self, mission_id: str):
+        super().__init__()
+        self.mission_id = mission_id
+        self.engine = QQmlApplicationEngine(str(QML_PATH))

--- a/modules/safety/panels/hazard_map_panel.py
+++ b/modules/safety/panels/hazard_map_panel.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from PySide6.QtCore import QObject
+from PySide6.QtQml import QQmlApplicationEngine
+
+QML_PATH = Path(__file__).resolve().parent.parent / "qml" / "HazardMap.qml"
+
+
+class HazardMapPanel(QObject):
+    def __init__(self, mission_id: str):
+        super().__init__()
+        self.mission_id = mission_id
+        self.engine = QQmlApplicationEngine(str(QML_PATH))

--- a/modules/safety/panels/ics206_builder.py
+++ b/modules/safety/panels/ics206_builder.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from PySide6.QtCore import QObject
+from PySide6.QtQml import QQmlApplicationEngine
+
+QML_PATH = Path(__file__).resolve().parent.parent / "qml" / "ICS206Builder.qml"
+
+
+class ICS206Builder(QObject):
+    def __init__(self, mission_id: str):
+        super().__init__()
+        self.mission_id = mission_id
+        self.engine = QQmlApplicationEngine(str(QML_PATH))

--- a/modules/safety/panels/injury_log_dialog.py
+++ b/modules/safety/panels/injury_log_dialog.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from PySide6.QtCore import QObject
+from PySide6.QtQml import QQmlApplicationEngine
+
+QML_PATH = Path(__file__).resolve().parent.parent / "qml" / "InjuryLogEditor.qml"
+
+
+class InjuryLogDialog(QObject):
+    def __init__(self, mission_id: str):
+        super().__init__()
+        self.mission_id = mission_id
+        self.engine = QQmlApplicationEngine(str(QML_PATH))

--- a/modules/safety/panels/safety_dashboard.py
+++ b/modules/safety/panels/safety_dashboard.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from PySide6.QtCore import QObject
+from PySide6.QtQml import QQmlApplicationEngine
+
+QML_PATH = Path(__file__).resolve().parent.parent / "qml" / "SafetyDashboard.qml"
+
+
+class SafetyDashboard(QObject):
+    """Main dashboard combining safety reports and medical incidents."""
+
+    def __init__(self, mission_id: str):
+        super().__init__()
+        self.mission_id = mission_id
+        self.engine = QQmlApplicationEngine(str(QML_PATH))

--- a/modules/safety/panels/safety_report_dialog.py
+++ b/modules/safety/panels/safety_report_dialog.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from PySide6.QtCore import QObject
+from PySide6.QtQml import QQmlComponent, QQmlApplicationEngine
+
+QML_PATH = Path(__file__).resolve().parent.parent / "qml" / "SafetyReportEditor.qml"
+
+
+class SafetyReportDialog(QObject):
+    def __init__(self, mission_id: str):
+        super().__init__()
+        self.mission_id = mission_id
+        self.engine = QQmlApplicationEngine(str(QML_PATH))

--- a/modules/safety/panels/triage_tracker.py
+++ b/modules/safety/panels/triage_tracker.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from PySide6.QtCore import QObject
+from PySide6.QtQml import QQmlApplicationEngine
+
+QML_PATH = Path(__file__).resolve().parent.parent / "qml" / "TriageTracker.qml"
+
+
+class TriageTracker(QObject):
+    def __init__(self, mission_id: str):
+        super().__init__()
+        self.mission_id = mission_id
+        self.engine = QQmlApplicationEngine(str(QML_PATH))

--- a/modules/safety/print_ics_206.py
+++ b/modules/safety/print_ics_206.py
@@ -1,0 +1,16 @@
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple
+
+
+def generate(mission_id: str, html: str) -> Tuple[bytes, str]:
+    """Generate a PDF from HTML for ICS-206. Stub implementation."""
+    forms_dir = Path("data/missions") / mission_id / "forms"
+    forms_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    pdf_path = forms_dir / f"ICS206-{timestamp}.pdf"
+    content = b"%PDF-1.4\n% Stub PDF for ICS-206\n"
+    with open(pdf_path, "wb") as f:
+        f.write(content)
+    return content, str(pdf_path)

--- a/modules/safety/qml/CAPORMBuilder.qml
+++ b/modules/safety/qml/CAPORMBuilder.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 600
+    height: 400
+    Text { text: "CAP ORM Builder"; anchors.centerIn: parent }
+}

--- a/modules/safety/qml/HazardMap.qml
+++ b/modules/safety/qml/HazardMap.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 600
+    height: 400
+    Text { text: "Hazard Map"; anchors.centerIn: parent }
+}

--- a/modules/safety/qml/ICS206Builder.qml
+++ b/modules/safety/qml/ICS206Builder.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 600
+    height: 400
+    Text { text: "ICS 206 Builder"; anchors.centerIn: parent }
+}

--- a/modules/safety/qml/InjuryLogEditor.qml
+++ b/modules/safety/qml/InjuryLogEditor.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 400
+    height: 300
+    Text { text: "Injury Log Editor"; anchors.centerIn: parent }
+}

--- a/modules/safety/qml/SafetyDashboard.qml
+++ b/modules/safety/qml/SafetyDashboard.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 800
+    height: 600
+    Text { text: "Safety Dashboard"; anchors.centerIn: parent }
+}

--- a/modules/safety/qml/SafetyReportEditor.qml
+++ b/modules/safety/qml/SafetyReportEditor.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 400
+    height: 300
+    Text { text: "Safety Report Editor"; anchors.centerIn: parent }
+}

--- a/modules/safety/qml/TriageTracker.qml
+++ b/modules/safety/qml/TriageTracker.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 400
+    height: 300
+    Text { text: "Triage Tracker"; anchors.centerIn: parent }
+}

--- a/modules/safety/repository.py
+++ b/modules/safety/repository.py
@@ -1,0 +1,29 @@
+import os
+from contextlib import contextmanager
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .models.safety_models import Base
+
+DATA_DIR = Path("data/missions")
+
+
+def get_mission_engine(mission_id: str):
+    mission_path = DATA_DIR / f"{mission_id}.db"
+    mission_path.parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite:///{mission_path}", future=True)
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@contextmanager
+def with_mission_session(mission_id: str) -> Session:
+    engine = get_mission_engine(mission_id)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/modules/safety/services.py
+++ b/modules/safety/services.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from typing import Callable, List, Optional
+
+from .models import safety_models as models
+from .models import schemas
+from .print_ics_206 import generate as generate_ics206_pdf
+from .repository import with_mission_session
+
+# In-memory audit log and notification hooks
+_audit_log: List[dict] = []
+_flagged_callbacks: List[Callable[[schemas.SafetyReportRead], None]] = []
+
+
+def register_flagged_callback(cb: Callable[[schemas.SafetyReportRead], None]):
+    """Register a callback for flagged safety reports."""
+    _flagged_callbacks.append(cb)
+
+
+def _notify_flagged(report: schemas.SafetyReportRead):
+    for cb in _flagged_callbacks:
+        cb(report)
+
+
+def _audit(action: str, model: str, data: dict):
+    _audit_log.append({
+        "ts": datetime.utcnow().isoformat(),
+        "action": action,
+        "model": model,
+        "data": data,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Safety Reports
+# ---------------------------------------------------------------------------
+
+def list_safety_reports(
+    mission_id: str,
+    severity: Optional[str] = None,
+    flagged: Optional[bool] = None,
+    q: Optional[str] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+) -> List[schemas.SafetyReportRead]:
+    with with_mission_session(mission_id) as session:
+        query = session.query(models.SafetyReport)
+        if severity:
+            query = query.filter_by(severity=severity)
+        if flagged is not None:
+            query = query.filter_by(flagged=flagged)
+        if start:
+            query = query.filter(models.SafetyReport.time >= start)
+        if end:
+            query = query.filter(models.SafetyReport.time <= end)
+        if q:
+            like = f"%{q}%"
+            query = query.filter(models.SafetyReport.notes.ilike(like))
+        return [schemas.SafetyReportRead.from_orm(r) for r in query.all()]
+
+
+def create_safety_report(mission_id: str, data: schemas.SafetyReportCreate) -> schemas.SafetyReportRead:
+    with with_mission_session(mission_id) as session:
+        report = models.SafetyReport(**data.dict())
+        session.add(report)
+        session.commit()
+        session.refresh(report)
+        result = schemas.SafetyReportRead.from_orm(report)
+        _audit("create", "SafetyReport", data.dict())
+        if report.flagged:
+            _notify_flagged(result)
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Medical Incidents
+# ---------------------------------------------------------------------------
+
+def list_medical_incidents(mission_id: str) -> List[schemas.MedicalIncidentRead]:
+    with with_mission_session(mission_id) as session:
+        incidents = session.query(models.MedicalIncident).all()
+        return [schemas.MedicalIncidentRead.from_orm(i) for i in incidents]
+
+
+def create_medical_incident(mission_id: str, data: schemas.MedicalIncidentCreate) -> schemas.MedicalIncidentRead:
+    with with_mission_session(mission_id) as session:
+        incident = models.MedicalIncident(**data.dict())
+        session.add(incident)
+        session.commit()
+        session.refresh(incident)
+        _audit("create", "MedicalIncident", data.dict())
+        return schemas.MedicalIncidentRead.from_orm(incident)
+
+
+# ---------------------------------------------------------------------------
+# Triage Entries
+# ---------------------------------------------------------------------------
+
+def list_triage_entries(mission_id: str) -> List[schemas.TriageEntryRead]:
+    with with_mission_session(mission_id) as session:
+        entries = session.query(models.TriageEntry).all()
+        return [schemas.TriageEntryRead.from_orm(e) for e in entries]
+
+
+def create_triage_entry(mission_id: str, data: schemas.TriageEntryCreate) -> schemas.TriageEntryRead:
+    with with_mission_session(mission_id) as session:
+        entry = models.TriageEntry(**data.dict())
+        session.add(entry)
+        session.commit()
+        session.refresh(entry)
+        _audit("create", "TriageEntry", data.dict())
+        return schemas.TriageEntryRead.from_orm(entry)
+
+
+# ---------------------------------------------------------------------------
+# Hazard Zones
+# ---------------------------------------------------------------------------
+
+def list_hazard_zones(mission_id: str) -> List[schemas.HazardZoneRead]:
+    with with_mission_session(mission_id) as session:
+        zones = session.query(models.HazardZone).all()
+        return [schemas.HazardZoneRead.from_orm(z) for z in zones]
+
+
+def create_hazard_zone(mission_id: str, data: schemas.HazardZoneCreate) -> schemas.HazardZoneRead:
+    with with_mission_session(mission_id) as session:
+        zone = models.HazardZone(**data.dict())
+        session.add(zone)
+        session.commit()
+        session.refresh(zone)
+        _audit("create", "HazardZone", data.dict())
+        return schemas.HazardZoneRead.from_orm(zone)
+
+
+# ---------------------------------------------------------------------------
+# CAP ORM
+# ---------------------------------------------------------------------------
+
+def create_cap_orm(mission_id: str, data: schemas.CapOrmCreate) -> schemas.CapOrmRead:
+    with with_mission_session(mission_id) as session:
+        orm = models.CapOrmForm(mission_id=mission_id, **data.dict())
+        session.add(orm)
+        session.commit()
+        session.refresh(orm)
+        _audit("create", "CapOrmForm", data.dict())
+        return schemas.CapOrmRead.from_orm(orm)
+
+
+# ---------------------------------------------------------------------------
+# ICS-206 Builder
+# ---------------------------------------------------------------------------
+
+def build_ics206(mission_id: str, payload: schemas.ICS206Create) -> schemas.ICS206Read:
+    data = payload.dict()
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    forms_dir = os.path.join("data", "missions", mission_id, "forms")
+    os.makedirs(forms_dir, exist_ok=True)
+
+    json_path = os.path.join(forms_dir, f"ICS206-{timestamp}.json")
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    html = "<html><body><pre>" + json.dumps(data, indent=2) + "</pre></body></html>"
+    generate_ics206_pdf(mission_id, html)
+
+    _audit("build", "ICS206", data)
+    return schemas.ICS206Read(**data)
+
+
+__all__ = [
+    "register_flagged_callback",
+    "list_safety_reports",
+    "create_safety_report",
+    "list_medical_incidents",
+    "create_medical_incident",
+    "list_triage_entries",
+    "create_triage_entry",
+    "list_hazard_zones",
+    "create_hazard_zone",
+    "create_cap_orm",
+    "build_ics206",
+]


### PR DESCRIPTION
## Summary
- scaffold Safety module with FastAPI router, services, and SQLAlchemy models
- add repository helpers for mission-specific SQLite databases
- include Qt panel stubs and QML views for dashboards and editors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68998e477e18832ba25b62f2b86774f7