### PR TITLE
Refactor mission retrieval to use mission numbers

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from modules.operations.panels.team_status_panel import TeamStatusPanel
 from modules.operations.panels.task_status_panel import TaskStatusPanel
 from models.qmlwindow import QmlWindow, new_mission_form, open_mission_list
 from utils.state import AppState
-from models.database import get_mission_by_id
+from models.database import get_mission_by_number
 from bridge.settings_bridge import QmlSettingsBridge
 from utils.settingsmanager import SettingsManager
 
@@ -28,9 +28,9 @@ class MainWindow(QMainWindow):
         self.settings_bridge = settings_bridge
 
         # Try to load the active mission and include it in the title
-        active_id = AppState.get_active_mission()
-        if active_id:
-            mission = get_mission_by_id(active_id)
+        active_number = AppState.get_active_mission()
+        if active_number:
+            mission = get_mission_by_number(active_number)
             if mission:
                 # Use an f-string so the mission details appear in the title
                 title = f"SARApp - {mission['number']} | {mission['name']}"
@@ -255,17 +255,17 @@ class MainWindow(QMainWindow):
 
     def update_title_with_active_mission(self):
         print("[DEBUG] update_title_with_active_mission called")
-        mission_id = AppState.get_active_mission()
-        print(f"[DEBUG] Active mission ID: {mission_id}")
-        if mission_id:
-                mission = get_mission_by_id(mission_id)
+        mission_number = AppState.get_active_mission()
+        print(f"[DEBUG] Active mission number: {mission_number}")
+        if mission_number:
+                mission = get_mission_by_number(mission_number)
                 if mission:
                     print(f"[DEBUG] Setting title to: {mission['number']}: {mission['name']}")
                     self.setWindowTitle(f"SARApp - {mission['number']}: {mission['name']}")
                 else:
-                    print("[DEBUG] No mission found with that ID")
+                    print("[DEBUG] No mission found with that number")
         else:
-                print("[DEBUG] No active mission ID set")
+                print("[DEBUG] No active mission number set")
 
     def open_settings_window(self):
         from PySide6.QtQml import QQmlApplicationEngine

--- a/models/database.py
+++ b/models/database.py
@@ -198,13 +198,13 @@ def get_all_active_missions():
     print("DEBUG ACTIVE MISSIONS:", rows[0] if rows else "None")
     return rows
 
-def get_mission_by_id(mission_id):
+def get_mission_by_number(mission_number):
     import sqlite3
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row  # Allows access like a dictionary
     cursor = conn.cursor()
 
-    cursor.execute("SELECT * FROM missions WHERE id = ?", (mission_id,))
+    cursor.execute("SELECT * FROM missions WHERE number = ?", (mission_number,))
     row = cursor.fetchone()
     description = cursor.description
     conn.close()

--- a/models/mission_handler.py
+++ b/models/mission_handler.py
@@ -1,11 +1,11 @@
 from PySide6.QtCore import QObject, Slot, Signal
 from models.mission import Mission
-from models.database import insert_new_mission, get_mission_by_id
+from models.database import insert_new_mission, get_mission_by_number
 from utils.mission_db import create_mission_database
 from utils.state import AppState
 
 class MissionHandler(QObject):
-    mission_selected = Signal(str)  # Emit mission_id as int
+    mission_selected = Signal(str)  # Emit mission number as str
 
     def __init__(self):
         super().__init__()
@@ -32,15 +32,17 @@ class MissionHandler(QObject):
             new_mission.icp_location,
             new_mission.is_training
         )
-        create_mission_database(mission_id)
-        print(f" Mission '{name}' created with ID {mission_id}")
+        mission_number = new_mission.number
+        create_mission_database(mission_number)
+        AppState.set_active_mission(mission_number)
+        print(f" Mission '{name}' created with ID {mission_id} and number {mission_number}")
 
-    @Slot(int)
-    def select_mission(self, mission_id):
-        AppState.set_active_mission(mission_id)
-        mission = get_mission_by_id(mission_id)
+    @Slot(str)
+    def select_mission(self, mission_number):
+        AppState.set_active_mission(mission_number)
+        mission = get_mission_by_number(mission_number)
         if mission:
             print(f"Selected mission: {mission['number']} - {mission['name']}")
         else:
-            print("Mission ID not found.")
-        self.mission_selected.emit(mission_id)  # Notify QML
+            print("Mission number not found.")
+        self.mission_selected.emit(mission_number)  # Notify QML

--- a/models/missionlist.py
+++ b/models/missionlist.py
@@ -37,7 +37,7 @@ class MissionListModel(QAbstractListModel):
             Qt.UserRole + 5: b"icp_location",
         }
 
-    def get_mission_id(self, row):
+    def get_mission_number(self, row):
         if 0 <= row < len(self._missions):
-            return self._missions[row]['id']
+            return self._missions[row]['number']
         return None

--- a/models/qmlwindow.py
+++ b/models/qmlwindow.py
@@ -6,7 +6,7 @@ import os
 
 from models.mission_handler import MissionHandler
 from models.missionlist import MissionListModel
-from models.database import get_all_active_missions, get_mission_by_id
+from models.database import get_all_active_missions, get_mission_by_number
 from utils.state import AppState
 
 
@@ -46,9 +46,9 @@ def open_mission_list(main_window=None):
 
         handler = MissionHandler()
 
-        def handle_selection(mission_id):
-            AppState.set_active_mission(mission_id)
-            mission = get_mission_by_id(mission_id)
+        def handle_selection(mission_number):
+            AppState.set_active_mission(mission_number)
+            mission = get_mission_by_number(mission_number)
             if mission:
                 print(f"✅ Selected mission: {mission['number']} - {mission['name']}")
                 if main_window:

--- a/qml/missionlist.qml
+++ b/qml/missionlist.qml
@@ -7,7 +7,7 @@ Item {
     width: 800
     height: 500
 
-    signal missionSelected(int missionId)
+    signal missionSelected(string missionNumber)
 
     Rectangle {
         anchors.fill: parent
@@ -91,8 +91,8 @@ Item {
                             if (clickCount === 2) {
                                 clickTimer.stop()
                                 clickCount = 0
-                                console.log("Double-click detected on ID:", model.id)
-                                root.missionSelected(model.id)
+                                console.log("Double-click detected on number:", model.number)
+                                root.missionSelected(model.number)
                             }
                         }
                     }

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -9,12 +9,12 @@ from utils.state import AppState
 
 @pytest.fixture(autouse=True)
 def reset_state():
-    AppState._active_mission_id = None
+    AppState._active_mission_number = None
     AppState._active_op_period_id = None
     AppState._active_user_id = None
     AppState._active_user_role = None
     yield
-    AppState._active_mission_id = None
+    AppState._active_mission_number = None
     AppState._active_op_period_id = None
     AppState._active_user_id = None
     AppState._active_user_role = None

--- a/utils/state.py
+++ b/utils/state.py
@@ -2,18 +2,18 @@
 # utils/state.py
 
 class AppState:
-    _active_mission_id = None
+    _active_mission_number = None
     _active_op_period_id = None
     _active_user_id = None
     _active_user_role = None
 
     @classmethod
-    def set_active_mission(cls, mission_id):
-        cls._active_mission_id = mission_id
+    def set_active_mission(cls, mission_number):
+        cls._active_mission_number = mission_number
 
     @classmethod
     def get_active_mission(cls):
-        return cls._active_mission_id
+        return cls._active_mission_number
 
     @classmethod
     def set_active_op_period(cls, op_period_id):


### PR DESCRIPTION
## Summary
- Capture both database row ID and mission number when creating missions
- Track active missions by mission number and fetch mission data by number
- Update mission list selection and related utilities to operate on mission numbers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c3bdb7600832b9a702f6ca038c3f5