### PR TITLE
Add communications module skeleton

### DIFF
--- a/modules/communications/__init__.py
+++ b/modules/communications/__init__.py
@@ -1,0 +1,16 @@
+"""Communications module exposing API router and GUI panel entry point."""
+
+from .api import router
+
+
+def get_comms_panel(parent=None):
+    """Return the default communications panel widget.
+
+    Parameters
+    ----------
+    parent: QWidget | None
+        Optional parent widget.
+    """
+    from .panels.ChannelsPanel import ChannelsPanel
+
+    return ChannelsPanel(parent)

--- a/modules/communications/api.py
+++ b/modules/communications/api.py
@@ -1,0 +1,22 @@
+"""FastAPI router for communications module."""
+
+from fastapi import APIRouter, HTTPException
+from .models.schemas import ChannelCreate, ChannelRead
+from . import services
+
+router = APIRouter()
+
+
+@router.get("/channels", response_model=list[ChannelRead])
+def list_channels() -> list[ChannelRead]:
+    """Return all channels from the master library."""
+    return services.list_channels()
+
+
+@router.post("/channels", response_model=ChannelRead)
+def create_channel(channel: ChannelCreate) -> ChannelRead:
+    """Insert a new channel into the master library."""
+    try:
+        return services.add_channel(channel)
+    except ValueError as exc:  # pragma: no cover - simple example
+        raise HTTPException(status_code=400, detail=str(exc))

--- a/modules/communications/assignments.py
+++ b/modules/communications/assignments.py
@@ -1,0 +1,23 @@
+"""Helpers for team/role to channel assignments."""
+
+from sqlmodel import Session, select
+
+from .repository import get_mission_engine
+from .models.comms_models import ChannelAssignment
+from .models.schemas import ChannelAssignment as ChannelAssignmentSchema
+
+
+def set_assignment(data: ChannelAssignmentSchema) -> ChannelAssignment:
+    engine = get_mission_engine(data.mission_id)
+    assignment = ChannelAssignment.model_validate(data)
+    with Session(engine) as session:
+        session.add(assignment)
+        session.commit()
+        session.refresh(assignment)
+    return assignment
+
+
+def list_assignments(mission_id: str) -> list[ChannelAssignment]:
+    engine = get_mission_engine(mission_id)
+    with Session(engine) as session:
+        return session.exec(select(ChannelAssignment)).all()

--- a/modules/communications/channel_import.py
+++ b/modules/communications/channel_import.py
@@ -1,0 +1,32 @@
+"""CSV to master library importer."""
+
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from .models.schemas import ChannelCreate
+from . import services
+
+
+def read_csv(path: Path) -> Iterable[ChannelCreate]:
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            yield ChannelCreate(
+                name=row.get("name", ""),
+                rx_freq=float(row.get("rx_freq", 0)),
+                tx_freq=float(row.get("tx_freq", 0)),
+                mode=row.get("mode", "analog"),
+                tone=row.get("tone"),
+                nac=row.get("nac"),
+                band=row.get("band"),
+                call_sign=row.get("call_sign"),
+                usage=row.get("usage"),
+                encrypted=row.get("encrypted", "").lower() == "true",
+            )
+
+
+def import_csv(path: Path) -> int:
+    """Import channels from a CSV file into the master library."""
+    channels = read_csv(path)
+    return services.import_channels(channels)

--- a/modules/communications/exporter.py
+++ b/modules/communications/exporter.py
@@ -1,0 +1,28 @@
+"""ICS-205/205A export helpers."""
+
+import csv
+from pathlib import Path
+from sqlmodel import Session, select
+
+from .repository import get_mission_engine
+from .models.comms_models import ChannelAssignment
+
+
+def export_ics205(mission_id: str, output_dir: Path) -> Path:
+    """Export channel assignments to a CSV file (stub for ICS-205)."""
+    engine = get_mission_engine(mission_id)
+    with Session(engine) as session:
+        assignments = session.exec(select(ChannelAssignment)).all()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"{mission_id}_ICS205.csv"
+    with path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Team", "Channel ID"])
+        for a in assignments:
+            writer.writerow([a.team, a.channel_id])
+    return path
+
+
+def export_ics205a(mission_id: str, output_dir: Path) -> Path:
+    """Stub for ICS-205A export; currently mirrors :func:`export_ics205`."""
+    return export_ics205(mission_id, output_dir)

--- a/modules/communications/models/__init__.py
+++ b/modules/communications/models/__init__.py
@@ -1,0 +1,19 @@
+"""Database and schema models for communications."""
+
+from .schemas import (
+    ChannelCreate,
+    ChannelRead,
+    ChannelAssignment,
+    MessageLogEntry,
+)
+from .comms_models import Channel, ChannelAssignment as ChannelAssignmentTable, MessageLogEntry as MessageLogEntryTable
+
+__all__ = [
+    "ChannelCreate",
+    "ChannelRead",
+    "ChannelAssignment",
+    "MessageLogEntry",
+    "Channel",
+    "ChannelAssignmentTable",
+    "MessageLogEntryTable",
+]

--- a/modules/communications/models/comms_models.py
+++ b/modules/communications/models/comms_models.py
@@ -1,0 +1,36 @@
+"""SQLModel table definitions for communications."""
+
+from datetime import datetime
+from typing import Optional
+from sqlmodel import SQLModel, Field
+
+
+class Channel(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    rx_freq: float
+    tx_freq: float
+    mode: str  # analog or digital
+    tone: str | None = None
+    nac: str | None = None
+    band: str | None = None
+    call_sign: str | None = None
+    usage: str | None = None
+    encrypted: bool = False
+
+
+class ChannelAssignment(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    mission_id: str
+    team: str
+    channel_id: int
+
+
+class MessageLogEntry(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    mission_id: str
+    timestamp: datetime
+    sender: str
+    recipient: str
+    method: str
+    message: str

--- a/modules/communications/models/schemas.py
+++ b/modules/communications/models/schemas.py
@@ -1,0 +1,46 @@
+"""Pydantic models for communications API."""
+
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict
+
+
+class ChannelBase(BaseModel):
+    name: str
+    rx_freq: float
+    tx_freq: float
+    mode: str
+    tone: str | None = None
+    nac: str | None = None
+    band: str | None = None
+    call_sign: str | None = None
+    usage: str | None = None
+    encrypted: bool = False
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ChannelCreate(ChannelBase):
+    pass
+
+
+class ChannelRead(ChannelBase):
+    id: int
+
+
+class ChannelAssignment(BaseModel):
+    mission_id: str
+    team: str
+    channel_id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MessageLogEntry(BaseModel):
+    mission_id: str
+    timestamp: datetime
+    sender: str
+    recipient: str
+    method: str
+    message: str
+
+    model_config = ConfigDict(from_attributes=True)

--- a/modules/communications/panels/AssignmentsPanel.py
+++ b/modules/communications/panels/AssignmentsPanel.py
@@ -1,0 +1,10 @@
+"""Panel for mission channel assignments."""
+
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class AssignmentsPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Assignments Panel"))

--- a/modules/communications/panels/ChannelsPanel.py
+++ b/modules/communications/panels/ChannelsPanel.py
@@ -1,0 +1,10 @@
+"""Panel for managing the master channel library."""
+
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class ChannelsPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Channels Panel"))

--- a/modules/communications/panels/InteropMatrix.py
+++ b/modules/communications/panels/InteropMatrix.py
@@ -1,0 +1,10 @@
+"""Panel showing interoperability matrix across bands."""
+
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class InteropMatrix(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Interop Matrix"))

--- a/modules/communications/panels/MessageLogPanel.py
+++ b/modules/communications/panels/MessageLogPanel.py
@@ -1,0 +1,10 @@
+"""Panel for simple message logging."""
+
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class MessageLogPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Message Log"))

--- a/modules/communications/panels/RadioPlanBuilder.py
+++ b/modules/communications/panels/RadioPlanBuilder.py
@@ -1,0 +1,10 @@
+"""Panel for editing operational period radio plans."""
+
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class RadioPlanBuilder(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Radio Plan Builder"))

--- a/modules/communications/panels/__init__.py
+++ b/modules/communications/panels/__init__.py
@@ -1,0 +1,15 @@
+"""GUI panels for the communications module."""
+
+from .ChannelsPanel import ChannelsPanel
+from .AssignmentsPanel import AssignmentsPanel
+from .RadioPlanBuilder import RadioPlanBuilder
+from .InteropMatrix import InteropMatrix
+from .MessageLogPanel import MessageLogPanel
+
+__all__ = [
+    "ChannelsPanel",
+    "AssignmentsPanel",
+    "RadioPlanBuilder",
+    "InteropMatrix",
+    "MessageLogPanel",
+]

--- a/modules/communications/qml/AssignmentsPanel.qml
+++ b/modules/communications/qml/AssignmentsPanel.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 400; height: 300
+    Text { text: "Assignments Panel"; anchors.centerIn: parent }
+}

--- a/modules/communications/qml/ChannelsPanel.qml
+++ b/modules/communications/qml/ChannelsPanel.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 400; height: 300
+    Text { text: "Channels Panel"; anchors.centerIn: parent }
+}

--- a/modules/communications/qml/InteropMatrix.qml
+++ b/modules/communications/qml/InteropMatrix.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 400; height: 300
+    Text { text: "Interop Matrix"; anchors.centerIn: parent }
+}

--- a/modules/communications/qml/MessageLogPanel.qml
+++ b/modules/communications/qml/MessageLogPanel.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 400; height: 300
+    Text { text: "Message Log"; anchors.centerIn: parent }
+}

--- a/modules/communications/qml/RadioPlanBuilder.qml
+++ b/modules/communications/qml/RadioPlanBuilder.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 400; height: 300
+    Text { text: "Radio Plan Builder"; anchors.centerIn: parent }
+}

--- a/modules/communications/qml/__init__.py
+++ b/modules/communications/qml/__init__.py
@@ -1,0 +1,1 @@
+"""QML resources for communications module."""

--- a/modules/communications/repository.py
+++ b/modules/communications/repository.py
@@ -1,0 +1,28 @@
+"""Database helpers for communications module."""
+
+from pathlib import Path
+from sqlmodel import SQLModel, create_engine
+
+DATA_DIR = Path("data")
+MASTER_DB = DATA_DIR / "master.db"
+MISSIONS_DIR = DATA_DIR / "missions"
+
+
+def get_engine(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return create_engine(f"sqlite:///{path}")
+
+
+def get_master_engine():
+    """Return engine for the master communications library."""
+    engine = get_engine(MASTER_DB)
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def get_mission_engine(mission_id: str):
+    """Return engine for a mission-specific database."""
+    path = MISSIONS_DIR / f"{mission_id}.db"
+    engine = get_engine(path)
+    SQLModel.metadata.create_all(engine)
+    return engine

--- a/modules/communications/services.py
+++ b/modules/communications/services.py
@@ -1,0 +1,37 @@
+"""Business logic for communications module."""
+
+from typing import Iterable
+from sqlmodel import Session, select
+
+from .repository import get_master_engine
+from .models.schemas import ChannelCreate, ChannelRead
+from .models.comms_models import Channel
+
+
+def list_channels() -> list[ChannelRead]:
+    engine = get_master_engine()
+    with Session(engine) as session:
+        channels = session.exec(select(Channel)).all()
+        return [ChannelRead.model_validate(channel) for channel in channels]
+
+
+def add_channel(data: ChannelCreate) -> ChannelRead:
+    engine = get_master_engine()
+    channel = Channel.model_validate(data)
+    with Session(engine) as session:
+        session.add(channel)
+        session.commit()
+        session.refresh(channel)
+    return ChannelRead.model_validate(channel)
+
+
+def import_channels(channels: Iterable[ChannelCreate]) -> int:
+    """Bulk-import channels into the master library."""
+    engine = get_master_engine()
+    count = 0
+    with Session(engine) as session:
+        for ch in channels:
+            session.add(Channel.model_validate(ch))
+            count += 1
+        session.commit()
+    return count

--- a/modules/communications/tone_squelch.py
+++ b/modules/communications/tone_squelch.py
@@ -1,0 +1,33 @@
+"""Helpers for tone and squelch parsing."""
+
+import re
+from typing import Optional
+
+
+def parse_ctcss(value: Optional[str]) -> Optional[float]:
+    """Parse a CTCSS tone value to float Hz."""
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def parse_nac(value: Optional[str]) -> Optional[str]:
+    """Parse a P25 Network Access Code (NAC)."""
+    if not value:
+        return None
+    value = value.strip().lstrip("0x").upper()
+    if re.fullmatch(r"[0-9A-F]{3}", value):
+        return value
+    return None
+
+
+def parse_tone(value: Optional[str]) -> Optional[str]:
+    """Attempt to parse tone as CTCSS or NAC."""
+    nac = parse_nac(value)
+    if nac:
+        return nac
+    ctcss = parse_ctcss(value)
+    return f"{ctcss:.1f}" if ctcss is not None else None


### PR DESCRIPTION
## Summary
- scaffold communications module with API router, services, repository, and database models
- add CSV importer, assignment helpers, exports, and tone parsing utilities
- provide panel widgets and QML stubs for channels, assignments, radio plan builder, interop matrix, and message log

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a58a6596f0832b970dc984800c68ff