### PR TITLE
Use string mission identifiers in Public Info module

### DIFF
--- a/modules/public_info/api.py
+++ b/modules/public_info/api.py
@@ -24,7 +24,7 @@ def get_current_user():
     return {"id": 1, "roles": ["PIO", "LeadPIO"]}
 
 
-def get_repo(mission_id: int = 1):  # mission id would come from app state
+def get_repo(mission_id: str = "1"):  # mission id would come from app state
     return PublicInfoRepository(mission_id)
 
 

--- a/modules/public_info/models/message.py
+++ b/modules/public_info/models/message.py
@@ -26,7 +26,7 @@ class Status(str, Enum):
 @dataclass
 class Message:
     id: Optional[int]
-    mission_id: int
+    mission_id: str
     title: str
     body: str
     type: MessageType

--- a/modules/public_info/models/repository.py
+++ b/modules/public_info/models/repository.py
@@ -12,11 +12,13 @@ def _utcnow() -> str:
     return datetime.utcnow().isoformat() + "Z"
 
 
-def get_db_path(mission_id: int) -> str:
+def get_db_path(mission_id: str) -> str:
+    mission_id = str(mission_id)
     return os.path.join(DB_DIR, f"{mission_id}.db")
 
 
-def get_connection(mission_id: int) -> sqlite3.Connection:
+def get_connection(mission_id: str) -> sqlite3.Connection:
+    mission_id = str(mission_id)
     path = get_db_path(mission_id)
     os.makedirs(os.path.dirname(path), exist_ok=True)
     conn = sqlite3.connect(path)
@@ -24,14 +26,15 @@ def get_connection(mission_id: int) -> sqlite3.Connection:
     return conn
 
 
-def init_db(mission_id: int) -> None:
+def init_db(mission_id: str) -> None:
+    mission_id = str(mission_id)
     conn = get_connection(mission_id)
     cur = conn.cursor()
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS public_info_messages (
             id INTEGER PRIMARY KEY,
-            mission_id INTEGER NOT NULL,
+            mission_id TEXT NOT NULL,
             title TEXT NOT NULL,
             body TEXT NOT NULL,
             type TEXT NOT NULL,
@@ -63,7 +66,8 @@ def init_db(mission_id: int) -> None:
 
 
 class PublicInfoRepository:
-    def __init__(self, mission_id: int):
+    def __init__(self, mission_id: str):
+        mission_id = str(mission_id)
         init_db(mission_id)
         self.mission_id = mission_id
 

--- a/modules/public_info/models/schemas.py
+++ b/modules/public_info/models/schemas.py
@@ -28,7 +28,7 @@ class MessageUpdate(BaseModel):
 
 class MessageRead(MessageBase):
     id: int
-    mission_id: int
+    mission_id: str
     status: Status
     revision: int
     created_by: int

--- a/modules/public_info/panels/editor_panel.py
+++ b/modules/public_info/panels/editor_panel.py
@@ -16,7 +16,7 @@ from ..models.repository import PublicInfoRepository
 class EditorPanel(QWidget):
     """Editor panel for creating and managing a PIO message."""
 
-    def __init__(self, mission_id: int, current_user: dict, message_id: int | None = None, parent=None):
+    def __init__(self, mission_id: str, current_user: dict, message_id: int | None = None, parent=None):
         super().__init__(parent)
         self.repo = PublicInfoRepository(mission_id)
         self.current_user = current_user

--- a/modules/public_info/panels/history_panel.py
+++ b/modules/public_info/panels/history_panel.py
@@ -6,7 +6,7 @@ from ..models.repository import PublicInfoRepository
 class HistoryPanel(QWidget):
     """Read-only panel listing published messages."""
 
-    def __init__(self, mission_id: int, parent=None):
+    def __init__(self, mission_id: str, parent=None):
         super().__init__(parent)
         self.repo = PublicInfoRepository(mission_id)
 

--- a/modules/public_info/panels/queue_panel.py
+++ b/modules/public_info/panels/queue_panel.py
@@ -16,7 +16,7 @@ from ..models.repository import PublicInfoRepository
 class QueuePanel(QWidget):
     """UI panel showing list of PIO messages."""
 
-    def __init__(self, mission_id: int, current_user: dict, parent=None):
+    def __init__(self, mission_id: str, current_user: dict, parent=None):
         super().__init__(parent)
         self.repo = PublicInfoRepository(mission_id)
         self.current_user = current_user

--- a/modules/public_info/seed.py
+++ b/modules/public_info/seed.py
@@ -3,7 +3,7 @@
 from .models.repository import PublicInfoRepository
 
 
-def seed(mission_id: int) -> None:
+def seed(mission_id: str) -> None:
     repo = PublicInfoRepository(mission_id)
     admin = {"id": 1, "roles": ["PIO", "LeadPIO", "IC"]}
 
@@ -47,4 +47,4 @@ def seed(mission_id: int) -> None:
 
 
 if __name__ == "__main__":
-    seed(1)
+    seed("1")


### PR DESCRIPTION
## Summary
- accept mission IDs as strings in Public Info API and UI panels
- persist mission IDs as text in Public Info repository
- update message schemas and seed script for string-based mission IDs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c3bd7a43c832ba5d11bbf8d81c66e