### PR TITLE
Use mission number as selection identifier

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from modules.operations.panels.team_status_panel import TeamStatusPanel
 from modules.operations.panels.task_status_panel import TaskStatusPanel
 from models.qmlwindow import QmlWindow, new_mission_form, open_mission_list
 from utils.state import AppState
-from models.database import get_mission_by_id
+from models.database import get_mission_by_number
 from bridge.settings_bridge import QmlSettingsBridge
 from utils.settingsmanager import SettingsManager
 
@@ -30,7 +30,7 @@ class MainWindow(QMainWindow):
         # Try to load the active mission and include it in the title
         active_id = AppState.get_active_mission()
         if active_id:
-            mission = get_mission_by_id(active_id)
+            mission = get_mission_by_number(active_id)
             if mission:
                 # Use an f-string so the mission details appear in the title
                 title = f"SARApp - {mission['number']} | {mission['name']}"
@@ -258,7 +258,7 @@ class MainWindow(QMainWindow):
         mission_id = AppState.get_active_mission()
         print(f"[DEBUG] Active mission ID: {mission_id}")
         if mission_id:
-                mission = get_mission_by_id(mission_id)
+                mission = get_mission_by_number(mission_id)
                 if mission:
                     print(f"[DEBUG] Setting title to: {mission['number']}: {mission['name']}")
                     self.setWindowTitle(f"SARApp - {mission['number']}: {mission['name']}")

--- a/models/database.py
+++ b/models/database.py
@@ -214,3 +214,19 @@ def get_mission_by_id(mission_id):
         return dict(zip(keys, row))
     return None
 
+def get_mission_by_number(mission_number):
+    import sqlite3
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row  # Allows access like a dictionary
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT * FROM missions WHERE number = ?", (mission_number,))
+    row = cursor.fetchone()
+    description = cursor.description
+    conn.close()
+
+    if row:
+        keys = [desc[0] for desc in description]
+        return dict(zip(keys, row))
+    return None
+

--- a/models/mission_handler.py
+++ b/models/mission_handler.py
@@ -1,11 +1,11 @@
 from PySide6.QtCore import QObject, Slot, Signal
 from models.mission import Mission
-from models.database import insert_new_mission, get_mission_by_id
+from models.database import insert_new_mission, get_mission_by_number
 from utils.mission_db import create_mission_database
 from utils.state import AppState
 
 class MissionHandler(QObject):
-    mission_selected = Signal(str)  # Emit mission_id as int
+    mission_selected = Signal(str)  # Emit mission identifier
 
     def __init__(self):
         super().__init__()
@@ -35,10 +35,10 @@ class MissionHandler(QObject):
         create_mission_database(mission_id)
         print(f" Mission '{name}' created with ID {mission_id}")
 
-    @Slot(int)
+    @Slot(str)
     def select_mission(self, mission_id):
         AppState.set_active_mission(mission_id)
-        mission = get_mission_by_id(mission_id)
+        mission = get_mission_by_number(mission_id)
         if mission:
             print(f"Selected mission: {mission['number']} - {mission['name']}")
         else:

--- a/models/missionlist.py
+++ b/models/missionlist.py
@@ -14,7 +14,7 @@ class MissionListModel(QAbstractListModel):
 
         mission = self._missions[index.row()]
         if role == Qt.UserRole:
-            return mission["id"]
+            return mission["number"]
         elif role == Qt.UserRole + 1:
             return mission["name"]
         elif role == Qt.UserRole + 2:
@@ -39,5 +39,5 @@ class MissionListModel(QAbstractListModel):
 
     def get_mission_id(self, row):
         if 0 <= row < len(self._missions):
-            return self._missions[row]['id']
+            return self._missions[row]['number']
         return None

--- a/models/qmlwindow.py
+++ b/models/qmlwindow.py
@@ -6,7 +6,7 @@ import os
 
 from models.mission_handler import MissionHandler
 from models.missionlist import MissionListModel
-from models.database import get_all_active_missions, get_mission_by_id
+from models.database import get_all_active_missions, get_mission_by_number
 from utils.state import AppState
 
 
@@ -48,7 +48,7 @@ def open_mission_list(main_window=None):
 
         def handle_selection(mission_id):
             AppState.set_active_mission(mission_id)
-            mission = get_mission_by_id(mission_id)
+            mission = get_mission_by_number(mission_id)
             if mission:
                 print(f"✅ Selected mission: {mission['number']} - {mission['name']}")
                 if main_window:

--- a/qml/missionlist.qml
+++ b/qml/missionlist.qml
@@ -7,7 +7,7 @@ Item {
     width: 800
     height: 500
 
-    signal missionSelected(int missionId)
+    signal missionSelected(string missionId)
 
     Rectangle {
         anchors.fill: parent
@@ -91,8 +91,8 @@ Item {
                             if (clickCount === 2) {
                                 clickTimer.stop()
                                 clickCount = 0
-                                console.log("Double-click detected on ID:", model.id)
-                                root.missionSelected(model.id)
+                                console.log("Double-click detected on ID:", model.number)
+                                root.missionSelected(model.number)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Use mission number as the list model identifier and getter
- Emit mission number via `missionSelected` signal and treat ID as string
- Handle mission selection with mission numbers by adding `get_mission_by_number`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689c3bd5b788832b89830f6cf9d9a062