### PR TITLE
feat: add organization assignment models

### DIFF
--- a/modules/_infra/__init__.py
+++ b/modules/_infra/__init__.py
@@ -1,1 +1,5 @@
 """Shared infrastructure utilities."""
+
+from .base import Base
+
+__all__ = ["Base"]

--- a/modules/_infra/base.py
+++ b/modules/_infra/base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/modules/_infra/repository.py
+++ b/modules/_infra/repository.py
@@ -7,7 +7,10 @@ from typing import Dict, Any
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from modules.ics214.models import Base  # type: ignore
+from modules._infra.base import Base
+# Import model modules so tables are registered on Base metadata
+import modules.ics214.models  # noqa: F401
+import modules.org.models  # noqa: F401
 
 _engine_cache: Dict[str, Any] = {}
 

--- a/modules/ics214/models.py
+++ b/modules/ics214/models.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-from sqlalchemy.orm import declarative_base, relationship, Mapped, mapped_column
+from sqlalchemy.orm import relationship, Mapped, mapped_column
 from sqlalchemy import DateTime, String, Integer, Boolean, ForeignKey, JSON, Index, UniqueConstraint
 
-Base = declarative_base()
+from modules._infra.base import Base
 
 class ICS214Stream(Base):
     __tablename__ = "ics214_streams"

--- a/modules/org/models.py
+++ b/modules/org/models.py
@@ -1,0 +1,100 @@
+"""SQLAlchemy models for incident organization structures and assignments."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    String,
+    Integer,
+    ForeignKey,
+    JSON,
+    CheckConstraint,
+    Index,
+    text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from modules._infra.base import Base
+
+
+class OrgStructure(Base):
+    __tablename__ = "org_structures"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    parent_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("org_structures.id", ondelete="CASCADE"), nullable=True
+    )
+    incident_id: Mapped[str] = mapped_column(String, index=True)
+    op_id: Mapped[int] = mapped_column(Integer, index=True)
+    node_type: Mapped[str] = mapped_column(String)
+    role_code: Mapped[str | None] = mapped_column(String, nullable=True)
+    title: Mapped[str] = mapped_column(String)
+    order_index: Mapped[int] = mapped_column(Integer, default=0)
+    flags_json: Mapped[dict | None] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    parent = relationship("OrgStructure", remote_side=[id], backref="children")
+
+
+class OrgAssignment(Base):
+    __tablename__ = "org_assignments"
+    __table_args__ = (
+        CheckConstraint(
+            "assignment_role IN ('primary','deputy','assistant','trainee')",
+            name="chk_assignment_role",
+        ),
+        Index(
+            "ux_primary_per_node_per_op",
+            "incident_id",
+            "op_id",
+            "node_id",
+            unique=True,
+            sqlite_where=text("assignment_role = 'primary'"),
+        ),
+        Index(
+            "ux_deputy_per_node_per_op",
+            "incident_id",
+            "op_id",
+            "node_id",
+            unique=True,
+            sqlite_where=text("assignment_role = 'deputy'"),
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    incident_id: Mapped[str] = mapped_column(String, index=True)
+    op_id: Mapped[int] = mapped_column(Integer, index=True)
+    node_id: Mapped[int] = mapped_column(ForeignKey("org_structures.id", ondelete="CASCADE"), index=True)
+    person_id: Mapped[str] = mapped_column(String)
+    assignment_role: Mapped[str] = mapped_column(String, default="primary")
+    start_ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    end_ts: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    notes: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    node = relationship("OrgStructure", backref="assignments")
+
+
+class OrgVersion(Base):
+    __tablename__ = "org_versions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    incident_id: Mapped[str] = mapped_column(String, index=True)
+    op_id: Mapped[int] = mapped_column(Integer, index=True)
+    label: Mapped[str] = mapped_column(String)
+    snapshot_json: Mapped[dict] = mapped_column(JSON)
+    created_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class OrgAudit(Base):
+    __tablename__ = "org_audit"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    incident_id: Mapped[str] = mapped_column(String, index=True)
+    op_id: Mapped[int] = mapped_column(Integer, index=True)
+    user_id: Mapped[str] = mapped_column(String)
+    action: Mapped[str] = mapped_column(String)
+    details_json: Mapped[dict | None] = mapped_column(JSON, default=dict)
+    at_ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ fastapi
 pydantic
 reportlab
 PySide6-QtAds
+httpx
+sqlalchemy


### PR DESCRIPTION
## Summary
- add shared SQLAlchemy Base and organization models with role variants
- register models in repository and expose Base for reuse
- include httpx and sqlalchemy in requirements

## Testing
- `python -m py_compile modules/_infra/base.py modules/_infra/repository.py modules/ics214/models.py modules/org/models.py`
- `QT_QPA_PLATFORM=offscreen pytest modules/ics214/tests/test_models.py -q`
- `QT_QPA_PLATFORM=offscreen pytest modules/ics214/tests/test_services.py -q`
- `QT_QPA_PLATFORM=offscreen pytest modules/ics214/tests/test_api.py -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68b65d9b17f0832b8dd576833ccaaf6b