### PR TITLE
Add Planned Event Toolkit scaffolding

### DIFF
--- a/modules/plannedtoolkit/__init__.py
+++ b/modules/plannedtoolkit/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .api import router
+from .panels.PlannedToolkitHome import PlannedToolkitHome
+
+
+def get_planned_toolkit_panel():
+    """Return the main panel instance for the Planned Event Toolkit."""
+    return PlannedToolkitHome()
+
+__all__ = ["router", "get_planned_toolkit_panel"]

--- a/modules/plannedtoolkit/api.py
+++ b/modules/plannedtoolkit/api.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from fastapi import APIRouter
+
+from . import services, exporter
+from .models import schemas
+
+router = APIRouter(prefix="/api/planned", tags=["planned"])
+
+
+@router.get("/templates", response_model=List[schemas.EventTemplateRead])
+def get_templates():
+    return services.list_templates()
+
+
+@router.post("/templates", response_model=schemas.EventTemplateRead)
+def create_template(template: schemas.EventTemplateCreate):
+    return services.create_template(template)
+
+
+@router.post("/templates/{template_id}/clone")
+def clone_template(template_id: int, req: schemas.CloneFromTemplateRequest | None = None):
+    name = req.name if req else None
+    event_id = services.clone_template(template_id, name)
+    return {"event_id": event_id}
+
+
+@router.get("/events")
+def list_events():
+    missions_dir = Path("data/missions")
+    missions_dir.mkdir(parents=True, exist_ok=True)
+    return {"events": [p.stem for p in missions_dir.glob("*.db")]}  # simple listing
+
+
+@router.get("/events/{event_id}", response_model=schemas.EventRead | None)
+def get_event(event_id: str):
+    return services.get_event(event_id)
+
+
+@router.get("/events/{event_id}/sites", response_model=List[schemas.EventSiteRead])
+def list_sites(event_id: str):
+    return services.list_sites(event_id)
+
+
+@router.post("/events/{event_id}/sites", response_model=schemas.EventSiteRead)
+def add_site(event_id: str, site: schemas.EventSiteCreate):
+    return services.add_site(event_id, site)
+
+
+@router.get("/events/{event_id}/routes", response_model=List[schemas.EventRouteRead])
+def list_routes(event_id: str):
+    return services.list_routes(event_id)
+
+
+@router.post("/events/{event_id}/routes", response_model=schemas.EventRouteRead)
+def add_route(event_id: str, route: schemas.EventRouteCreate):
+    return services.add_route(event_id, route)
+
+
+@router.post("/events/{event_id}/iap/build", response_model=schemas.ExportArtifactRead)
+def build_iap(event_id: str, req: schemas.IapBuildRequest):
+    artifact = exporter.export_iap(event_id, req)
+    return schemas.ExportArtifactRead.from_orm(artifact)

--- a/modules/plannedtoolkit/exporter.py
+++ b/modules/plannedtoolkit/exporter.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+from zipfile import ZipFile
+
+from reportlab.pdfgen import canvas
+
+from . import planned_models as models
+from .models import schemas
+from .repository import with_event_session
+
+
+def export_iap(event_id: str, request: schemas.IapBuildRequest) -> models.ExportArtifact:
+    exports_dir = Path("data/missions") / event_id / "exports"
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    ts = int(dt.datetime.utcnow().timestamp())
+    pdf_path = exports_dir / f"iap_{ts}.pdf"
+    c = canvas.Canvas(str(pdf_path))
+    c.drawString(100, 750, "IAP Packet Placeholder")
+    c.save()
+
+    zip_path = exports_dir / f"iap_{ts}.zip"
+    with ZipFile(zip_path, "w") as z:
+        z.write(pdf_path, pdf_path.name)
+
+    with with_event_session(event_id) as session:
+        artifact = models.ExportArtifact(
+            op_number=request.op_numbers[0] if request.op_numbers else None,
+            type="iap",
+            file_path=str(zip_path),
+            created_at=dt.datetime.utcnow(),
+        )
+        session.add(artifact)
+        session.flush()
+        return artifact

--- a/modules/plannedtoolkit/gis.py
+++ b/modules/plannedtoolkit/gis.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+
+
+def normalize_geometry(geom: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder that returns geometry untouched."""
+    return geom
+
+
+def compute_route_length(geom: Dict[str, Any]) -> float:
+    """Stub that returns zero length."""
+    return 0.0

--- a/modules/plannedtoolkit/models/schemas.py
+++ b/modules/plannedtoolkit/models/schemas.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+from typing import List, Optional, Dict, Any
+from pydantic import BaseModel
+
+# Template schemas
+
+
+class EventTemplateBase(BaseModel):
+    name: str
+    category: Optional[str] = None
+    description: Optional[str] = None
+    default_ops_period_hours: Optional[int] = 12
+    default_objectives_json: Optional[Dict[str, Any]] = None
+    default_roles_json: Optional[Dict[str, Any]] = None
+    default_checklists_json: Optional[Dict[str, Any]] = None
+
+
+class EventTemplateCreate(EventTemplateBase):
+    pass
+
+
+class EventTemplateUpdate(EventTemplateBase):
+    pass
+
+
+class EventTemplateRead(EventTemplateBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TemplateSiteBase(BaseModel):
+    name: str
+    site_type: Optional[str] = None
+    geometry_json: Optional[Dict[str, Any]] = None
+    capacity: Optional[int] = None
+    notes: Optional[str] = None
+
+
+class TemplateSiteCreate(TemplateSiteBase):
+    template_id: int
+
+
+class TemplateSiteRead(TemplateSiteBase):
+    id: int
+    template_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TemplateRouteBase(BaseModel):
+    name: str
+    geometry_json: Optional[Dict[str, Any]] = None
+    notes: Optional[str] = None
+
+
+class TemplateRouteCreate(TemplateRouteBase):
+    template_id: int
+
+
+class TemplateRouteRead(TemplateRouteBase):
+    id: int
+    template_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TemplateCommsBase(BaseModel):
+    channels_json: Optional[Dict[str, Any]] = None
+
+
+class TemplateCommsCreate(TemplateCommsBase):
+    template_id: int
+
+
+class TemplateCommsRead(TemplateCommsBase):
+    id: int
+    template_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TemplateMedicalBase(BaseModel):
+    hospitals_json: Optional[Dict[str, Any]] = None
+    ems_contacts_json: Optional[Dict[str, Any]] = None
+    aid_stations_json: Optional[Dict[str, Any]] = None
+
+
+class TemplateMedicalCreate(TemplateMedicalBase):
+    template_id: int
+
+
+class TemplateMedicalRead(TemplateMedicalBase):
+    id: int
+    template_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TemplateSafetyBase(BaseModel):
+    hazards_json: Optional[Dict[str, Any]] = None
+    mitigations_json: Optional[Dict[str, Any]] = None
+    safety_messages_json: Optional[Dict[str, Any]] = None
+
+
+class TemplateSafetyCreate(TemplateSafetyBase):
+    template_id: int
+
+
+class TemplateSafetyRead(TemplateSafetyBase):
+    id: int
+    template_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TemplatePermitsBase(BaseModel):
+    requirements_json: Optional[Dict[str, Any]] = None
+
+
+class TemplatePermitsCreate(TemplatePermitsBase):
+    template_id: int
+
+
+class TemplatePermitsRead(TemplatePermitsBase):
+    id: int
+    template_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TemplateVendorsBase(BaseModel):
+    vendors_json: Optional[Dict[str, Any]] = None
+
+
+class TemplateVendorsCreate(TemplateVendorsBase):
+    template_id: int
+
+
+class TemplateVendorsRead(TemplateVendorsBase):
+    id: int
+    template_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TemplateContactsBase(BaseModel):
+    contacts_json: Optional[Dict[str, Any]] = None
+
+
+class TemplateContactsCreate(TemplateContactsBase):
+    template_id: int
+
+
+class TemplateContactsRead(TemplateContactsBase):
+    id: int
+    template_id: int
+
+    class Config:
+        orm_mode = True
+
+
+# Event instance schemas
+
+
+class EventBaseModel(BaseModel):
+    name: str
+    start_datetime: Optional[str] = None
+    end_datetime: Optional[str] = None
+    status: Optional[str] = "planning"
+    objectives_json: Optional[Dict[str, Any]] = None
+
+
+class EventCreate(EventBaseModel):
+    template_id: Optional[int] = None
+
+
+class EventRead(EventBaseModel):
+    id: int
+    template_id: Optional[int] = None
+
+    class Config:
+        orm_mode = True
+
+
+class EventSiteBase(BaseModel):
+    name: str
+    site_type: Optional[str] = None
+    geometry_json: Optional[Dict[str, Any]] = None
+    capacity: Optional[int] = None
+    notes: Optional[str] = None
+
+
+class EventSiteCreate(EventSiteBase):
+    event_id: int
+
+
+class EventSiteRead(EventSiteBase):
+    id: int
+    event_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class EventRouteBase(BaseModel):
+    name: str
+    geometry_json: Optional[Dict[str, Any]] = None
+    segments_json: Optional[Dict[str, Any]] = None
+    notes: Optional[str] = None
+
+
+class EventRouteCreate(EventRouteBase):
+    event_id: int
+
+
+class EventRouteRead(EventRouteBase):
+    id: int
+    event_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class OpsPeriodBase(BaseModel):
+    op_number: int
+    start_datetime: Optional[str] = None
+    end_datetime: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class OpsPeriodCreate(OpsPeriodBase):
+    event_id: int
+
+
+class OpsPeriodRead(OpsPeriodBase):
+    id: int
+    event_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class StaffingRowBase(BaseModel):
+    op_number: int
+    location_ref: Optional[str] = None
+    position: Optional[str] = None
+    required: Optional[int] = 0
+    assigned: Optional[int] = 0
+    notes: Optional[str] = None
+
+
+class StaffingRowCreate(StaffingRowBase):
+    event_id: int
+
+
+class StaffingRowRead(StaffingRowBase):
+    id: int
+    event_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class CommsPlanBase(BaseModel):
+    op_number: int
+    channels_json: Optional[Dict[str, Any]] = None
+    notes: Optional[str] = None
+
+
+class CommsPlanCreate(CommsPlanBase):
+    event_id: int
+
+
+class CommsPlanRead(CommsPlanBase):
+    id: int
+    event_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class MedicalPlanBase(BaseModel):
+    op_number: int
+    hospitals_json: Optional[Dict[str, Any]] = None
+    ems_contacts_json: Optional[Dict[str, Any]] = None
+    aid_stations_json: Optional[Dict[str, Any]] = None
+    notes: Optional[str] = None
+
+
+class MedicalPlanCreate(MedicalPlanBase):
+    event_id: int
+
+
+class MedicalPlanRead(MedicalPlanBase):
+    id: int
+    event_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class SafetyPlanBase(BaseModel):
+    op_number: int
+    hazards_json: Optional[Dict[str, Any]] = None
+    mitigations_json: Optional[Dict[str, Any]] = None
+    safety_messages_json: Optional[Dict[str, Any]] = None
+    notes: Optional[str] = None
+
+
+class SafetyPlanCreate(SafetyPlanBase):
+    event_id: int
+
+
+class SafetyPlanRead(SafetyPlanBase):
+    id: int
+    event_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class PermitBase(BaseModel):
+    name: str
+    issuer: Optional[str] = None
+    number: Optional[str] = None
+    expires_on: Optional[str] = None
+    status: Optional[str] = None
+    file_path: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class PermitCreate(PermitBase):
+    event_id: int
+
+
+class PermitRead(PermitBase):
+    id: int
+    event_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class VendorBase(BaseModel):
+    name: str
+    contact_json: Optional[Dict[str, Any]] = None
+    approved: Optional[bool] = False
+    notes: Optional[str] = None
+
+
+class VendorCreate(VendorBase):
+    event_id: int
+
+
+class VendorRead(VendorBase):
+    id: int
+    event_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class ContactBase(BaseModel):
+    name: str
+    agency: Optional[str] = None
+    role: Optional[str] = None
+    phones_json: Optional[Dict[str, Any]] = None
+    emails_json: Optional[Dict[str, Any]] = None
+    notes: Optional[str] = None
+
+
+class ContactCreate(ContactBase):
+    event_id: int
+
+
+class ContactRead(ContactBase):
+    id: int
+    event_id: int
+
+    class Config:
+        orm_mode = True
+
+
+class AttachmentBase(BaseModel):
+    file_path: str
+    title: Optional[str] = None
+    category: Optional[str] = None
+    tags_json: Optional[Dict[str, Any]] = None
+
+
+class AttachmentCreate(AttachmentBase):
+    event_id: int
+
+
+class AttachmentRead(AttachmentBase):
+    id: int
+    event_id: int
+    created_at: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+
+class ExportArtifactBase(BaseModel):
+    op_number: Optional[int] = None
+    type: str
+    file_path: str
+
+
+class ExportArtifactCreate(ExportArtifactBase):
+    event_id: int
+
+
+class ExportArtifactRead(ExportArtifactBase):
+    id: int
+    event_id: int
+    created_at: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+
+# Helper schemas
+
+
+class CloneFromTemplateRequest(BaseModel):
+    template_id: int
+    name: Optional[str] = None
+
+
+class IapBuildRequest(BaseModel):
+    forms: List[str]
+    op_numbers: List[int]
+    attachments: Optional[List[int]] = None
+
+
+class SearchQuery(BaseModel):
+    text: str
+    filters: Optional[Dict[str, Any]] = None
+
+
+class SearchResult(BaseModel):
+    id: int
+    type: str
+    snippet: str
+
+
+class PermissionOut(BaseModel):
+    can_edit: bool = True
+    can_finalize: bool = False
+    can_export: bool = False

--- a/modules/plannedtoolkit/panels/AfterActionNotes.py
+++ b/modules/plannedtoolkit/panels/AfterActionNotes.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class AfterActionNotes(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "AfterActionNotes.qml")

--- a/modules/plannedtoolkit/panels/CommsPlanBuilder.py
+++ b/modules/plannedtoolkit/panels/CommsPlanBuilder.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class CommsPlanBuilder(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "CommsPlanBuilder.qml")

--- a/modules/plannedtoolkit/panels/EventWizard.py
+++ b/modules/plannedtoolkit/panels/EventWizard.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class EventWizard(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "EventWizard.qml")

--- a/modules/plannedtoolkit/panels/IAPBuilder.py
+++ b/modules/plannedtoolkit/panels/IAPBuilder.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class IAPBuilder(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "IAPBuilder.qml")

--- a/modules/plannedtoolkit/panels/MedicalPlanBuilder.py
+++ b/modules/plannedtoolkit/panels/MedicalPlanBuilder.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class MedicalPlanBuilder(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "MedicalPlanBuilder.qml")

--- a/modules/plannedtoolkit/panels/OpsPeriodScheduler.py
+++ b/modules/plannedtoolkit/panels/OpsPeriodScheduler.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class OpsPeriodScheduler(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "OpsPeriodScheduler.qml")

--- a/modules/plannedtoolkit/panels/PlannedToolkitHome.py
+++ b/modules/plannedtoolkit/panels/PlannedToolkitHome.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class PlannedToolkitHome(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "PlannedToolkitHome.qml")

--- a/modules/plannedtoolkit/panels/ResourcePlanner.py
+++ b/modules/plannedtoolkit/panels/ResourcePlanner.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class ResourcePlanner(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "ResourcePlanner.qml")

--- a/modules/plannedtoolkit/panels/SafetyRiskBuilder.py
+++ b/modules/plannedtoolkit/panels/SafetyRiskBuilder.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class SafetyRiskBuilder(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "SafetyRiskBuilder.qml")

--- a/modules/plannedtoolkit/panels/SiteRoutePlanner.py
+++ b/modules/plannedtoolkit/panels/SiteRoutePlanner.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class SiteRoutePlanner(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "SiteRoutePlanner.qml")

--- a/modules/plannedtoolkit/panels/VendorPermits.py
+++ b/modules/plannedtoolkit/panels/VendorPermits.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget
+from . import _load_qml
+
+
+class VendorPermits(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        _load_qml(self, "VendorPermits.qml")

--- a/modules/plannedtoolkit/panels/__init__.py
+++ b/modules/plannedtoolkit/panels/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+from PySide6.QtQuickWidgets import QQuickWidget
+from PySide6.QtCore import QUrl
+
+
+def _load_qml(widget: QWidget, qml_name: str) -> QQuickWidget:
+    layout = QVBoxLayout(widget)
+    qml_widget = QQuickWidget()
+    qml_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "qml", qml_name))
+    qml_widget.setSource(QUrl.fromLocalFile(qml_path))
+    qml_widget.setResizeMode(QQuickWidget.SizeRootObjectToView)
+    layout.addWidget(qml_widget)
+    return qml_widget

--- a/modules/plannedtoolkit/planned_models.py
+++ b/modules/plannedtoolkit/planned_models.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import datetime as dt
+from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, JSON, Boolean
+from sqlalchemy.orm import declarative_base, relationship
+
+MasterBase = declarative_base()
+EventBase = declarative_base()
+
+
+class EventTemplate(MasterBase):
+    __tablename__ = "event_templates"
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    category = Column(String)
+    description = Column(Text)
+    default_ops_period_hours = Column(Integer, default=12)
+    default_objectives_json = Column(JSON)
+    default_roles_json = Column(JSON)
+    default_checklists_json = Column(JSON)
+    created_by = Column(String)
+    created_at = Column(DateTime, default=dt.datetime.utcnow)
+    updated_at = Column(DateTime, default=dt.datetime.utcnow, onupdate=dt.datetime.utcnow)
+    version = Column(Integer, default=1)
+
+    routes = relationship("TemplateRoute", cascade="all, delete-orphan")
+    sites = relationship("TemplateSite", cascade="all, delete-orphan")
+    comms = relationship("TemplateComms", cascade="all, delete-orphan")
+    medical = relationship("TemplateMedical", cascade="all, delete-orphan")
+    safety = relationship("TemplateSafety", cascade="all, delete-orphan")
+    permits = relationship("TemplatePermits", cascade="all, delete-orphan")
+    vendors = relationship("TemplateVendors", cascade="all, delete-orphan")
+    contacts = relationship("TemplateContacts", cascade="all, delete-orphan")
+
+
+class TemplateRoute(MasterBase):
+    __tablename__ = "template_routes"
+    id = Column(Integer, primary_key=True)
+    template_id = Column(Integer, ForeignKey("event_templates.id"))
+    name = Column(String, nullable=False)
+    geometry_json = Column(JSON)
+    notes = Column(Text)
+
+
+class TemplateSite(MasterBase):
+    __tablename__ = "template_sites"
+    id = Column(Integer, primary_key=True)
+    template_id = Column(Integer, ForeignKey("event_templates.id"))
+    name = Column(String, nullable=False)
+    site_type = Column(String)
+    geometry_json = Column(JSON)
+    capacity = Column(Integer)
+    notes = Column(Text)
+
+
+class TemplateComms(MasterBase):
+    __tablename__ = "template_comms"
+    id = Column(Integer, primary_key=True)
+    template_id = Column(Integer, ForeignKey("event_templates.id"))
+    channels_json = Column(JSON)
+
+
+class TemplateMedical(MasterBase):
+    __tablename__ = "template_medical"
+    id = Column(Integer, primary_key=True)
+    template_id = Column(Integer, ForeignKey("event_templates.id"))
+    hospitals_json = Column(JSON)
+    ems_contacts_json = Column(JSON)
+    aid_stations_json = Column(JSON)
+
+
+class TemplateSafety(MasterBase):
+    __tablename__ = "template_safety"
+    id = Column(Integer, primary_key=True)
+    template_id = Column(Integer, ForeignKey("event_templates.id"))
+    hazards_json = Column(JSON)
+    mitigations_json = Column(JSON)
+    safety_messages_json = Column(JSON)
+
+
+class TemplatePermits(MasterBase):
+    __tablename__ = "template_permits"
+    id = Column(Integer, primary_key=True)
+    template_id = Column(Integer, ForeignKey("event_templates.id"))
+    requirements_json = Column(JSON)
+
+
+class TemplateVendors(MasterBase):
+    __tablename__ = "template_vendors"
+    id = Column(Integer, primary_key=True)
+    template_id = Column(Integer, ForeignKey("event_templates.id"))
+    vendors_json = Column(JSON)
+
+
+class TemplateContacts(MasterBase):
+    __tablename__ = "template_contacts"
+    id = Column(Integer, primary_key=True)
+    template_id = Column(Integer, ForeignKey("event_templates.id"))
+    contacts_json = Column(JSON)
+
+
+# Event instance models
+
+
+class Event(EventBase):
+    __tablename__ = "events"
+    id = Column(Integer, primary_key=True)
+    template_id = Column(Integer)
+    name = Column(String, nullable=False)
+    start_datetime = Column(DateTime)
+    end_datetime = Column(DateTime)
+    status = Column(String, default="planning")
+    objectives_json = Column(JSON)
+    created_by = Column(String)
+    created_at = Column(DateTime, default=dt.datetime.utcnow)
+    updated_at = Column(DateTime, default=dt.datetime.utcnow, onupdate=dt.datetime.utcnow)
+
+
+class EventSite(EventBase):
+    __tablename__ = "event_sites"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    name = Column(String, nullable=False)
+    site_type = Column(String)
+    geometry_json = Column(JSON)
+    capacity = Column(Integer)
+    notes = Column(Text)
+
+
+class EventRoute(EventBase):
+    __tablename__ = "event_routes"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    name = Column(String, nullable=False)
+    geometry_json = Column(JSON)
+    segments_json = Column(JSON)
+    notes = Column(Text)
+
+
+class OpsPeriod(EventBase):
+    __tablename__ = "ops_periods"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    op_number = Column(Integer, nullable=False)
+    start_datetime = Column(DateTime)
+    end_datetime = Column(DateTime)
+    notes = Column(Text)
+
+
+class StaffingRow(EventBase):
+    __tablename__ = "staffing_matrix"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    op_number = Column(Integer)
+    location_ref = Column(String)
+    position = Column(String)
+    required = Column(Integer, default=0)
+    assigned = Column(Integer, default=0)
+    notes = Column(Text)
+
+
+class CommsPlan(EventBase):
+    __tablename__ = "comms_plan"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    op_number = Column(Integer)
+    channels_json = Column(JSON)
+    notes = Column(Text)
+
+
+class MedicalPlan(EventBase):
+    __tablename__ = "medical_plan"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    op_number = Column(Integer)
+    hospitals_json = Column(JSON)
+    ems_contacts_json = Column(JSON)
+    aid_stations_json = Column(JSON)
+    notes = Column(Text)
+
+
+class SafetyPlan(EventBase):
+    __tablename__ = "safety_plan"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    op_number = Column(Integer)
+    hazards_json = Column(JSON)
+    mitigations_json = Column(JSON)
+    safety_messages_json = Column(JSON)
+    notes = Column(Text)
+
+
+class Permit(EventBase):
+    __tablename__ = "permits"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    name = Column(String)
+    issuer = Column(String)
+    number = Column(String)
+    expires_on = Column(DateTime)
+    status = Column(String)
+    file_path = Column(String)
+    notes = Column(Text)
+
+
+class Vendor(EventBase):
+    __tablename__ = "vendors"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    name = Column(String)
+    contact_json = Column(JSON)
+    approved = Column(Boolean, default=False)
+    notes = Column(Text)
+
+
+class Contact(EventBase):
+    __tablename__ = "contacts"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    name = Column(String)
+    agency = Column(String)
+    role = Column(String)
+    phones_json = Column(JSON)
+    emails_json = Column(JSON)
+    notes = Column(Text)
+
+
+class Attachment(EventBase):
+    __tablename__ = "attachments"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    file_path = Column(String)
+    title = Column(String)
+    category = Column(String)
+    tags_json = Column(JSON)
+    created_at = Column(DateTime, default=dt.datetime.utcnow)
+
+
+class ExportArtifact(EventBase):
+    __tablename__ = "exports"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    op_number = Column(Integer)
+    type = Column(String)
+    file_path = Column(String)
+    created_at = Column(DateTime, default=dt.datetime.utcnow)
+
+
+class AuditLog(EventBase):
+    __tablename__ = "audit_log"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer)
+    entity = Column(String)
+    entity_id = Column(Integer)
+    action = Column(String)
+    who = Column(String)
+    when = Column(DateTime, default=dt.datetime.utcnow)
+    details_json = Column(JSON)

--- a/modules/plannedtoolkit/qml/AfterActionNotes.qml
+++ b/modules/plannedtoolkit/qml/AfterActionNotes.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "AfterActionNotes" }
+}

--- a/modules/plannedtoolkit/qml/CommsPlanBuilder.qml
+++ b/modules/plannedtoolkit/qml/CommsPlanBuilder.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "CommsPlanBuilder" }
+}

--- a/modules/plannedtoolkit/qml/EventWizard.qml
+++ b/modules/plannedtoolkit/qml/EventWizard.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "EventWizard" }
+}

--- a/modules/plannedtoolkit/qml/IAPBuilder.qml
+++ b/modules/plannedtoolkit/qml/IAPBuilder.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "IAPBuilder" }
+}

--- a/modules/plannedtoolkit/qml/MedicalPlanBuilder.qml
+++ b/modules/plannedtoolkit/qml/MedicalPlanBuilder.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "MedicalPlanBuilder" }
+}

--- a/modules/plannedtoolkit/qml/OpsPeriodScheduler.qml
+++ b/modules/plannedtoolkit/qml/OpsPeriodScheduler.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "OpsPeriodScheduler" }
+}

--- a/modules/plannedtoolkit/qml/PlannedToolkitHome.qml
+++ b/modules/plannedtoolkit/qml/PlannedToolkitHome.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "PlannedToolkitHome" }
+}

--- a/modules/plannedtoolkit/qml/ResourcePlanner.qml
+++ b/modules/plannedtoolkit/qml/ResourcePlanner.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "ResourcePlanner" }
+}

--- a/modules/plannedtoolkit/qml/SafetyRiskBuilder.qml
+++ b/modules/plannedtoolkit/qml/SafetyRiskBuilder.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "SafetyRiskBuilder" }
+}

--- a/modules/plannedtoolkit/qml/SiteRoutePlanner.qml
+++ b/modules/plannedtoolkit/qml/SiteRoutePlanner.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "SiteRoutePlanner" }
+}

--- a/modules/plannedtoolkit/qml/VendorPermits.qml
+++ b/modules/plannedtoolkit/qml/VendorPermits.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    width: 800; height: 600
+    color: "#f0f0f0"
+    Text { anchors.centerIn: parent; text: "VendorPermits" }
+}

--- a/modules/plannedtoolkit/repository.py
+++ b/modules/plannedtoolkit/repository.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from .planned_models import MasterBase, EventBase
+
+DATA_ROOT = Path("data")
+MASTER_DB = DATA_ROOT / "master.db"
+MISSIONS_DIR = DATA_ROOT / "missions"
+
+
+def get_master_engine():
+    MASTER_DB.parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite:///{MASTER_DB}", future=True)
+    MasterBase.metadata.create_all(engine)
+    return engine
+
+
+def get_event_engine(event_id: str):
+    db_path = MISSIONS_DIR / f"{event_id}.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite:///{db_path}", future=True)
+    EventBase.metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE VIRTUAL TABLE IF NOT EXISTS attachment_fts USING fts5(title, content)") )
+    return engine
+
+
+@contextmanager
+def with_master_session():
+    engine = get_master_engine()
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    finally:
+        session.close()
+
+
+@contextmanager
+def with_event_session(event_id: str):
+    engine = get_event_engine(event_id)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    finally:
+        session.close()

--- a/modules/plannedtoolkit/scheduler.py
+++ b/modules/plannedtoolkit/scheduler.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import List
+
+from . import planned_models as models
+from .repository import with_event_session
+
+
+def generate_op_periods(event_id: str, start: dt.datetime, end: dt.datetime, hours: int) -> List[models.OpsPeriod]:
+    periods = []
+    op_number = 1
+    current = start
+    while current < end:
+        period_end = min(current + dt.timedelta(hours=hours), end)
+        op = models.OpsPeriod(
+            event_id=1,
+            op_number=op_number,
+            start_datetime=current,
+            end_datetime=period_end,
+        )
+        periods.append(op)
+        current = period_end
+        op_number += 1
+    with with_event_session(event_id) as session:
+        session.add_all(periods)
+    return periods

--- a/modules/plannedtoolkit/search_index.py
+++ b/modules/plannedtoolkit/search_index.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import List
+from sqlalchemy import text
+
+from .repository import with_event_session
+
+
+def search(event_id: str, query: str) -> List[dict]:
+    with with_event_session(event_id) as session:
+        result = session.execute(
+            text("SELECT rowid, snippet(attachment_fts) FROM attachment_fts WHERE attachment_fts MATCH :q"),
+            {"q": query},
+        )
+        return [{"id": row[0], "snippet": row[1]} for row in result]

--- a/modules/plannedtoolkit/services.py
+++ b/modules/plannedtoolkit/services.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import List
+from uuid import uuid4
+
+from . import planned_models as models
+from .models import schemas
+from .repository import with_master_session, with_event_session
+
+
+# Template services
+
+def create_template(data: schemas.EventTemplateCreate) -> models.EventTemplate:
+    with with_master_session() as session:
+        obj = models.EventTemplate(**data.dict())
+        session.add(obj)
+        session.flush()
+        return obj
+
+
+def list_templates() -> List[models.EventTemplate]:
+    with with_master_session() as session:
+        return session.query(models.EventTemplate).all()
+
+
+def clone_template(template_id: int, name: str | None = None) -> str:
+    with with_master_session() as session:
+        template = session.get(models.EventTemplate, template_id)
+        if not template:
+            raise ValueError("Template not found")
+    event_id = uuid4().hex
+    with with_event_session(event_id) as session:
+        event = models.Event(
+            template_id=template.id,
+            name=name or template.name,
+            status="planning",
+            objectives_json=template.default_objectives_json,
+            created_at=dt.datetime.utcnow(),
+            updated_at=dt.datetime.utcnow(),
+        )
+        session.add(event)
+    return event_id
+
+
+# Event services
+
+def create_event(event_id: str, data: schemas.EventCreate) -> models.Event:
+    with with_event_session(event_id) as session:
+        obj = models.Event(**data.dict())
+        session.add(obj)
+        session.flush()
+        return obj
+
+
+def get_event(event_id: str) -> models.Event | None:
+    with with_event_session(event_id) as session:
+        return session.query(models.Event).first()
+
+
+def add_site(event_id: str, data: schemas.EventSiteCreate) -> models.EventSite:
+    with with_event_session(event_id) as session:
+        obj = models.EventSite(**data.dict())
+        session.add(obj)
+        session.flush()
+        return obj
+
+
+def list_sites(event_id: str) -> List[models.EventSite]:
+    with with_event_session(event_id) as session:
+        return session.query(models.EventSite).all()
+
+
+def add_route(event_id: str, data: schemas.EventRouteCreate) -> models.EventRoute:
+    with with_event_session(event_id) as session:
+        obj = models.EventRoute(**data.dict())
+        session.add(obj)
+        session.flush()
+        return obj
+
+
+def list_routes(event_id: str) -> List[models.EventRoute]:
+    with with_event_session(event_id) as session:
+        return session.query(models.EventRoute).all()
+
+
+# Placeholder functions for other planners
+
+def add_staffing_row(event_id: str, data: schemas.StaffingRowCreate) -> models.StaffingRow:
+    with with_event_session(event_id) as session:
+        obj = models.StaffingRow(**data.dict())
+        session.add(obj)
+        session.flush()
+        return obj
+
+
+def add_comms_plan(event_id: str, data: schemas.CommsPlanCreate) -> models.CommsPlan:
+    with with_event_session(event_id) as session:
+        obj = models.CommsPlan(**data.dict())
+        session.add(obj)
+        session.flush()
+        return obj
+
+
+def add_medical_plan(event_id: str, data: schemas.MedicalPlanCreate) -> models.MedicalPlan:
+    with with_event_session(event_id) as session:
+        obj = models.MedicalPlan(**data.dict())
+        session.add(obj)
+        session.flush()
+        return obj
+
+
+def add_safety_plan(event_id: str, data: schemas.SafetyPlanCreate) -> models.SafetyPlan:
+    with with_event_session(event_id) as session:
+        obj = models.SafetyPlan(**data.dict())
+        session.add(obj)
+        session.flush()
+        return obj
+


### PR DESCRIPTION
## Summary
- scaffold Planned Event Toolkit module with FastAPI router, models, and services
- add SQLite repository for master and event databases with export/search helpers
- provide basic QML panels for planned event workflows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689991b4f754832b9ce46f8cb91c83ac