### PR TITLE
Fix task detail path

### DIFF
--- a/main.py
+++ b/main.py
@@ -243,7 +243,7 @@ class MainWindow(QMainWindow):
 
     def open_task_detail(self):
         self.task_window = QQuickView()
-        self.task_window.setSource(QUrl("TaskDetail.qml"))
+        self.task_window.setSource(QUrl("modules/operations/qml/taskdetail.qml"))
         self.task_window.setResizeMode(QQuickView.SizeRootObjectToView)
         self.task_window.setColor("white")
         self.task_window.show()


### PR DESCRIPTION
## Summary
- Load task detail window from `modules/operations/qml/taskdetail.qml` so the correct QML is displayed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899a3fbb82c832bb2cfc6b7a42628b0