### PR TITLE
Track team comms via radio log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Incident Management Assistant
+
+This project provides tooling and user interface components for incident management workflows.
+
+## Team Communication Timers
+
+Radio traffic can be logged using the communications module. When a radio log entry references a known team in the `sender` or `recipient` fields, that team's `last_comm_ping` timestamp is updated. This timer allows operators to track when each team last made contact over the radio.
+
+The helper `log_radio_entry` in `modules/communications/radio_log.py` persists a message and performs the timer update automatically.

--- a/modules/communications/radio_log.py
+++ b/modules/communications/radio_log.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime
+import re
+from typing import Iterable
+
+from sqlmodel import Session
+
+from .models.comms_models import MessageLogEntry
+from .repository import get_incident_engine
+from modules.operations.teams.data import repository as team_repo
+
+
+def _reset_comm_timers(text: str) -> None:
+    """Reset communication timers for any teams matching ``text``."""
+    if not text:
+        return
+    # Split on common delimiters but preserve full tokens for lookup
+    parts = [p.strip() for p in re.split(r"[,/]", str(text)) if p.strip()]
+    if not parts:
+        parts = [str(text).strip()]
+    for label in parts:
+        for team_id in team_repo.find_team_ids_by_label(label):
+            team_repo.reset_team_comm_timer(team_id)
+
+
+def log_radio_entry(
+    incident_id: str,
+    sender: str,
+    recipient: str,
+    message: str,
+    method: str = "radio",
+) -> MessageLogEntry:
+    """Persist a radio log entry and update team communication timers.
+
+    Parameters
+    ----------
+    incident_id: str
+        Identifier for the mission-scoped database.
+    sender: str
+        Free-text sender label.
+    recipient: str
+        Free-text recipient label.
+    message: str
+        Body of the radio message.
+    method: str
+        Communication method; defaults to ``"radio"``.
+    """
+    engine = get_incident_engine(str(incident_id))
+    entry = MessageLogEntry(
+        incident_id=str(incident_id),
+        timestamp=datetime.utcnow(),
+        sender=str(sender),
+        recipient=str(recipient),
+        method=str(method),
+        message=str(message),
+    )
+    with Session(engine) as session:
+        session.add(entry)
+        session.commit()
+        session.refresh(entry)
+
+    # Update timers for any teams mentioned
+    _reset_comm_timers(sender)
+    _reset_comm_timers(recipient)
+
+    try:
+        from . import notify_message_logged
+
+        notify_message_logged(sender, recipient)
+    except Exception:
+        pass
+
+    return entry

--- a/modules/operations/teams/data/team.py
+++ b/modules/operations/teams/data/team.py
@@ -25,6 +25,7 @@ class Team:
     phone: Optional[str] = None
     notes: Optional[str] = None
     last_update_ts: datetime = field(default_factory=datetime.utcnow)
+    last_comm_ts: Optional[datetime] = None
     last_known_lat: Optional[float] = None
     last_known_lon: Optional[float] = None
     members: List[int] = field(default_factory=list)
@@ -56,6 +57,7 @@ class Team:
             "phone": self.phone,
             "notes": self.notes,
             "status_updated": (self.last_update_ts or datetime.utcnow()).isoformat(),
+            "last_comm_ping": (self.last_comm_ts.isoformat() if self.last_comm_ts else None),
             "last_known_lat": self.last_known_lat,
             "last_known_lon": self.last_known_lon,
             "members_json": json.dumps(list(self.members or [])),
@@ -104,6 +106,12 @@ class Team:
         except Exception:
             last_ts = datetime.utcnow()
 
+        comm_ts = _get("last_comm_ping")
+        try:
+            comm_dt = datetime.fromisoformat(comm_ts) if comm_ts else None
+        except Exception:
+            comm_dt = None
+
         return Team(
             team_id=int(_get("id")) if _get("id") is not None else None,
             name=str(_get("name") or ""),
@@ -116,6 +124,7 @@ class Team:
             phone=_get("phone"),
             notes=_get("notes"),
             last_update_ts=last_ts,
+            last_comm_ts=comm_dt,
             last_known_lat=(float(_get("last_known_lat")) if _get("last_known_lat") is not None else None),
             last_known_lon=(float(_get("last_known_lon")) if _get("last_known_lon") is not None else None),
             members=_parse_json(_get("members_json")),
@@ -142,6 +151,7 @@ class Team:
             "phone": self.phone,
             "notes": self.notes,
             "last_update_ts": (self.last_update_ts or datetime.utcnow()).isoformat(),
+            "last_comm_ts": (self.last_comm_ts.isoformat() if self.last_comm_ts else None),
             "last_known_lat": self.last_known_lat,
             "last_known_lon": self.last_known_lon,
             "members": list(self.members or []),

--- a/tests/test_radio_log.py
+++ b/tests/test_radio_log.py
@@ -1,0 +1,114 @@
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+
+@pytest.fixture
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHECKIN_DATA_DIR", str(tmp_path))
+    import utils.incident_context as ic
+    importlib.reload(ic)
+    ic.set_active_incident("test_incident")
+
+    # Lightweight package scaffolding to avoid heavy Qt imports
+    modules_pkg = types.ModuleType("modules")
+    modules_pkg.__path__ = []
+    operations_pkg = types.ModuleType("modules.operations")
+    operations_pkg.__path__ = []
+    operations_data_pkg = types.ModuleType("modules.operations.data")
+    operations_data_pkg.__path__ = [str(ROOT / "modules/operations/data")]
+    operations_teams_pkg = types.ModuleType("modules.operations.teams")
+    operations_teams_pkg.__path__ = [str(ROOT / "modules/operations/teams")]
+    operations_teams_data_pkg = types.ModuleType("modules.operations.teams.data")
+    operations_teams_data_pkg.__path__ = [str(ROOT / "modules/operations/teams/data")]
+    communications_pkg = types.ModuleType("modules.communications")
+    communications_pkg.__path__ = [str(ROOT / "modules/communications")]
+    communications_models_pkg = types.ModuleType("modules.communications.models")
+    communications_models_pkg.__path__ = [str(ROOT / "modules/communications/models")]
+    sys.modules.update(
+        {
+            "modules": modules_pkg,
+            "modules.operations": operations_pkg,
+            "modules.operations.data": operations_data_pkg,
+            "modules.operations.teams": operations_teams_pkg,
+            "modules.operations.teams.data": operations_teams_data_pkg,
+            "modules.communications": communications_pkg,
+            "modules.communications.models": communications_models_pkg,
+        }
+    )
+
+    # Load required modules via file specs
+    spec = importlib.util.spec_from_file_location(
+        "modules.operations.data.repository",
+        ROOT / "modules/operations/data/repository.py",
+    )
+    ops_repo = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = ops_repo
+    spec.loader.exec_module(ops_repo)
+    with ops_repo._connect() as con:
+        con.execute("CREATE TABLE IF NOT EXISTS teams (id INTEGER PRIMARY KEY)")
+        con.commit()
+
+    spec = importlib.util.spec_from_file_location(
+        "modules.operations.teams.data.team",
+        ROOT / "modules/operations/teams/data/team.py",
+    )
+    team_model = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = team_model
+    spec.loader.exec_module(team_model)
+
+    spec = importlib.util.spec_from_file_location(
+        "modules.operations.teams.data.repository",
+        ROOT / "modules/operations/teams/data/repository.py",
+    )
+    team_repo = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = team_repo
+    spec.loader.exec_module(team_repo)
+
+    spec = importlib.util.spec_from_file_location(
+        "modules.communications.repository",
+        ROOT / "modules/communications/repository.py",
+    )
+    comm_repo = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = comm_repo
+    spec.loader.exec_module(comm_repo)
+    comm_repo.DATA_DIR = tmp_path
+
+    spec = importlib.util.spec_from_file_location(
+        "modules.communications.models.comms_models",
+        ROOT / "modules/communications/models/comms_models.py",
+    )
+    comm_models = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = comm_models
+    spec.loader.exec_module(comm_models)
+
+    spec = importlib.util.spec_from_file_location(
+        "modules.communications.radio_log",
+        ROOT / "modules/communications/radio_log.py",
+    )
+    radio_log = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = radio_log
+    spec.loader.exec_module(radio_log)
+
+    return ic, team_repo, radio_log
+
+
+def test_radio_log_resets_timer(setup_env):
+    ic, team_repo, radio_log = setup_env
+    from modules.operations.teams.data.team import Team
+
+    team = Team(name="Alpha")
+    team_repo.save_team(team)
+    assert team_repo.get_team(team.team_id).last_comm_ts is None
+
+    radio_log.log_radio_entry("test_incident", sender="Alpha", recipient="Ops", message="hi")
+
+    updated = team_repo.get_team(team.team_id)
+    assert updated.last_comm_ts is not None


### PR DESCRIPTION
## Summary
- add last_comm_ping tracking to team data model
- reset team communication timers when radio messages mention them
- document radio log timer reset behavior and add tests

## Testing
- `pytest tests/test_radio_log.py -q`
- `pytest -q` *(fails: Missing dependencies such as httpx, sqlalchemy, PySide6)*

------
https://chatgpt.com/codex/tasks/task_b_68b65ca09698832ba0a7df84ba4ff60c