### PR TITLE
Use Path import for test service path setup

### DIFF
--- a/tests/logistics/test_service.py
+++ b/tests/logistics/test_service.py
@@ -1,7 +1,7 @@
-import sys, pathlib
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
-
+import sys
 from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from modules.logistics import services
 from modules.logistics.models import (


### PR DESCRIPTION
## Summary
- import sys and Path at top of test_service
- simplify sys.path.append call to use Path

## Testing
- `pytest tests/logistics/test_service.py`


------
https://chatgpt.com/codex/tasks/task_b_6899c3eeb270832bbbeea8b51882e210