### PR TITLE
Remove duplicate Assign Teams action

### DIFF
--- a/main.py
+++ b/main.py
@@ -136,7 +136,6 @@ class MainWindow(QMainWindow):
         operations_menu.addSeparator()
         operations_menu.addAction(QAction("Tasks", self))
         operations_menu.addAction(QAction("Assign Teams", self))
-        operations_menu.addAction(QAction("Assign Teams", self))
 
         # Logistics Menu
         logistics_menu = menu_bar.addMenu("Logistics")


### PR DESCRIPTION
## Summary
- remove duplicate "Assign Teams" menu item in Operations menu

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6899a3f90b20832ba7c2833785602aad