### PR TITLE
Handle invalid settings file gracefully

### DIFF
--- a/utils/settingsmanager.py
+++ b/utils/settingsmanager.py
@@ -9,10 +9,16 @@ class SettingsManager:
 
     def load(self):
         if os.path.exists(self.filename):
-            with open(self.filename, "r") as f:
-                self.settings = json.load(f)
+            try:
+                with open(self.filename, "r") as f:
+                    self.settings = json.load(f)
+            except json.JSONDecodeError:
+                print(f"Warning: Failed to decode JSON from {self.filename}. Resetting settings.")
+                self.settings = {}
+                self.save()
         else:
             self.settings = {}
+            self.save()
 
     def save(self):
         with open(self.filename, "w") as f:


### PR DESCRIPTION
## Summary
- Guard settings loading against invalid JSON by catching `json.JSONDecodeError`
- Reset settings to defaults and recreate settings file when decoding fails or file is missing

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6899c3f5b1e8832ba574a068bb5afa31