### PR TITLE
Add ICS-214 panel loader

### DIFF
--- a/modules/ics214/__init__.py
+++ b/modules/ics214/__init__.py
@@ -1,1 +1,5 @@
 """ICS-214 Activity Log module."""
+
+from .windows import get_ics214_panel
+
+__all__ = ["get_ics214_panel"]

--- a/modules/ics214/windows.py
+++ b/modules/ics214/windows.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+__all__ = ["get_ics214_panel"]
+
+
+def get_ics214_panel(incident_id: object | None = None):
+    """Return QWidget hosting the ICS-214 Activity Log QML panel."""
+    from models.qmlwindow import QmlWindow
+
+    qml_path = Path(__file__).resolve().parent / "qml" / "Ics214Home.qml"
+    return QmlWindow(str(qml_path), "ICS-214 Activity Log")


### PR DESCRIPTION
## Summary
- expose ICS-214 panel loader function
- provide QML-based placeholder widget for ICS-214 Activity Log

## Testing
- `pytest -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68b661dcee84832b94ae5c72b54f57c4