### PR TITLE
refactor(ui): use existing sample_data.py for ADS demo docks

### DIFF
--- a/data/sample_data.py
+++ b/data/sample_data.py
@@ -2,6 +2,8 @@
 
 # if __name__ == "__main__":
 #     pass
+from typing import Any
+
 from modules.operations.models.tasks import Task
 from modules.operations.models.teams import Team
 
@@ -17,4 +19,84 @@ sample_teams = [
     Team("A-026", "CAP 2020", "Orme, William", "555-1234", "Wheels Down", "Aerial Photography", "St. Claire Co Shoreline"),
     Team("G-026", "UDF Charlie", "Leannis, Lynn", "555-1234", "Arrival", "ELT Grid Search", "NW Oakland Co"),
     Team("", "GT-Delta", "Weeter, Danielle", "555-1234", "Out of Service")
+]
+
+# Tables -----------------------------------------------------------------
+
+TEAM_HEADERS: list[str] = [
+    "Sortie #",
+    "Team Name",
+    "Team Leader",
+    "Contact #",
+    "Status",
+    "Assignment",
+    "Location",
+]
+
+TEAM_ROWS: list[list[Any]] = [
+    ["", "GT-Alpha", "Pheley, Brendan", "517-554-0085", "Available", "", ""],
+    [
+        "G-023",
+        "GT-Bravo",
+        "Weeter, Danielle",
+        "555-1234",
+        "Enroute",
+        "Ramp Check",
+        "KTEW",
+    ],
+    [
+        "A-026",
+        "CAP 2020",
+        "Orme, William",
+        "555-1234",
+        "Wheels Down",
+        "Aerial Photography",
+        "St. Claire Co Shoreline",
+    ],
+    [
+        "G-026",
+        "UDF Charlie",
+        "Leannis, Lynn",
+        "555-1234",
+        "Arrival",
+        "ELT Grid Search",
+        "NW Oakland Co",
+    ],
+    ["", "GT-Delta", "Weeter, Danielle", "555-1234", "Out of Service", "", ""],
+]
+
+TASK_HEADERS: list[str] = [
+    "Task #",
+    "Task Name",
+    "Status",
+    "Priority",
+    "Assigned Team(s)",
+    "Location",
+]
+
+TASK_ROWS: list[list[Any]] = [
+    [
+        "T-001",
+        "Ramp Check",
+        "In Progress",
+        "High",
+        "GT-Bravo",
+        "KTEW",
+    ],
+    [
+        "T-002",
+        "ELT Grid Search",
+        "Planned",
+        "Urgent",
+        "",
+        "NW Oakland Co",
+    ],
+    [
+        "T-003",
+        "Aerial Photography",
+        "Complete",
+        "Normal",
+        "CAP 2020",
+        "St. Claire Shoreline",
+    ],
 ]

--- a/ui/docks.py
+++ b/ui/docks.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget
+from PySide6QtAds import CDockWidget
+
+from data.sample_data import (
+    TEAM_HEADERS,
+    TEAM_ROWS,
+    TASK_HEADERS,
+    TASK_ROWS,
+)
+
+
+def _make_table(headers: Iterable[str], rows: Iterable[Iterable[object]]) -> QTableWidget:
+    table = QTableWidget()
+    headers = list(headers)
+    table.setColumnCount(len(headers))
+    table.setHorizontalHeaderLabels(headers)
+    for r, row in enumerate(rows):
+        table.insertRow(r)
+        for c, value in enumerate(row):
+            item = QTableWidgetItem(str(value))
+            table.setItem(r, c, item)
+    return table
+
+
+def create_team_status_dock(parent=None):
+    w = QWidget(parent)
+    layout = QVBoxLayout(w)
+    table = _make_table(TEAM_HEADERS, TEAM_ROWS)
+    layout.addWidget(table)
+    dock = CDockWidget("Team Status")
+    dock.setWidget(w)
+    return dock
+
+
+def create_task_status_dock(parent=None):
+    w = QWidget(parent)
+    layout = QVBoxLayout(w)
+    table = _make_table(TASK_HEADERS, TASK_ROWS)
+    layout.addWidget(table)
+    dock = CDockWidget("Task Status")
+    dock.setWidget(w)
+    return dock
+


### PR DESCRIPTION
## Summary
- wire ADS demo docks to use shared sample_data constants
- add TEAM/TASK table definitions in sample_data

## Testing
- `QT_QPA_PLATFORM=offscreen timeout 5s python main.py`

------
https://chatgpt.com/codex/tasks/task_b_68b3b5bea7d0832b970b1ce9f0b87920