### PR TITLE
Use mission selector for mission menu actions

### DIFF
--- a/main.py
+++ b/main.py
@@ -383,22 +383,16 @@ class MainWindow(QMainWindow):
 # ===== Part 4: Handlers in Menu Order (panel-factory pattern) ============
 # --- 4.1 Menu ------------------------------------------------------------
     def open_menu_new_mission(self) -> None:
-        from modules import missions
-        mission_id = getattr(self, "current_mission_id", None)
-        panel = missions.get_new_mission_panel(mission_id)
-        self._open_modeless(panel, title="New Mission")
+        from ui_bootstrap.mission_select_bootstrap import show_mission_selector
+        show_mission_selector()
 
     def open_menu_open_mission(self) -> None:
-        from modules import missions
-        mission_id = getattr(self, "current_mission_id", None)
-        panel = missions.get_mission_list_panel(mission_id)
-        self._open_modeless(panel, title="Incident Selection")
+        from ui_bootstrap.mission_select_bootstrap import show_mission_selector
+        show_mission_selector()
 
     def open_menu_save_mission(self) -> None:
-        from modules import missions
-        mission_id = getattr(self, "current_mission_id", None)
-        panel = missions.get_save_mission_panel(mission_id)
-        self._open_modeless(panel, title="Save Mission")
+        from ui_bootstrap.mission_select_bootstrap import show_mission_selector
+        show_mission_selector()
 
     def open_menu_settings(self) -> None:
         from modules import settingsui


### PR DESCRIPTION
## Summary
- Replace mission panel imports with new mission selector bootstrap
- Call `show_mission_selector` when user opens New/Open/Save Mission

## Testing
- `pytest -q` *(failed: KeyboardInterrupt after hanging)*

------
https://chatgpt.com/codex/tasks/task_b_68ad5d8559d4832bacd367a6c2973e29