### PR TITLE
Implement check-in module with dual SQLite databases

### DIFF
--- a/modules/logistics/checkin/README.md
+++ b/modules/logistics/checkin/README.md
@@ -1,0 +1,32 @@
+# Check-In Module
+
+This module provides a minimal offline-first check-in workflow for
+SARApp / ICS Command Assistant.  It follows the design document's
+structure with a clean separation between models, repository, service
+API, and a QML based user interface.
+
+## Usage
+
+* Persistent data is stored in `data/master.db`.
+* Each mission/incident has its own database under `data/missions/<id>.db`.
+* Activate a mission via `utils.mission_context.set_active_mission("MISSION_ID")`.
+* Interact with the repository or API modules to lookup or check-in
+  personnel and assets.  The `checkin_bridge` exposes these services to
+  QML.
+
+## Tests
+
+Run the unit tests with:
+
+```bash
+pytest tests/test_checkin_repository.py tests/test_checkin_api.py
+```
+
+The tests create temporary databases and therefore do not interfere
+with existing data files.
+
+## Notes
+
+The database schemas are placeholders and will be expanded in future
+iterations.  Additional validation and error handling should be added
+as the application evolves.

--- a/modules/logistics/checkin/__init__.py
+++ b/modules/logistics/checkin/__init__.py
@@ -1,0 +1,7 @@
+"""Check-In module for SARApp / ICS Command Assistant.
+
+This package implements a minimal offline-first check-in workflow
+supporting personnel and assets.  The code is deliberately small but
+heavily commented so it can serve as a starting point for future
+expansion.
+"""

--- a/modules/logistics/checkin/api.py
+++ b/modules/logistics/checkin/api.py
@@ -1,0 +1,107 @@
+"""High level services orchestrating repository operations."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from . import repository
+
+# Mapping helpers allowing generic functions
+FIND_BY_ID = {
+    "personnel": repository.find_personnel_by_id,
+    "equipment": repository.find_equipment_by_id,
+    "vehicle": repository.find_vehicle_by_id,
+    "aircraft": repository.find_aircraft_by_id,
+}
+
+FIND_BY_NAME = {
+    "personnel": repository.find_personnel_by_name,
+    "equipment": repository.find_equipment_by_name,
+    "vehicle": repository.find_vehicle_by_name,
+    "aircraft": repository.find_aircraft_by_tail,
+}
+
+COPY_TO_MISSION = {
+    "personnel": repository.copy_personnel_to_mission,
+    "equipment": repository.copy_equipment_to_mission,
+    "vehicle": repository.copy_vehicle_to_mission,
+    "aircraft": repository.copy_aircraft_to_mission,
+}
+
+CREATE_MASTER = {
+    "personnel": repository.create_or_update_personnel_master,
+    "equipment": repository.create_or_update_equipment_master,
+    "vehicle": repository.create_or_update_vehicle_master,
+    "aircraft": repository.create_or_update_aircraft_master,
+}
+
+
+def lookup_entity(entity_type: str, mode: str, **kwargs) -> List[Dict]:
+    """Lookup entities for display in the UI."""
+    if mode == "id":
+        result = FIND_BY_ID[entity_type](kwargs.get("value"))
+        return [result] if result else []
+    else:
+        if entity_type == "aircraft":
+            return FIND_BY_NAME[entity_type](kwargs.get("value"))
+        if entity_type == "personnel":
+            return FIND_BY_NAME[entity_type](kwargs.get("first"), kwargs.get("last"))
+        return FIND_BY_NAME[entity_type](kwargs.get("value"))
+
+
+def check_in_entity(entity_type: str, lookup_key: Dict, payload: Dict | None = None) -> Dict:
+    """Perform a check-in operation based on the lookup key.
+
+    Parameters
+    ----------
+    entity_type:
+        One of ``personnel``, ``equipment``, ``vehicle`` or ``aircraft``.
+    lookup_key:
+        Dict describing how to lookup the entity.  For example
+        ``{"mode": "id", "value": "P-123"}`` or
+        ``{"mode": "name", "first": "A", "last": "B"}``.
+    payload:
+        Optional payload used when the record needs to be created.
+    """
+    mode = lookup_key.get("mode")
+    params = {k: v for k, v in lookup_key.items() if k != "mode"}
+    candidates = lookup_entity(entity_type, mode, **params)
+    if candidates:
+        # Found in master -> copy to mission
+        entity = candidates[0]
+        COPY_TO_MISSION[entity_type](entity)
+        return {
+            "success": True,
+            "message": "Checked in",
+            "entity": entity,
+            "was_created": False,
+            "was_copied": True,
+        }
+    else:
+        return {"success": False, "requiresCreate": True, "message": "Not found"}
+
+
+def create_master_plus_mission(entity_type: str, payload: Dict) -> Dict:
+    """Create a new master record and copy it to the mission DB."""
+    CREATE_MASTER[entity_type](payload)
+    COPY_TO_MISSION[entity_type](payload)
+    return {
+        "success": True,
+        "message": "Created and checked in",
+        "entity": payload,
+        "was_created": True,
+        "was_copied": True,
+    }
+
+
+def update_mission_status(entity_type: str, entity_id: str, status: str) -> None:
+    """Update the status for a mission record."""
+    sql_map = {
+        "personnel": "UPDATE personnel_mission SET status = ? WHERE id = ?",
+        "equipment": "UPDATE equipment_mission SET status = ? WHERE id = ?",
+        "vehicle": "UPDATE vehicle_mission SET status = ? WHERE id = ?",
+        "aircraft": "UPDATE aircraft_mission SET status = ? WHERE id = ?",
+    }
+    from utils.db import get_mission_conn
+    with get_mission_conn() as conn:
+        conn.execute(sql_map[entity_type], (status, entity_id))
+        conn.commit()

--- a/modules/logistics/checkin/checkin_bridge.py
+++ b/modules/logistics/checkin/checkin_bridge.py
@@ -1,0 +1,47 @@
+"""Qt bridge exposing the check-in API to QML."""
+from __future__ import annotations
+
+from PySide6.QtCore import QObject, Signal, Slot, QByteArray
+
+from . import api
+
+
+class CheckInBridge(QObject):
+    """QObject bridge used by QML to interact with the Python backend."""
+
+    lookupResults = Signal(list)
+    checkInResult = Signal(dict)
+    toast = Signal(str)
+
+    @Slot(str, str, str)
+    def lookup(self, entityType: str, mode: str, value: str) -> None:
+        try:
+            if mode == "id":
+                results = api.lookup_entity(entityType, mode, value=value)
+            elif entityType == "personnel" and mode == "name":
+                first, last = value.split(" ", 1)
+                results = api.lookup_entity(entityType, mode, first=first, last=last)
+            else:
+                results = api.lookup_entity(entityType, mode, value=value)
+            self.lookupResults.emit(results)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.toast.emit(str(exc))
+
+    @Slot(str, str)
+    def checkInById(self, entityType: str, idValue: str) -> None:
+        try:
+            result = api.check_in_entity(entityType, {"mode": "id", "value": idValue})
+            self.checkInResult.emit(result)
+            if result.get("success"):
+                self.toast.emit("Checked In")
+        except Exception as exc:  # pragma: no cover
+            self.toast.emit(str(exc))
+
+    @Slot(str, dict)
+    def createNew(self, entityType: str, payload: dict) -> None:
+        try:
+            result = api.create_master_plus_mission(entityType, payload)
+            self.checkInResult.emit(result)
+            self.toast.emit("Created")
+        except Exception as exc:  # pragma: no cover
+            self.toast.emit(str(exc))

--- a/modules/logistics/checkin/models.py
+++ b/modules/logistics/checkin/models.py
@@ -1,0 +1,49 @@
+"""Light weight data models used by the check-in module.
+
+The models intentionally mirror the placeholder database schemas and
+contain only a subset of fields.  Each model is a dataclass to keep the
+code concise while still being explicit about the attributes present.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Personnel:
+    id: str
+    first_name: str
+    last_name: str
+    callsign: Optional[str] = None
+    role: Optional[str] = None
+    status: Optional[str] = None
+
+
+@dataclass
+class Equipment:
+    id: str
+    name: str
+    type: Optional[str] = None
+    status: Optional[str] = None
+    assigned_to: Optional[str] = None
+
+
+@dataclass
+class Vehicle:
+    id: str
+    name: str
+    type: Optional[str] = None
+    status: Optional[str] = None
+    callsign: Optional[str] = None
+    assigned_to: Optional[str] = None
+
+
+@dataclass
+class Aircraft:
+    id: str
+    tail_number: str
+    type: Optional[str] = None
+    status: Optional[str] = None
+    callsign: Optional[str] = None
+    assigned_to: Optional[str] = None

--- a/modules/logistics/checkin/panels/CheckInPanel.py
+++ b/modules/logistics/checkin/panels/CheckInPanel.py
@@ -1,0 +1,21 @@
+"""Optional widget wrapper to host the QML check-in window."""
+from __future__ import annotations
+
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+from PySide6.QtQuickWidgets import QQuickWidget
+from PySide6.QtQml import QQmlEngine
+
+from ..checkin_bridge import CheckInBridge
+
+
+class CheckInPanel(QWidget):
+    """Simple QWidget that loads the QML CheckInWindow."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.bridge = CheckInBridge()
+        self.view = QQuickWidget()
+        self.view.engine().rootContext().setContextProperty("checkInBridge", self.bridge)
+        self.view.setSource("modules/logistics/checkin/qml/CheckInWindow.qml")
+        layout.addWidget(self.view)

--- a/modules/logistics/checkin/qml/CheckInWindow.qml
+++ b/modules/logistics/checkin/qml/CheckInWindow.qml
@@ -1,0 +1,29 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+// Main window with tabs for each entity type
+Item {
+    width: 600
+    height: 400
+
+    TabView {
+        anchors.fill: parent
+        Tab { title: "Personnel"; Loader { source: "components/LookupPanel.qml"; property string entityType: "personnel" } }
+        Tab { title: "Equipment"; Loader { source: "components/LookupPanel.qml"; property string entityType: "equipment" } }
+        Tab { title: "Vehicles"; Loader { source: "components/LookupPanel.qml"; property string entityType: "vehicle" } }
+        Tab { title: "Aircraft"; Loader { source: "components/LookupPanel.qml"; property string entityType: "aircraft" } }
+    }
+
+    // Toast message overlay
+    Loader {
+        id: toastLoader
+        source: "components/Toast.qml"
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+    }
+
+    Connections {
+        target: checkInBridge
+        function onToast(msg) { toastLoader.item.show(msg) }
+    }
+}

--- a/modules/logistics/checkin/qml/components/CheckInForm.qml
+++ b/modules/logistics/checkin/qml/components/CheckInForm.qml
@@ -1,0 +1,32 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+// Minimal form used when creating a new record
+Item {
+    id: root
+    property string entityType: "personnel"
+    property var payload: ({})
+    signal submit(string entityType, var payload)
+
+    Column {
+        spacing: 4
+        TextField { id: idField; placeholderText: "ID" }
+        TextField { id: nameField; placeholderText: entityType === "aircraft" ? "Tail / Name" : "Name" }
+        Button {
+            text: "Create"
+            onClicked: {
+                payload = {id: idField.text}
+                if (entityType === "personnel") {
+                    var parts = nameField.text.split(" ")
+                    payload.first_name = parts[0]
+                    payload.last_name = parts[1] || ""
+                } else if (entityType === "aircraft") {
+                    payload.tail_number = nameField.text
+                } else {
+                    payload.name = nameField.text
+                }
+                submit(entityType, payload)
+            }
+        }
+    }
+}

--- a/modules/logistics/checkin/qml/components/ConfirmCreateDialog.qml
+++ b/modules/logistics/checkin/qml/components/ConfirmCreateDialog.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+// Dialog asking user to confirm creation of new master record
+Dialog {
+    id: dlg
+    property string entityType
+    property var payload
+    title: "Create New"
+    modal: true
+
+    Column {
+        spacing: 8
+        Text { text: "Record not found. Create new master record?" }
+        Row {
+            spacing: 8
+            Button { text: "Create"; onClicked: { checkInBridge.createNew(entityType, payload); dlg.close() } }
+            Button { text: "Cancel"; onClicked: dlg.close() }
+        }
+    }
+}

--- a/modules/logistics/checkin/qml/components/LookupPanel.qml
+++ b/modules/logistics/checkin/qml/components/LookupPanel.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+// Simple lookup panel allowing search by ID or name
+Item {
+    property string entityType: "personnel"
+    signal search(string entityType, string mode, string value)
+
+    Column {
+        spacing: 4
+        Row {
+            RadioButton { id: byId; text: "ID"; checked: true }
+            RadioButton { id: byName; text: "Name" }
+        }
+        TextField { id: input; placeholderText: byId.checked ? "ID" : "Name" }
+        Button {
+            text: "Search"
+            onClicked: {
+                search(entityType, byId.checked ? "id" : "name", input.text)
+                checkInBridge.lookup(entityType, byId.checked ? "id" : "name", input.text)
+            }
+        }
+    }
+}

--- a/modules/logistics/checkin/qml/components/Toast.qml
+++ b/modules/logistics/checkin/qml/components/Toast.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    id: root
+    width: textItem.width + 20
+    height: textItem.height + 20
+    color: "#333"
+    radius: 4
+    opacity: 0
+
+    Text { id: textItem; color: "white"; anchors.centerIn: parent }
+
+    function show(message) {
+        textItem.text = message
+        root.opacity = 1
+        SequentialAnimation {
+            NumberAnimation { target: root; property: "opacity"; to: 0; duration: 3000; easing.type: Easing.InOutQuad }
+        }.start()
+    }
+}

--- a/modules/logistics/checkin/repository.py
+++ b/modules/logistics/checkin/repository.py
@@ -1,0 +1,332 @@
+"""Database access layer for the check-in module.
+
+This module exposes simple functions that interact with both the
+persistent master database and the currently active mission database.
+Functions are intentionally straightforward and heavily commented so
+that they can be expanded in future iterations without major refactors.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+import sqlite3
+
+from utils.db import get_master_conn, get_mission_conn
+from utils import mission_context
+from utils.schema_placeholders import ensure_master_tables_exist, ensure_mission_tables_exist
+
+# ---------------------------------------------------------------------------
+# Lookup helpers
+# ---------------------------------------------------------------------------
+
+def _row_to_dict(row: sqlite3.Row) -> Optional[Dict]:
+    """Convert a Row to a plain dict."""
+    return dict(row) if row else None
+
+
+def find_personnel_by_id(pid: str) -> Optional[Dict]:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        cur = conn.execute("SELECT * FROM personnel_master WHERE id = ?", (pid,))
+        return _row_to_dict(cur.fetchone())
+
+
+def find_personnel_by_name(first: str, last: str) -> List[Dict]:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        cur = conn.execute(
+            "SELECT * FROM personnel_master WHERE first_name = ? AND last_name = ?",
+            (first, last),
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def find_equipment_by_id(eid: str) -> Optional[Dict]:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        cur = conn.execute("SELECT * FROM equipment_master WHERE id = ?", (eid,))
+        return _row_to_dict(cur.fetchone())
+
+
+def find_equipment_by_name(name: str) -> List[Dict]:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        cur = conn.execute("SELECT * FROM equipment_master WHERE name = ?", (name,))
+        return [dict(row) for row in cur.fetchall()]
+
+
+def find_vehicle_by_id(vid: str) -> Optional[Dict]:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        cur = conn.execute("SELECT * FROM vehicle_master WHERE id = ?", (vid,))
+        return _row_to_dict(cur.fetchone())
+
+
+def find_vehicle_by_name(name: str) -> List[Dict]:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        cur = conn.execute("SELECT * FROM vehicle_master WHERE name = ?", (name,))
+        return [dict(row) for row in cur.fetchall()]
+
+
+def find_aircraft_by_id(aid: str) -> Optional[Dict]:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        cur = conn.execute("SELECT * FROM aircraft_master WHERE id = ?", (aid,))
+        return _row_to_dict(cur.fetchone())
+
+
+def find_aircraft_by_tail(tail_number: str) -> List[Dict]:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        cur = conn.execute("SELECT * FROM aircraft_master WHERE tail_number = ?", (tail_number,))
+        return [dict(row) for row in cur.fetchall()]
+
+# ---------------------------------------------------------------------------
+# Master creation helpers
+# ---------------------------------------------------------------------------
+
+def _timestamp() -> str:
+    return datetime.utcnow().isoformat()
+
+
+def create_or_update_personnel_master(data: Dict) -> None:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        payload = data.copy()
+        payload.setdefault("callsign", None)
+        payload.setdefault("role", None)
+        payload.setdefault("status", "Available")
+        payload.setdefault("created_at", _timestamp())
+        payload["updated_at"] = _timestamp()
+        conn.execute(
+            """
+            INSERT INTO personnel_master (id, first_name, last_name, callsign, role, status, created_at, updated_at)
+            VALUES (:id, :first_name, :last_name, :callsign, :role, :status, :created_at, :updated_at)
+            ON CONFLICT(id) DO UPDATE SET
+                first_name=excluded.first_name,
+                last_name=excluded.last_name,
+                callsign=excluded.callsign,
+                role=excluded.role,
+                status=excluded.status,
+                updated_at=excluded.updated_at
+            """,
+            payload,
+        )
+        conn.commit()
+
+
+def create_or_update_equipment_master(data: Dict) -> None:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        payload = data.copy()
+        payload.setdefault("type", None)
+        payload.setdefault("assigned_to", None)
+        payload.setdefault("status", "Available")
+        payload.setdefault("created_at", _timestamp())
+        payload["updated_at"] = _timestamp()
+        conn.execute(
+            """
+            INSERT INTO equipment_master (id, name, type, status, assigned_to, created_at, updated_at)
+            VALUES (:id, :name, :type, :status, :assigned_to, :created_at, :updated_at)
+            ON CONFLICT(id) DO UPDATE SET
+                name=excluded.name,
+                type=excluded.type,
+                status=excluded.status,
+                assigned_to=excluded.assigned_to,
+                updated_at=excluded.updated_at
+            """,
+            payload,
+        )
+        conn.commit()
+
+
+def create_or_update_vehicle_master(data: Dict) -> None:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        payload = data.copy()
+        payload.setdefault("type", None)
+        payload.setdefault("callsign", None)
+        payload.setdefault("assigned_to", None)
+        payload.setdefault("status", "Available")
+        payload.setdefault("created_at", _timestamp())
+        payload["updated_at"] = _timestamp()
+        conn.execute(
+            """
+            INSERT INTO vehicle_master (id, name, type, status, callsign, assigned_to, created_at, updated_at)
+            VALUES (:id, :name, :type, :status, :callsign, :assigned_to, :created_at, :updated_at)
+            ON CONFLICT(id) DO UPDATE SET
+                name=excluded.name,
+                type=excluded.type,
+                status=excluded.status,
+                callsign=excluded.callsign,
+                assigned_to=excluded.assigned_to,
+                updated_at=excluded.updated_at
+            """,
+            payload,
+        )
+        conn.commit()
+
+
+def create_or_update_aircraft_master(data: Dict) -> None:
+    with get_master_conn() as conn:
+        ensure_master_tables_exist(conn)
+        payload = data.copy()
+        payload.setdefault("tail_number", data.get("tail_number"))
+        payload.setdefault("type", None)
+        payload.setdefault("callsign", None)
+        payload.setdefault("assigned_to", None)
+        payload.setdefault("status", "Available")
+        payload.setdefault("created_at", _timestamp())
+        payload["updated_at"] = _timestamp()
+        conn.execute(
+            """
+            INSERT INTO aircraft_master (id, tail_number, type, status, callsign, assigned_to, created_at, updated_at)
+            VALUES (:id, :tail_number, :type, :status, :callsign, :assigned_to, :created_at, :updated_at)
+            ON CONFLICT(id) DO UPDATE SET
+                tail_number=excluded.tail_number,
+                type=excluded.type,
+                status=excluded.status,
+                callsign=excluded.callsign,
+                assigned_to=excluded.assigned_to,
+                updated_at=excluded.updated_at
+            """,
+            payload,
+        )
+        conn.commit()
+
+# ---------------------------------------------------------------------------
+# Mission copy helpers
+# ---------------------------------------------------------------------------
+
+def _mission_insert(sql: str, payload: Dict) -> None:
+    with get_mission_conn() as conn:
+        ensure_mission_tables_exist(conn)
+        conn.execute(sql, payload)
+        conn.commit()
+
+
+def copy_personnel_to_mission(personnel: Dict) -> None:
+    mission_id = mission_context.get_active_mission_id()
+    payload = personnel.copy()
+    payload.update(
+        {
+            "mission_id": mission_id,
+            "status": "Checked-In",
+            "checked_in_at": _timestamp(),
+            "updated_at": _timestamp(),
+        }
+    )
+    payload.setdefault("callsign", None)
+    payload.setdefault("role", None)
+    _mission_insert(
+        """
+        INSERT INTO personnel_mission (id, mission_id, first_name, last_name, callsign, role, status, checked_in_at, updated_at)
+        VALUES (:id, :mission_id, :first_name, :last_name, :callsign, :role, :status, :checked_in_at, :updated_at)
+        ON CONFLICT(id) DO UPDATE SET
+            mission_id=excluded.mission_id,
+            first_name=excluded.first_name,
+            last_name=excluded.last_name,
+            callsign=excluded.callsign,
+            role=excluded.role,
+            status=excluded.status,
+            checked_in_at=excluded.checked_in_at,
+            updated_at=excluded.updated_at
+        """,
+        payload,
+    )
+
+
+def copy_equipment_to_mission(equipment: Dict) -> None:
+    mission_id = mission_context.get_active_mission_id()
+    payload = equipment.copy()
+    payload.update(
+        {
+            "mission_id": mission_id,
+            "status": "Checked-In",
+            "checked_in_at": _timestamp(),
+            "updated_at": _timestamp(),
+        }
+    )
+    payload.setdefault("type", None)
+    payload.setdefault("assigned_to", None)
+    _mission_insert(
+        """
+        INSERT INTO equipment_mission (id, mission_id, name, type, status, assigned_to, checked_in_at, updated_at)
+        VALUES (:id, :mission_id, :name, :type, :status, :assigned_to, :checked_in_at, :updated_at)
+        ON CONFLICT(id) DO UPDATE SET
+            mission_id=excluded.mission_id,
+            name=excluded.name,
+            type=excluded.type,
+            status=excluded.status,
+            assigned_to=excluded.assigned_to,
+            checked_in_at=excluded.checked_in_at,
+            updated_at=excluded.updated_at
+        """,
+        payload,
+    )
+
+
+def copy_vehicle_to_mission(vehicle: Dict) -> None:
+    mission_id = mission_context.get_active_mission_id()
+    payload = vehicle.copy()
+    payload.update(
+        {
+            "mission_id": mission_id,
+            "status": "Checked-In",
+            "checked_in_at": _timestamp(),
+            "updated_at": _timestamp(),
+        }
+    )
+    payload.setdefault("type", None)
+    payload.setdefault("callsign", None)
+    payload.setdefault("assigned_to", None)
+    _mission_insert(
+        """
+        INSERT INTO vehicle_mission (id, mission_id, name, type, status, callsign, assigned_to, checked_in_at, updated_at)
+        VALUES (:id, :mission_id, :name, :type, :status, :callsign, :assigned_to, :checked_in_at, :updated_at)
+        ON CONFLICT(id) DO UPDATE SET
+            mission_id=excluded.mission_id,
+            name=excluded.name,
+            type=excluded.type,
+            status=excluded.status,
+            callsign=excluded.callsign,
+            assigned_to=excluded.assigned_to,
+            checked_in_at=excluded.checked_in_at,
+            updated_at=excluded.updated_at
+        """,
+        payload,
+    )
+
+
+def copy_aircraft_to_mission(aircraft: Dict) -> None:
+    mission_id = mission_context.get_active_mission_id()
+    payload = aircraft.copy()
+    payload.update(
+        {
+            "mission_id": mission_id,
+            "status": "Checked-In",
+            "checked_in_at": _timestamp(),
+            "updated_at": _timestamp(),
+        }
+    )
+    payload.setdefault("tail_number", aircraft.get("tail_number"))
+    payload.setdefault("type", None)
+    payload.setdefault("callsign", None)
+    payload.setdefault("assigned_to", None)
+    _mission_insert(
+        """
+        INSERT INTO aircraft_mission (id, mission_id, tail_number, type, status, callsign, assigned_to, checked_in_at, updated_at)
+        VALUES (:id, :mission_id, :tail_number, :type, :status, :callsign, :assigned_to, :checked_in_at, :updated_at)
+        ON CONFLICT(id) DO UPDATE SET
+            mission_id=excluded.mission_id,
+            tail_number=excluded.tail_number,
+            type=excluded.type,
+            status=excluded.status,
+            callsign=excluded.callsign,
+            assigned_to=excluded.assigned_to,
+            checked_in_at=excluded.checked_in_at,
+            updated_at=excluded.updated_at
+        """,
+        payload,
+    )

--- a/modules/logistics/checkin/validators.py
+++ b/modules/logistics/checkin/validators.py
@@ -1,0 +1,35 @@
+"""Input validation helpers for the check-in module."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+REQUIRED_PERSONNEL_FIELDS = ["id", "first_name", "last_name"]
+REQUIRED_EQUIPMENT_FIELDS = ["id", "name"]
+REQUIRED_VEHICLE_FIELDS = ["id", "name"]
+REQUIRED_AIRCRAFT_FIELDS = ["id", "tail_number"]
+
+
+def _validate(payload: Dict[str, str], required: List[str]) -> List[str]:
+    """Return a list of error messages for missing required fields."""
+    errors = []
+    for field in required:
+        if not payload.get(field):
+            errors.append(f"{field} is required")
+    return errors
+
+
+def validate_personnel(payload: Dict[str, str]) -> List[str]:
+    return _validate(payload, REQUIRED_PERSONNEL_FIELDS)
+
+
+def validate_equipment(payload: Dict[str, str]) -> List[str]:
+    return _validate(payload, REQUIRED_EQUIPMENT_FIELDS)
+
+
+def validate_vehicle(payload: Dict[str, str]) -> List[str]:
+    return _validate(payload, REQUIRED_VEHICLE_FIELDS)
+
+
+def validate_aircraft(payload: Dict[str, str]) -> List[str]:
+    return _validate(payload, REQUIRED_AIRCRAFT_FIELDS)

--- a/tests/test_checkin_api.py
+++ b/tests/test_checkin_api.py
@@ -1,0 +1,76 @@
+import importlib
+import os
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+
+def setup_api(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHECKIN_DATA_DIR", str(tmp_path))
+    import utils.mission_context as mc
+    import utils.db as db
+    importlib.reload(mc)
+    importlib.reload(db)
+
+    modules_pkg = types.ModuleType("modules")
+    modules_pkg.__path__ = []
+    logistics_pkg = types.ModuleType("modules.logistics")
+    logistics_pkg.__path__ = []
+    checkin_pkg = types.ModuleType("modules.logistics.checkin")
+    checkin_pkg.__path__ = [str(ROOT / "modules/logistics/checkin")]
+    sys.modules["modules"] = modules_pkg
+    sys.modules["modules.logistics"] = logistics_pkg
+    sys.modules["modules.logistics.checkin"] = checkin_pkg
+
+    spec_repo = importlib.util.spec_from_file_location(
+        "modules.logistics.checkin.repository",
+        ROOT / "modules/logistics/checkin/repository.py",
+    )
+    repo = importlib.util.module_from_spec(spec_repo)
+    sys.modules[spec_repo.name] = repo
+    spec_repo.loader.exec_module(repo)
+
+    spec_api = importlib.util.spec_from_file_location(
+        "modules.logistics.checkin.api",
+        ROOT / "modules/logistics/checkin/api.py",
+    )
+    api = importlib.util.module_from_spec(spec_api)
+    sys.modules[spec_api.name] = api
+    spec_api.loader.exec_module(api)
+
+    mc.set_active_mission("m1")
+    return api, repo, mc
+
+
+def test_check_in_flow(tmp_path, monkeypatch):
+    api, repo, mc = setup_api(tmp_path, monkeypatch)
+    master_payload = {"id": "P2", "first_name": "Bob", "last_name": "Jones"}
+    repo.create_or_update_personnel_master(master_payload)
+
+    # Existing record should copy to mission
+    result = api.check_in_entity("personnel", {"mode": "id", "value": "P2"})
+    assert result["success"] and result["was_copied"]
+
+    mission_db = tmp_path / "missions" / "m1.db"
+    with sqlite3.connect(mission_db) as conn:
+        assert conn.execute("SELECT count(*) FROM personnel_mission WHERE id='P2'").fetchone()[0] == 1
+
+    # Non existing should request creation
+    result = api.check_in_entity("personnel", {"mode": "id", "value": "P3"})
+    assert result.get("requiresCreate")
+
+    # Create new record and ensure it exists in both DBs
+    payload = {"id": "P3", "first_name": "Eve", "last_name": "Doe"}
+    res2 = api.create_master_plus_mission("personnel", payload)
+    assert res2["success"] and res2["was_created"]
+    with sqlite3.connect(mission_db) as conn:
+        assert conn.execute("SELECT count(*) FROM personnel_mission WHERE id='P3'").fetchone()[0] == 1
+    master_db = tmp_path / "master.db"
+    with sqlite3.connect(master_db) as conn:
+        assert conn.execute("SELECT count(*) FROM personnel_master WHERE id='P3'").fetchone()[0] == 1

--- a/tests/test_checkin_repository.py
+++ b/tests/test_checkin_repository.py
@@ -1,0 +1,65 @@
+import importlib
+import os
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+
+def setup_repo(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHECKIN_DATA_DIR", str(tmp_path))
+    import utils.mission_context as mc
+    import utils.db as db
+    importlib.reload(mc)
+    importlib.reload(db)
+
+    # Create lightweight package hierarchy to avoid heavy imports
+    modules_pkg = types.ModuleType("modules")
+    modules_pkg.__path__ = []
+    logistics_pkg = types.ModuleType("modules.logistics")
+    logistics_pkg.__path__ = []
+    checkin_pkg = types.ModuleType("modules.logistics.checkin")
+    checkin_pkg.__path__ = [str(ROOT / "modules/logistics/checkin")]
+    sys.modules["modules"] = modules_pkg
+    sys.modules["modules.logistics"] = logistics_pkg
+    sys.modules["modules.logistics.checkin"] = checkin_pkg
+
+    spec = importlib.util.spec_from_file_location(
+        "modules.logistics.checkin.repository",
+        ROOT / "modules/logistics/checkin/repository.py",
+    )
+    repo = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = repo
+    spec.loader.exec_module(repo)
+
+    mc.set_active_mission("test_mission")
+    return repo, mc
+
+
+def test_tables_created_and_copy(tmp_path, monkeypatch):
+    repo, mc = setup_repo(tmp_path, monkeypatch)
+
+    payload = {
+        "id": "P1",
+        "first_name": "Alice",
+        "last_name": "Smith",
+    }
+    repo.create_or_update_personnel_master(payload)
+    repo.copy_personnel_to_mission(payload)
+
+    master_db = tmp_path / "master.db"
+    mission_db = tmp_path / "missions" / "test_mission.db"
+
+    assert master_db.exists()
+    assert mission_db.exists()
+
+    with sqlite3.connect(master_db) as conn:
+        assert conn.execute("SELECT count(*) FROM personnel_master").fetchone()[0] == 1
+    with sqlite3.connect(mission_db) as conn:
+        row = conn.execute("SELECT status FROM personnel_mission WHERE id = 'P1'").fetchone()
+        assert row[0] == "Checked-In"

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,38 @@
+"""Light weight SQLite connection helpers.
+
+These functions centralise the logic for creating connections to the
+application's databases.  Tests can override the base directory by
+setting the ``CHECKIN_DATA_DIR`` environment variable before importing
+this module.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+from . import mission_context
+
+# Base directory for data storage.  Defaults to ``data`` in the
+# repository root but can be overridden for tests by the environment
+# variable above.
+_DATA_DIR = Path(os.environ.get("CHECKIN_DATA_DIR", "data"))
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    """Create a SQLite connection with row factory configured."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def get_master_conn() -> sqlite3.Connection:
+    """Return a connection to the persistent master database."""
+    return _connect(_DATA_DIR / "master.db")
+
+
+def get_mission_conn() -> sqlite3.Connection:
+    """Return a connection to the active mission database."""
+    mission_path = mission_context.get_active_mission_db_path()
+    return _connect(mission_path)

--- a/utils/mission_context.py
+++ b/utils/mission_context.py
@@ -1,0 +1,52 @@
+"""Mission context utilities.
+
+This module stores the identifier for the currently active
+mission/incident and exposes helpers to derive the path for the
+mission specific database.  The module intentionally keeps state in
+module level globals so it can be easily mocked in tests or adjusted by
+higher level application code.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import os
+
+# Optional environment variable allowing tests to redirect where data
+# files are stored.  Defaults to the repository's ``data`` directory.
+_DATA_DIR = Path(os.environ.get("CHECKIN_DATA_DIR", "data"))
+
+_active_mission_id: str | None = None
+
+
+def set_active_mission(mission_id: str) -> None:
+    """Set the identifier for the active mission.
+
+    Parameters
+    ----------
+    mission_id:
+        Identifier for the mission.  This is typically a short string
+        or UUID.  No validation is performed here as this module is a
+        thin context holder.
+    """
+    global _active_mission_id
+    _active_mission_id = mission_id
+
+
+def get_active_mission_id() -> str | None:
+    """Return the currently configured mission identifier or ``None``."""
+    return _active_mission_id
+
+
+def get_active_mission_db_path() -> Path:
+    """Return the path for the active mission database.
+
+    The path is rooted under ``data/missions`` (or an overridden data
+    directory when running tests).  If the mission has not been set a
+    ``RuntimeError`` is raised.
+    """
+    if not _active_mission_id:
+        raise RuntimeError("Active mission has not been set")
+
+    base = _DATA_DIR / "missions"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{_active_mission_id}.db"

--- a/utils/schema_placeholders.py
+++ b/utils/schema_placeholders.py
@@ -1,0 +1,132 @@
+"""Placeholder database schema creation functions.
+
+The real application will eventually contain rich table definitions.
+For this kata we keep the schemas minimal and create them on demand.
+The functions below are idempotent and may be called multiple times.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+# SQL fragments for master tables
+_MASTER_TABLES = {
+    "personnel": """
+        CREATE TABLE IF NOT EXISTS personnel_master (
+            id TEXT PRIMARY KEY,
+            first_name TEXT,
+            last_name TEXT,
+            callsign TEXT,
+            role TEXT,
+            status TEXT,
+            created_at TEXT,
+            updated_at TEXT
+        )
+    """,
+    "equipment": """
+        CREATE TABLE IF NOT EXISTS equipment_master (
+            id TEXT PRIMARY KEY,
+            name TEXT,
+            type TEXT,
+            status TEXT,
+            assigned_to TEXT,
+            created_at TEXT,
+            updated_at TEXT
+        )
+    """,
+    "vehicle": """
+        CREATE TABLE IF NOT EXISTS vehicle_master (
+            id TEXT PRIMARY KEY,
+            name TEXT,
+            type TEXT,
+            status TEXT,
+            callsign TEXT,
+            assigned_to TEXT,
+            created_at TEXT,
+            updated_at TEXT
+        )
+    """,
+    "aircraft": """
+        CREATE TABLE IF NOT EXISTS aircraft_master (
+            id TEXT PRIMARY KEY,
+            tail_number TEXT,
+            type TEXT,
+            status TEXT,
+            callsign TEXT,
+            assigned_to TEXT,
+            created_at TEXT,
+            updated_at TEXT
+        )
+    """,
+}
+
+# SQL fragments for mission tables
+_MISSION_TABLES = {
+    "personnel": """
+        CREATE TABLE IF NOT EXISTS personnel_mission (
+            id TEXT PRIMARY KEY,
+            mission_id TEXT,
+            first_name TEXT,
+            last_name TEXT,
+            callsign TEXT,
+            role TEXT,
+            status TEXT,
+            checked_in_at TEXT,
+            updated_at TEXT
+        )
+    """,
+    "equipment": """
+        CREATE TABLE IF NOT EXISTS equipment_mission (
+            id TEXT PRIMARY KEY,
+            mission_id TEXT,
+            name TEXT,
+            type TEXT,
+            status TEXT,
+            assigned_to TEXT,
+            checked_in_at TEXT,
+            updated_at TEXT
+        )
+    """,
+    "vehicle": """
+        CREATE TABLE IF NOT EXISTS vehicle_mission (
+            id TEXT PRIMARY KEY,
+            mission_id TEXT,
+            name TEXT,
+            type TEXT,
+            status TEXT,
+            callsign TEXT,
+            assigned_to TEXT,
+            checked_in_at TEXT,
+            updated_at TEXT
+        )
+    """,
+    "aircraft": """
+        CREATE TABLE IF NOT EXISTS aircraft_mission (
+            id TEXT PRIMARY KEY,
+            mission_id TEXT,
+            tail_number TEXT,
+            type TEXT,
+            status TEXT,
+            callsign TEXT,
+            assigned_to TEXT,
+            checked_in_at TEXT,
+            updated_at TEXT
+        )
+    """,
+}
+
+
+def ensure_master_tables_exist(conn: sqlite3.Connection) -> None:
+    """Create placeholder master tables if they do not exist."""
+    cur = conn.cursor()
+    for ddl in _MASTER_TABLES.values():
+        cur.execute(ddl)
+    conn.commit()
+
+
+def ensure_mission_tables_exist(conn: sqlite3.Connection) -> None:
+    """Create placeholder mission tables if they do not exist."""
+    cur = conn.cursor()
+    for ddl in _MISSION_TABLES.values():
+        cur.execute(ddl)
+    conn.commit()


### PR DESCRIPTION
## Summary
- add logistics check-in module with dataclasses, repository layer, service API, and Qt bridge
- support dual-database strategy (persistent master + mission-specific) with placeholder schemas
- include QML UI skeleton and unit tests for repository and API flows

## Testing
- `pytest tests/test_checkin_repository.py tests/test_checkin_api.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b0afd47e88832bb7e73ef8c0ae6009