### PR TITLE
Refactor core models to use dataclasses

### DIFF
--- a/models/mission.py
+++ b/models/mission.py
@@ -1,15 +1,20 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
 class Mission:
-    def __init__(self, id, number, name, type, description, status, icp_location, start_time, end_time, is_training):
-        self.id = id
-        self.number = number
-        self.name = name
-        self.type = type  # e.g., "Search and Rescue", "Disaster Relief"
-        self.description = description
-        self.status = status  # e.g., "Active", "Closed", etc.
-        self.icp_location = icp_location
-        self.start_time = start_time
-        self.end_time = end_time
-        self.is_training = is_training  # Boolean
+    id: Optional[int]
+    number: str
+    name: str
+    type: str  # e.g., "Search and Rescue", "Disaster Relief"
+    description: str
+    status: str  # e.g., "Active", "Closed", etc.
+    icp_location: str
+    start_time: Optional[str]
+    end_time: Optional[str]
+    is_training: bool  # Boolean
 
     def __str__(self):
         return f"{self.name} ({self.status})"
+

--- a/modules/operations/models/tasks.py
+++ b/modules/operations/models/tasks.py
@@ -1,13 +1,15 @@
-# models/tasks.py
+from dataclasses import dataclass, field
+from typing import List, Optional
 
+
+@dataclass
 class Task:
-    def __init__(self, number, name, status, priority, assigned_teams=None, location=None):
-        self.number = number                  # e.g. "T-001"
-        self.name = name                      # e.g. "Ramp Check"
-        self.status = status                  # e.g. "In Progress"
-        self.priority = priority              # e.g. "High", "Urgent"
-        self.assigned_teams = assigned_teams or []  # List of team names or IDs
-        self.location = location              # Optional text or coordinate label
+    number: str                  # e.g. "T-001"
+    name: str                    # e.g. "Ramp Check"
+    status: str                  # e.g. "In Progress"
+    priority: str                # e.g. "High", "Urgent"
+    assigned_teams: List[str] = field(default_factory=list)  # List of team names or IDs
+    location: Optional[str] = None              # Optional text or coordinate label
 
     def __str__(self):
         return f"{self.number} - {self.name}"

--- a/modules/operations/models/teams.py
+++ b/modules/operations/models/teams.py
@@ -1,12 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass
 class Team:
-    def __init__(self, sortie, name, leader, contact, status, assignment="", location=""):
-        self.sortie = sortie        # e.g. "G-023"
-        self.name = name            # e.g. "GT-Bravo"
-        self.leader = leader        # e.g. "Weeter, Danielle"
-        self.contact = contact      # e.g. "555-1234"
-        self.status = status        # e.g. "Enroute"
-        self.assignment = assignment  # e.g. "Ramp Check"
-        self.location = location      # e.g. "KTEW"
+    sortie: str        # e.g. "G-023"
+    name: str          # e.g. "GT-Bravo"
+    leader: str        # e.g. "Weeter, Danielle"
+    contact: str       # e.g. "555-1234"
+    status: str        # e.g. "Enroute"
+    assignment: str = ""  # e.g. "Ramp Check"
+    location: str = ""    # e.g. "KTEW"
 
     def __str__(self):
         return f"{self.name} ({self.sortie})"


### PR DESCRIPTION
## Summary
- Convert Team, Task, and Mission classes into `@dataclass` structures with type hints
- Remove custom constructors and rely on dataclass-generated `__init__`
- Use default values and factories for optional fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899c3f4ded0832bab934d96747a34cf