### PR TITLE
feat(finance): add finance module scaffolding

### DIFF
--- a/modules/finance/__init__.py
+++ b/modules/finance/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .api import router
+from .panels.finance_home_panel import FinanceHomePanel
+
+
+def get_finance_panel() -> FinanceHomePanel:
+    """Return the main Finance panel."""
+    return FinanceHomePanel()
+
+__all__ = ["router", "get_finance_panel", "FinanceHomePanel"]

--- a/modules/finance/api.py
+++ b/modules/finance/api.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+
+from . import services
+from .models.schemas import (
+    VendorRead,
+    LaborRateRead,
+    EquipmentRateRead,
+    AccountRead,
+    TimeEntryCreate,
+    TimeEntryUpdate,
+    RequisitionCreate,
+    POCreate,
+    ReceiptCreate,
+    InvoiceCreate,
+    InvoiceUpdate,
+    CostEntryCreate,
+    BudgetCreate,
+    DailyCostFinalizeRequest,
+    ClaimCreate,
+    ClaimUpdate,
+    ReportRequest,
+    ExportArtifactRead,
+)
+
+router = APIRouter(prefix="/api/finance", tags=["finance"])
+
+# Lookups --------------------------------------------------------------------
+
+@router.get("/lookups/vendors", response_model=List[VendorRead])
+def lookup_vendors():
+    return services.list_vendors()
+
+
+@router.get("/lookups/rates/labor", response_model=List[LaborRateRead])
+def lookup_labor_rates():
+    return services.list_labor_rates()
+
+
+@router.get("/lookups/rates/equipment", response_model=List[EquipmentRateRead])
+def lookup_equipment_rates():
+    return services.list_equipment_rates()
+
+
+@router.get("/lookups/accounts", response_model=List[AccountRead])
+def lookup_accounts():
+    return services.list_accounts()
+
+# Time Unit ------------------------------------------------------------------
+
+@router.post("/time", response_model=int)
+def create_time_entry(mission_id: str, data: TimeEntryCreate):
+    return services.create_time_entry(mission_id, data)
+
+
+@router.put("/time/{entry_id}")
+def update_time_entry(mission_id: str, entry_id: int, data: TimeEntryUpdate):
+    services.update_time_entry(mission_id, entry_id, data)
+    return {"status": "ok"}
+
+
+@router.post("/time/{entry_id}/submit")
+def submit_time_entry(mission_id: str, entry_id: int):
+    services.submit_time_entry(mission_id, entry_id)
+    return {"status": "ok"}
+
+
+@router.post("/time/{entry_id}/approve")
+def approve_time_entry(mission_id: str, entry_id: int, approve: bool, actor_id: int):
+    services.approve_time_entry(mission_id, entry_id, actor_id, approve)
+    return {"status": "ok"}
+
+# Procurement ----------------------------------------------------------------
+
+@router.post("/requisitions", response_model=int)
+def create_requisition(mission_id: str, data: RequisitionCreate):
+    return services.create_requisition(mission_id, data)
+
+
+@router.post("/pos", response_model=int)
+def create_po(mission_id: str, data: POCreate):
+    return services.create_purchase_order(mission_id, data)
+
+
+@router.post("/pos/{po_id}/receive", response_model=int)
+def receive_po(mission_id: str, po_id: int, data: ReceiptCreate):
+    data.po_id = po_id
+    return services.receive_po(mission_id, data)
+
+
+@router.post("/invoices", response_model=int)
+def create_invoice(mission_id: str, data: InvoiceCreate):
+    return services.create_invoice(mission_id, data)
+
+
+@router.post("/invoices/{invoice_id}/approve")
+def approve_invoice(mission_id: str, invoice_id: int):
+    services.approve_invoice(mission_id, invoice_id)
+    return {"status": "ok"}
+
+# Cost Unit ------------------------------------------------------------------
+
+@router.post("/costs", response_model=int)
+def post_cost_entry(mission_id: str, data: CostEntryCreate):
+    return services.post_cost_entry(mission_id, data)
+
+
+@router.post("/budgets", response_model=int)
+def create_budget(mission_id: str, data: BudgetCreate):
+    return services.create_budget(mission_id, data)
+
+
+@router.post("/daily/finalize", response_model=int)
+def finalize_daily(mission_id: str, data: DailyCostFinalizeRequest):
+    return services.finalize_daily_cost_summary(mission_id, data)
+
+# Claims ---------------------------------------------------------------------
+
+@router.post("/claims", response_model=int)
+def create_claim(mission_id: str, data: ClaimCreate):
+    return services.create_claim(mission_id, data)
+
+
+@router.put("/claims/{claim_id}")
+def update_claim(mission_id: str, claim_id: int, data: ClaimUpdate):
+    services.update_claim(mission_id, claim_id, data)
+    return {"status": "ok"}
+
+# Exports --------------------------------------------------------------------
+
+@router.post("/exports/report", response_model=ExportArtifactRead)
+def export_report(mission_id: str, req: ReportRequest):
+    return services.generate_report(mission_id, req)
+
+
+@router.get("/exports", response_model=List[ExportArtifactRead])
+def list_exports(mission_id: str):
+    return services.list_exports(mission_id)

--- a/modules/finance/approvals.py
+++ b/modules/finance/approvals.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+def get_chain(session: Session, chain_id: int) -> List[str]:
+    row = session.execute(
+        text("SELECT steps_json FROM approval_chains WHERE id=:id"),
+        {"id": chain_id},
+    ).fetchone()
+    if not row:
+        return []
+    return json.loads(row[0])
+
+
+def next_step(chain: List[str], completed: List[str]) -> Optional[str]:
+    for step in chain:
+        if step not in completed:
+            return step
+    return None
+
+
+def record_approval(
+    session: Session,
+    mission_id: str,
+    entity: str,
+    entity_id: int,
+    step: str,
+    actor_id: int,
+    action: str,
+    comments: Optional[str] = None,
+) -> None:
+    session.execute(
+        text(
+            """
+            INSERT INTO approvals
+            (mission_id, entity, entity_id, step, actor_id, action, timestamp, comments)
+            VALUES (:mission_id, :entity, :entity_id, :step, :actor_id, :action, :timestamp, :comments)
+            """
+        ),
+        {
+            "mission_id": mission_id,
+            "entity": entity,
+            "entity_id": entity_id,
+            "step": step,
+            "actor_id": actor_id,
+            "action": action,
+            "timestamp": datetime.utcnow(),
+            "comments": comments,
+        },
+    )
+    session.commit()

--- a/modules/finance/exporter.py
+++ b/modules/finance/exporter.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def export_daily_cost_summary(session: Session, mission_id: str, day: str) -> Dict[str, str]:
+    row = session.execute(
+        text(
+            "SELECT total_labor, total_equipment, total_procurement, total_other FROM daily_cost_summary WHERE mission_id=:m AND date=:d"
+        ),
+        {"m": mission_id, "d": day},
+    ).mappings().first()
+    if not row:
+        row = {"total_labor": 0, "total_equipment": 0, "total_procurement": 0, "total_other": 0}
+
+    export_dir = BASE_DIR / "data" / "missions" / mission_id / "exports" / "finance"
+    export_dir.mkdir(parents=True, exist_ok=True)
+    path = export_dir / f"daily_cost_{day}.csv"
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["total_labor", "total_equipment", "total_procurement", "total_other"])
+        writer.writerow([row["total_labor"], row["total_equipment"], row["total_procurement"], row["total_other"]])
+    return {"path": str(path), "created_at": datetime.utcnow().isoformat()}
+
+
+def list_artifacts(mission_id: str) -> List[Dict[str, str]]:
+    export_dir = BASE_DIR / "data" / "missions" / mission_id / "exports" / "finance"
+    if not export_dir.exists():
+        return []
+    artifacts = []
+    for file in export_dir.iterdir():
+        artifacts.append({"path": str(file), "created_at": datetime.fromtimestamp(file.stat().st_mtime).isoformat()})
+    return artifacts

--- a/modules/finance/models/schemas.py
+++ b/modules/finance/models/schemas.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from datetime import date, datetime
+from typing import Optional, List
+
+# Master lookups -------------------------------------------------------------
+
+class VendorRead(BaseModel):
+    id: int
+    name: str
+    contacts_json: Optional[str] = None
+    payment_terms: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class LaborRateRead(BaseModel):
+    id: int
+    title: str
+    rate_per_hour: float
+    overtime_mult: float = 1.5
+    effective_from: date
+    effective_to: Optional[date] = None
+
+
+class EquipmentRateRead(BaseModel):
+    id: int
+    type: str
+    rate_per_hour: float
+    rate_per_day: float
+    effective_from: date
+    effective_to: Optional[date] = None
+
+
+class AccountRead(BaseModel):
+    id: int
+    code: str
+    name: str
+    category: str
+
+
+# Time Unit -----------------------------------------------------------------
+
+class TimeEntryBase(BaseModel):
+    person_id: int
+    role: str
+    op_period: str
+    date: date
+    hours_worked: float
+    overtime_hours: float = 0
+    labor_rate_id: int
+    equipment_id: Optional[int] = None
+    notes: Optional[str] = None
+
+
+class TimeEntryCreate(TimeEntryBase):
+    pass
+
+
+class TimeEntryUpdate(BaseModel):
+    hours_worked: Optional[float] = None
+    overtime_hours: Optional[float] = None
+    labor_rate_id: Optional[int] = None
+    equipment_id: Optional[int] = None
+    notes: Optional[str] = None
+    status: Optional[str] = None
+
+
+class TimeEntryRead(TimeEntryBase):
+    id: int
+    status: str
+    approved_by: Optional[int] = None
+    approved_at: Optional[datetime] = None
+
+
+# Procurement ---------------------------------------------------------------
+
+class RequisitionCreate(BaseModel):
+    req_number: str
+    requestor_id: int
+    date: date
+    description: str
+    amount_est: float
+    approval_chain_id: Optional[int] = None
+
+
+class RequisitionRead(RequisitionCreate):
+    id: int
+    status: str
+
+
+class POCreate(BaseModel):
+    po_number: str
+    vendor_id: int
+    req_id: int
+    date: date
+    amount_auth: float
+
+
+class PORead(POCreate):
+    id: int
+    status: str
+
+
+class ReceiptCreate(BaseModel):
+    po_id: int
+    date: date
+    qty: float
+    amount: float
+    notes: Optional[str] = None
+
+
+class ReceiptRead(ReceiptCreate):
+    id: int
+
+
+class InvoiceCreate(BaseModel):
+    po_id: int
+    vendor_invoice_no: str
+    date: date
+    amount: float
+
+
+class InvoiceUpdate(BaseModel):
+    status: Optional[str] = None
+    amount: Optional[float] = None
+
+
+class InvoiceRead(InvoiceCreate):
+    id: int
+    status: str
+
+
+# Cost Unit -----------------------------------------------------------------
+
+class CostEntryCreate(BaseModel):
+    date: date
+    account_id: int
+    description: str
+    amount: float
+    source: str
+    ref_table: Optional[str] = None
+    ref_id: Optional[int] = None
+
+
+class CostEntryRead(CostEntryCreate):
+    id: int
+
+
+class DailyCostFinalizeRequest(BaseModel):
+    date: date
+    notes: Optional[str] = None
+
+
+class BudgetCreate(BaseModel):
+    account_id: int
+    amount_budgeted: float
+    notes: Optional[str] = None
+
+
+class BudgetRead(BudgetCreate):
+    id: int
+
+
+# Claims --------------------------------------------------------------------
+
+class ClaimBase(BaseModel):
+    claim_type: str
+    claimant_id: int
+    date_reported: date
+    description: str
+    amount_est: float
+    attachments_json: Optional[str] = None
+
+
+class ClaimCreate(ClaimBase):
+    pass
+
+
+class ClaimUpdate(BaseModel):
+    description: Optional[str] = None
+    amount_est: Optional[float] = None
+    status: Optional[str] = None
+    attachments_json: Optional[str] = None
+
+
+class ClaimRead(ClaimBase):
+    id: int
+    status: str
+
+
+# Approvals & Audit ---------------------------------------------------------
+
+class ApprovalAction(BaseModel):
+    step: str
+    action: str
+    comments: Optional[str] = None
+
+
+class ApprovalRecordRead(BaseModel):
+    id: int
+    entity: str
+    entity_id: int
+    step: str
+    actor_id: int
+    action: str
+    timestamp: datetime
+    comments: Optional[str] = None
+
+
+# Reports / Exports ---------------------------------------------------------
+
+class ReportRequest(BaseModel):
+    report_type: str
+    date: Optional[date] = None
+
+
+class ExportArtifactRead(BaseModel):
+    path: str
+    created_at: datetime
+
+
+# Permissions ---------------------------------------------------------------
+
+class PermissionOut(BaseModel):
+    can_edit: bool = False
+    can_approve: bool = False
+    can_finalize: bool = False
+    can_export: bool = False

--- a/modules/finance/panels/__init__.py
+++ b/modules/finance/panels/__init__.py
@@ -1,0 +1,15 @@
+from .finance_home_panel import FinanceHomePanel
+from .time_unit_panel import TimeUnitPanel
+from .procurement_panel import ProcurementPanel
+from .cost_unit_panel import CostUnitPanel
+from .claims_panel import ClaimsPanel
+from .approvals_panel import ApprovalsPanel
+
+__all__ = [
+    "FinanceHomePanel",
+    "TimeUnitPanel",
+    "ProcurementPanel",
+    "CostUnitPanel",
+    "ClaimsPanel",
+    "ApprovalsPanel",
+]

--- a/modules/finance/panels/approvals_panel.py
+++ b/modules/finance/panels/approvals_panel.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+from PySide6.QtCore import QUrl
+from PySide6.QtQuickWidgets import QQuickWidget
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+
+
+class ApprovalsPanel(QWidget):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.view = QQuickWidget()
+        qml_file = Path(__file__).resolve().parent.parent / "qml" / "Approvals.qml"
+        self.view.setSource(QUrl.fromLocalFile(str(qml_file)))
+        self.view.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        layout.addWidget(self.view)

--- a/modules/finance/panels/claims_panel.py
+++ b/modules/finance/panels/claims_panel.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+from PySide6.QtCore import QUrl
+from PySide6.QtQuickWidgets import QQuickWidget
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+
+
+class ClaimsPanel(QWidget):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.view = QQuickWidget()
+        qml_file = Path(__file__).resolve().parent.parent / "qml" / "Claims.qml"
+        self.view.setSource(QUrl.fromLocalFile(str(qml_file)))
+        self.view.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        layout.addWidget(self.view)

--- a/modules/finance/panels/cost_unit_panel.py
+++ b/modules/finance/panels/cost_unit_panel.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+from PySide6.QtCore import QUrl
+from PySide6.QtQuickWidgets import QQuickWidget
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+
+
+class CostUnitPanel(QWidget):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.view = QQuickWidget()
+        qml_file = Path(__file__).resolve().parent.parent / "qml" / "CostUnit.qml"
+        self.view.setSource(QUrl.fromLocalFile(str(qml_file)))
+        self.view.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        layout.addWidget(self.view)

--- a/modules/finance/panels/finance_home_panel.py
+++ b/modules/finance/panels/finance_home_panel.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+from PySide6.QtCore import QUrl
+from PySide6.QtQuickWidgets import QQuickWidget
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+
+
+class FinanceHomePanel(QWidget):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.view = QQuickWidget()
+        qml_file = Path(__file__).resolve().parent.parent / "qml" / "FinanceHome.qml"
+        self.view.setSource(QUrl.fromLocalFile(str(qml_file)))
+        self.view.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        layout.addWidget(self.view)

--- a/modules/finance/panels/procurement_panel.py
+++ b/modules/finance/panels/procurement_panel.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+from PySide6.QtCore import QUrl
+from PySide6.QtQuickWidgets import QQuickWidget
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+
+
+class ProcurementPanel(QWidget):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.view = QQuickWidget()
+        qml_file = Path(__file__).resolve().parent.parent / "qml" / "Procurement.qml"
+        self.view.setSource(QUrl.fromLocalFile(str(qml_file)))
+        self.view.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        layout.addWidget(self.view)

--- a/modules/finance/panels/time_unit_panel.py
+++ b/modules/finance/panels/time_unit_panel.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+from PySide6.QtCore import QUrl
+from PySide6.QtQuickWidgets import QQuickWidget
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+
+
+class TimeUnitPanel(QWidget):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.view = QQuickWidget()
+        qml_file = Path(__file__).resolve().parent.parent / "qml" / "TimeUnit.qml"
+        self.view.setSource(QUrl.fromLocalFile(str(qml_file)))
+        self.view.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        layout.addWidget(self.view)

--- a/modules/finance/qml/Approvals.qml
+++ b/modules/finance/qml/Approvals.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    anchors.fill: parent
+    color: "transparent"
+    Label {
+        anchors.centerIn: parent
+        text: "Approvals"
+    }
+}

--- a/modules/finance/qml/Claims.qml
+++ b/modules/finance/qml/Claims.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    anchors.fill: parent
+    color: "transparent"
+    Label {
+        anchors.centerIn: parent
+        text: "Claims"
+    }
+}

--- a/modules/finance/qml/CostUnit.qml
+++ b/modules/finance/qml/CostUnit.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    anchors.fill: parent
+    color: "transparent"
+    Label {
+        anchors.centerIn: parent
+        text: "Cost Unit"
+    }
+}

--- a/modules/finance/qml/FinanceHome.qml
+++ b/modules/finance/qml/FinanceHome.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    anchors.fill: parent
+    color: "transparent"
+    Label {
+        anchors.centerIn: parent
+        text: "Finance Home"
+    }
+}

--- a/modules/finance/qml/Procurement.qml
+++ b/modules/finance/qml/Procurement.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    anchors.fill: parent
+    color: "transparent"
+    Label {
+        anchors.centerIn: parent
+        text: "Procurement"
+    }
+}

--- a/modules/finance/qml/TimeUnit.qml
+++ b/modules/finance/qml/TimeUnit.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    anchors.fill: parent
+    color: "transparent"
+    Label {
+        anchors.centerIn: parent
+        text: "Time Unit"
+    }
+}

--- a/modules/finance/rates.py
+++ b/modules/finance/rates.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import date
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+def resolve_labor_cost(
+    session: Session,
+    labor_rate_id: int,
+    work_date: date,
+    hours: float,
+    overtime_hours: float = 0.0,
+) -> float:
+    row = session.execute(
+        text(
+            """
+            SELECT rate_per_hour, overtime_mult FROM labor_rates
+            WHERE id=:id AND :d >= effective_from AND (effective_to IS NULL OR :d <= effective_to)
+            """
+        ),
+        {"id": labor_rate_id, "d": work_date},
+    ).mappings().first()
+    if not row:
+        return 0.0
+    return row["rate_per_hour"] * hours + row["rate_per_hour"] * row["overtime_mult"] * overtime_hours
+
+
+def resolve_equipment_cost(
+    session: Session,
+    equipment_rate_id: int,
+    work_date: date,
+    hours: float,
+) -> float:
+    row = session.execute(
+        text(
+            """
+            SELECT rate_per_hour FROM equipment_rates
+            WHERE id=:id AND :d >= effective_from AND (effective_to IS NULL OR :d <= effective_to)
+            """
+        ),
+        {"id": equipment_rate_id, "d": work_date},
+    ).mappings().first()
+    if not row:
+        return 0.0
+    return row["rate_per_hour"] * hours

--- a/modules/finance/repository.py
+++ b/modules/finance/repository.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker, Session
+
+BASE_DIR = Path(__file__).resolve().parent
+DATA_DIR = BASE_DIR / "data"
+MASTER_DB = DATA_DIR / "master.db"
+MISSIONS_DIR = DATA_DIR / "missions"
+
+# -- table initialization ----------------------------------------------------
+
+MASTER_TABLES = [
+    """
+    CREATE TABLE IF NOT EXISTS vendors (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        contacts_json TEXT,
+        payment_terms TEXT,
+        notes TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS labor_rates (
+        id INTEGER PRIMARY KEY,
+        title TEXT,
+        rate_per_hour REAL,
+        overtime_mult REAL,
+        effective_from DATE,
+        effective_to DATE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS equipment_rates (
+        id INTEGER PRIMARY KEY,
+        type TEXT,
+        rate_per_hour REAL,
+        rate_per_day REAL,
+        effective_from DATE,
+        effective_to DATE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS approval_chains (
+        id INTEGER PRIMARY KEY,
+        name TEXT,
+        steps_json TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS accounts (
+        id INTEGER PRIMARY KEY,
+        code TEXT,
+        name TEXT,
+        category TEXT
+    )
+    """,
+]
+
+MISSION_TABLES = [
+    """
+    CREATE TABLE IF NOT EXISTS time_entries (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        person_id INTEGER,
+        role TEXT,
+        op_period TEXT,
+        date DATE,
+        hours_worked REAL,
+        overtime_hours REAL,
+        labor_rate_id INTEGER,
+        equipment_id INTEGER,
+        notes TEXT,
+        status TEXT,
+        approved_by INTEGER,
+        approved_at DATETIME
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS requisitions (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        req_number TEXT,
+        request_id INTEGER,
+        requestor_id INTEGER,
+        date DATE,
+        description TEXT,
+        amount_est REAL,
+        status TEXT,
+        approval_chain_id INTEGER
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS purchase_orders (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        po_number TEXT,
+        vendor_id INTEGER,
+        req_id INTEGER,
+        date DATE,
+        amount_auth REAL,
+        status TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS receipts (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        po_id INTEGER,
+        date DATE,
+        qty REAL,
+        amount REAL,
+        notes TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS invoices (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        po_id INTEGER,
+        vendor_invoice_no TEXT,
+        date DATE,
+        amount REAL,
+        status TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS cost_entries (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        date DATE,
+        account_id INTEGER,
+        description TEXT,
+        amount REAL,
+        source TEXT,
+        ref_table TEXT,
+        ref_id INTEGER
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS daily_cost_summary (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        date DATE,
+        total_labor REAL,
+        total_equipment REAL,
+        total_procurement REAL,
+        total_other REAL,
+        notes TEXT,
+        finalized_by INTEGER,
+        finalized_at DATETIME
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS budgets (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        account_id INTEGER,
+        amount_budgeted REAL,
+        notes TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS claims (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        claim_type TEXT,
+        claimant_id INTEGER,
+        date_reported DATE,
+        description TEXT,
+        amount_est REAL,
+        status TEXT,
+        attachments_json TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS approvals (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        entity TEXT,
+        entity_id INTEGER,
+        step TEXT,
+        actor_id INTEGER,
+        action TEXT,
+        timestamp DATETIME,
+        comments TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS finance_audit (
+        id INTEGER PRIMARY KEY,
+        mission_id TEXT,
+        entity TEXT,
+        entity_id INTEGER,
+        action TEXT,
+        who INTEGER,
+        when DATETIME,
+        details_json TEXT
+    )
+    """,
+]
+
+
+def _init_db(engine: Engine, statements: list[str]) -> None:
+    with engine.begin() as conn:
+        for stmt in statements:
+            conn.exec_driver_sql(stmt)
+
+
+def get_master_engine() -> Engine:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite:///{MASTER_DB}")
+    _init_db(engine, MASTER_TABLES)
+    return engine
+
+
+def get_mission_engine(mission_id: str) -> Engine:
+    mission_path = MISSIONS_DIR / f"{mission_id}.db"
+    mission_path.parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(f"sqlite:///{mission_path}")
+    _init_db(engine, MISSION_TABLES)
+    return engine
+
+
+@contextmanager
+def with_master_session() -> Generator[Session, None, None]:
+    engine = get_master_engine()
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@contextmanager
+def with_mission_session(mission_id: str) -> Generator[Session, None, None]:
+    engine = get_mission_engine(mission_id)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/modules/finance/services.py
+++ b/modules/finance/services.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import text
+
+from .repository import with_master_session, with_mission_session
+from .rates import resolve_labor_cost, resolve_equipment_cost
+from .approvals import get_chain, next_step, record_approval
+from .models.schemas import (
+    TimeEntryCreate,
+    TimeEntryUpdate,
+    TimeEntryRead,
+    RequisitionCreate,
+    RequisitionRead,
+    POCreate,
+    PORead,
+    ReceiptCreate,
+    ReceiptRead,
+    InvoiceCreate,
+    InvoiceUpdate,
+    InvoiceRead,
+    CostEntryCreate,
+    CostEntryRead,
+    DailyCostFinalizeRequest,
+    BudgetCreate,
+    BudgetRead,
+    ClaimCreate,
+    ClaimUpdate,
+    ClaimRead,
+    VendorRead,
+    LaborRateRead,
+    EquipmentRateRead,
+    AccountRead,
+    ReportRequest,
+    ExportArtifactRead,
+)
+from .exporter import export_daily_cost_summary, list_artifacts
+
+# Lookups -------------------------------------------------------------------
+
+def list_vendors() -> List[VendorRead]:
+    with with_master_session() as session:
+        rows = session.execute(text("SELECT * FROM vendors")).mappings().all()
+        return [VendorRead(**row) for row in rows]
+
+
+def list_labor_rates() -> List[LaborRateRead]:
+    with with_master_session() as session:
+        rows = session.execute(text("SELECT * FROM labor_rates")).mappings().all()
+        return [LaborRateRead(**row) for row in rows]
+
+
+def list_equipment_rates() -> List[EquipmentRateRead]:
+    with with_master_session() as session:
+        rows = session.execute(text("SELECT * FROM equipment_rates")).mappings().all()
+        return [EquipmentRateRead(**row) for row in rows]
+
+
+def list_accounts() -> List[AccountRead]:
+    with with_master_session() as session:
+        rows = session.execute(text("SELECT * FROM accounts")).mappings().all()
+        return [AccountRead(**row) for row in rows]
+
+# Time Unit -----------------------------------------------------------------
+
+def create_time_entry(mission_id: str, data: TimeEntryCreate) -> int:
+    with with_mission_session(mission_id) as session:
+        result = session.execute(
+            text(
+                """
+                INSERT INTO time_entries (mission_id, person_id, role, op_period, date, hours_worked, overtime_hours, labor_rate_id, equipment_id, notes, status)
+                VALUES (:mission_id, :person_id, :role, :op_period, :date, :hours_worked, :overtime_hours, :labor_rate_id, :equipment_id, :notes, 'draft')
+                """
+            ),
+            {"mission_id": mission_id, **data.dict()},
+        )
+        session.commit()
+        return result.lastrowid
+
+
+def update_time_entry(mission_id: str, entry_id: int, data: TimeEntryUpdate) -> None:
+    fields = {k: v for k, v in data.dict().items() if v is not None}
+    sets = ", ".join(f"{k}=:{k}" for k in fields)
+    with with_mission_session(mission_id) as session:
+        session.execute(
+            text(f"UPDATE time_entries SET {sets} WHERE id=:id"),
+            {"id": entry_id, **fields},
+        )
+        session.commit()
+
+
+def submit_time_entry(mission_id: str, entry_id: int) -> None:
+    with with_mission_session(mission_id) as session:
+        session.execute(
+            text("UPDATE time_entries SET status='submitted' WHERE id=:id"),
+            {"id": entry_id},
+        )
+        session.commit()
+
+
+def approve_time_entry(mission_id: str, entry_id: int, approver_id: int, approve: bool) -> None:
+    status = "approved" if approve else "rejected"
+    with with_mission_session(mission_id) as session:
+        session.execute(
+            text(
+                "UPDATE time_entries SET status=:status, approved_by=:a, approved_at=:t WHERE id=:id"
+            ),
+            {"status": status, "a": approver_id, "t": datetime.utcnow(), "id": entry_id},
+        )
+        session.commit()
+
+# Procurement ----------------------------------------------------------------
+
+def create_requisition(mission_id: str, data: RequisitionCreate) -> int:
+    with with_mission_session(mission_id) as session:
+        result = session.execute(
+            text(
+                """
+                INSERT INTO requisitions (mission_id, req_number, requestor_id, date, description, amount_est, status, approval_chain_id)
+                VALUES (:mission_id, :req_number, :requestor_id, :date, :description, :amount_est, 'draft', :approval_chain_id)
+                """
+            ),
+            {"mission_id": mission_id, **data.dict()},
+        )
+        session.commit()
+        return result.lastrowid
+
+
+def create_purchase_order(mission_id: str, data: POCreate) -> int:
+    with with_mission_session(mission_id) as session:
+        result = session.execute(
+            text(
+                """
+                INSERT INTO purchase_orders (mission_id, po_number, vendor_id, req_id, date, amount_auth, status)
+                VALUES (:mission_id, :po_number, :vendor_id, :req_id, :date, :amount_auth, 'open')
+                """
+            ),
+            {"mission_id": mission_id, **data.dict()},
+        )
+        session.commit()
+        return result.lastrowid
+
+
+def receive_po(mission_id: str, data: ReceiptCreate) -> int:
+    with with_mission_session(mission_id) as session:
+        result = session.execute(
+            text(
+                """
+                INSERT INTO receipts (mission_id, po_id, date, qty, amount, notes)
+                VALUES (:mission_id, :po_id, :date, :qty, :amount, :notes)
+                """
+            ),
+            {"mission_id": mission_id, **data.dict()},
+        )
+        session.commit()
+        return result.lastrowid
+
+
+def create_invoice(mission_id: str, data: InvoiceCreate) -> int:
+    with with_mission_session(mission_id) as session:
+        result = session.execute(
+            text(
+                """
+                INSERT INTO invoices (mission_id, po_id, vendor_invoice_no, date, amount, status)
+                VALUES (:mission_id, :po_id, :vendor_invoice_no, :date, :amount, 'pending')
+                """
+            ),
+            {"mission_id": mission_id, **data.dict()},
+        )
+        session.commit()
+        return result.lastrowid
+
+
+def approve_invoice(mission_id: str, invoice_id: int) -> None:
+    with with_mission_session(mission_id) as session:
+        session.execute(
+            text("UPDATE invoices SET status='approved' WHERE id=:id"),
+            {"id": invoice_id},
+        )
+        session.commit()
+
+# Cost Unit ------------------------------------------------------------------
+
+def post_cost_entry(mission_id: str, data: CostEntryCreate) -> int:
+    with with_mission_session(mission_id) as session:
+        result = session.execute(
+            text(
+                """
+                INSERT INTO cost_entries (mission_id, date, account_id, description, amount, source, ref_table, ref_id)
+                VALUES (:mission_id, :date, :account_id, :description, :amount, :source, :ref_table, :ref_id)
+                """
+            ),
+            {"mission_id": mission_id, **data.dict()},
+        )
+        session.commit()
+        return result.lastrowid
+
+
+def create_budget(mission_id: str, data: BudgetCreate) -> int:
+    with with_mission_session(mission_id) as session:
+        result = session.execute(
+            text(
+                """
+                INSERT INTO budgets (mission_id, account_id, amount_budgeted, notes)
+                VALUES (:mission_id, :account_id, :amount_budgeted, :notes)
+                """
+            ),
+            {"mission_id": mission_id, **data.dict()},
+        )
+        session.commit()
+        return result.lastrowid
+
+
+def finalize_daily_cost_summary(mission_id: str, data: DailyCostFinalizeRequest) -> int:
+    with with_mission_session(mission_id) as session:
+        result = session.execute(
+            text(
+                """
+                INSERT INTO daily_cost_summary (mission_id, date, total_labor, total_equipment, total_procurement, total_other, notes, finalized_by, finalized_at)
+                VALUES (:mission_id, :date, 0, 0, 0, 0, :notes, :fb, :fa)
+                """
+            ),
+            {
+                "mission_id": mission_id,
+                "date": data.date,
+                "notes": data.notes,
+                "fb": 0,
+                "fa": datetime.utcnow(),
+            },
+        )
+        session.commit()
+        return result.lastrowid
+
+# Claims ---------------------------------------------------------------------
+
+def create_claim(mission_id: str, data: ClaimCreate) -> int:
+    with with_mission_session(mission_id) as session:
+        result = session.execute(
+            text(
+                """
+                INSERT INTO claims (mission_id, claim_type, claimant_id, date_reported, description, amount_est, status, attachments_json)
+                VALUES (:mission_id, :claim_type, :claimant_id, :date_reported, :description, :amount_est, 'open', :attachments_json)
+                """
+            ),
+            {"mission_id": mission_id, **data.dict()},
+        )
+        session.commit()
+        return result.lastrowid
+
+
+def update_claim(mission_id: str, claim_id: int, data: ClaimUpdate) -> None:
+    fields = {k: v for k, v in data.dict().items() if v is not None}
+    sets = ", ".join(f"{k}=:{k}" for k in fields)
+    with with_mission_session(mission_id) as session:
+        session.execute(
+            text(f"UPDATE claims SET {sets} WHERE id=:id"),
+            {"id": claim_id, **fields},
+        )
+        session.commit()
+
+# Exports --------------------------------------------------------------------
+
+def generate_report(mission_id: str, req: ReportRequest) -> ExportArtifactRead:
+    with with_mission_session(mission_id) as session:
+        if req.report_type == "daily_cost_summary":
+            info = export_daily_cost_summary(session, mission_id, req.date.isoformat())
+            return ExportArtifactRead(**info)
+        raise ValueError("unsupported report type")
+
+
+def list_exports(mission_id: str) -> List[ExportArtifactRead]:
+    artifacts = list_artifacts(mission_id)
+    return [ExportArtifactRead(**a) for a in artifacts]


### PR DESCRIPTION
## Summary
- scaffold finance API with lookups, time, procurement, cost, claims and export endpoints
- provide SQLite repository/session helpers and service layer operations
- add placeholder panels and QML views for finance workflows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68999a3bbcb4832b85915c21b97fc9d9