### PR TITLE
Add placeholder panel factories for SAR toolkits

### DIFF
--- a/modules/disasterresponse/__init__.py
+++ b/modules/disasterresponse/__init__.py
@@ -1,0 +1,13 @@
+from . import windows as disaster
+from .windows import (
+    get_damage_panel,
+    get_urban_interview_panel,
+    get_photos_panel,
+)
+
+__all__ = [
+    "disaster",
+    "get_damage_panel",
+    "get_urban_interview_panel",
+    "get_photos_panel",
+]

--- a/modules/disasterresponse/windows.py
+++ b/modules/disasterresponse/windows.py
@@ -1,0 +1,28 @@
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel
+
+__all__ = [
+    "get_damage_panel",
+    "get_urban_interview_panel",
+    "get_photos_panel",
+]
+
+def _make_panel(title: str, body: str) -> QWidget:
+    w = QWidget()
+    layout = QVBoxLayout(w)
+    t = QLabel(title)
+    t.setStyleSheet("font-size: 18px; font-weight: 600;")
+    layout.addWidget(t)
+    layout.addWidget(QLabel(body))
+    return w
+
+def get_damage_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Damage Assessment."""
+    return _make_panel("Damage Assessment", f"Damage assessment — mission: {mission_id}")
+
+def get_urban_interview_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Urban Interview Log."""
+    return _make_panel("Urban Interview Log", f"Urban interviews — mission: {mission_id}")
+
+def get_photos_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Damage Photos."""
+    return _make_panel("Damage Photos", f"Photos — mission: {mission_id}")

--- a/modules/initalresponse/__init__.py
+++ b/modules/initalresponse/__init__.py
@@ -1,0 +1,4 @@
+from modules.initialresponse import windows as initial
+from modules.initialresponse import get_hasty_panel, get_reflex_panel
+
+__all__ = ["initial", "get_hasty_panel", "get_reflex_panel"]

--- a/modules/initialresponse/__init__.py
+++ b/modules/initialresponse/__init__.py
@@ -1,0 +1,4 @@
+from . import windows as initial
+from .windows import get_hasty_panel, get_reflex_panel
+
+__all__ = ["initial", "get_hasty_panel", "get_reflex_panel"]

--- a/modules/initialresponse/windows.py
+++ b/modules/initialresponse/windows.py
@@ -1,0 +1,20 @@
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel
+
+__all__ = ["get_hasty_panel", "get_reflex_panel"]
+
+def _make_panel(title: str, body: str) -> QWidget:
+    w = QWidget()
+    layout = QVBoxLayout(w)
+    t = QLabel(title)
+    t.setStyleSheet("font-size: 18px; font-weight: 600;")
+    layout.addWidget(t)
+    layout.addWidget(QLabel(body))
+    return w
+
+def get_hasty_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Hasty Tools."""
+    return _make_panel("Hasty Tools", f"Hasty tools — mission: {mission_id}")
+
+def get_reflex_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Reflex Taskings."""
+    return _make_panel("Reflex Taskings", f"Reflex taskings — mission: {mission_id}")

--- a/modules/plannedtoolkit/__init__.py
+++ b/modules/plannedtoolkit/__init__.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
 from .api import router
-from .panels.PlannedToolkitHome import PlannedToolkitHome
+from .windows import (
+    get_promotions_panel,
+    get_vendors_panel,
+    get_safety_panel,
+    get_tasking_panel,
+    get_health_sanitation_panel,
+    get_planned_toolkit_panel,
+)
 
-
-def get_planned_toolkit_panel():
-    """Return the main panel instance for the Planned Event Toolkit."""
-    return PlannedToolkitHome()
-
-__all__ = ["router", "get_planned_toolkit_panel"]
+__all__ = [
+    "router",
+    "get_promotions_panel",
+    "get_vendors_panel",
+    "get_safety_panel",
+    "get_tasking_panel",
+    "get_health_sanitation_panel",
+    "get_planned_toolkit_panel",
+]

--- a/modules/plannedtoolkit/windows.py
+++ b/modules/plannedtoolkit/windows.py
@@ -1,0 +1,43 @@
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel
+
+__all__ = [
+    "get_promotions_panel",
+    "get_vendors_panel",
+    "get_safety_panel",
+    "get_tasking_panel",
+    "get_health_sanitation_panel",
+    "get_planned_toolkit_panel",
+]
+
+def _make_panel(title: str, body: str) -> QWidget:
+    w = QWidget()
+    layout = QVBoxLayout(w)
+    t = QLabel(title)
+    t.setStyleSheet("font-size: 18px; font-weight: 600;")
+    layout.addWidget(t)
+    layout.addWidget(QLabel(body))
+    return w
+
+def get_promotions_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for External Messaging."""
+    return _make_panel("External Messaging", f"Promotions — mission: {mission_id}")
+
+def get_vendors_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Vendors & Permits."""
+    return _make_panel("Vendors & Permits", f"Vendors — mission: {mission_id}")
+
+def get_safety_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Public Safety."""
+    return _make_panel("Public Safety", f"Safety — mission: {mission_id}")
+
+def get_tasking_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Tasking & Assignments."""
+    return _make_panel("Tasking & Assignments", f"Tasking — mission: {mission_id}")
+
+def get_health_sanitation_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Health & Sanitation."""
+    return _make_panel("Health & Sanitation", f"Health & sanitation — mission: {mission_id}")
+
+def get_planned_toolkit_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Planned Event Toolkit."""
+    return _make_panel("Planned Event Toolkit", f"Toolkit — mission: {mission_id}")

--- a/modules/sartoolkit/__init__.py
+++ b/modules/sartoolkit/__init__.py
@@ -1,0 +1,4 @@
+from . import windows as sar
+from .windows import get_missing_person_panel, get_pod_panel
+
+__all__ = ["sar", "get_missing_person_panel", "get_pod_panel"]

--- a/modules/sartoolkit/windows.py
+++ b/modules/sartoolkit/windows.py
@@ -1,0 +1,20 @@
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel
+
+__all__ = ["get_missing_person_panel", "get_pod_panel"]
+
+def _make_panel(title: str, body: str) -> QWidget:
+    w = QWidget()
+    layout = QVBoxLayout(w)
+    t = QLabel(title)
+    t.setStyleSheet("font-size: 18px; font-weight: 600;")
+    layout.addWidget(t)
+    layout.addWidget(QLabel(body))
+    return w
+
+def get_missing_person_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for Missing Person Toolkit."""
+    return _make_panel("Missing Person Toolkit", f"Toolkit — mission: {mission_id}")
+
+def get_pod_panel(mission_id=None) -> QWidget:
+    """Return placeholder QWidget for POD Calculator."""
+    return _make_panel("POD Calculator", f"POD — mission: {mission_id}")


### PR DESCRIPTION
## Summary
- add simple QWidget factories for SAR toolkit modules
- wire up disaster response, initial response, and planned event toolkits with placeholder panels
- expose factories via package `__init__` files and keep compatibility aliases

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after ~3m)*
- `pytest tests/logistics/test_service.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ac2d34b258832bb04b2f9a1f4b9b38