### PR TITLE
Expand team header details

### DIFF
--- a/modules/operations/teams/data/repository.py
+++ b/modules/operations/teams/data/repository.py
@@ -28,6 +28,8 @@ def _ensure_team_columns(con: sqlite3.Connection) -> None:
         to_add.append(("priority", "INTEGER"))
     if "team_leader" not in cols:
         to_add.append(("team_leader", "INTEGER"))
+    if "leader_phone" not in cols:
+        to_add.append(("leader_phone", "TEXT"))
     if "phone" not in cols:
         to_add.append(("phone", "TEXT"))
     if "notes" not in cols:
@@ -38,6 +40,10 @@ def _ensure_team_columns(con: sqlite3.Connection) -> None:
         to_add.append(("status_updated", "TEXT"))
     if "current_task_id" not in cols:
         to_add.append(("current_task_id", "INTEGER"))
+    if "primary_task" not in cols:
+        to_add.append(("primary_task", "TEXT"))
+    if "assignment" not in cols:
+        to_add.append(("assignment", "TEXT"))
     # Geo / movement
     if "last_known_lat" not in cols:
         to_add.append(("last_known_lat", "REAL"))

--- a/modules/operations/teams/data/team.py
+++ b/modules/operations/teams/data/team.py
@@ -21,7 +21,10 @@ class Team:
     status: str = "available"
     priority: Optional[int] = None
     current_task_id: Optional[int] = None
+    primary_task: Optional[str] = None
+    assignment: Optional[str] = None
     team_leader_id: Optional[int] = None  # FK to personnel.id
+    team_leader_phone: Optional[str] = None
     phone: Optional[str] = None
     notes: Optional[str] = None
     last_update_ts: datetime = field(default_factory=datetime.utcnow)
@@ -52,7 +55,10 @@ class Team:
             "status": (self.status or "").strip().lower() if self.status else None,
             "priority": self.priority,
             "current_task_id": self.current_task_id,
+            "primary_task": self.primary_task,
+            "assignment": self.assignment,
             "team_leader": self.team_leader_id,
+            "leader_phone": self.team_leader_phone,
             "phone": self.phone,
             "notes": self.notes,
             "status_updated": (self.last_update_ts or datetime.utcnow()).isoformat(),
@@ -112,7 +118,10 @@ class Team:
             status=status_norm,
             priority=(int(_get("priority")) if _get("priority") is not None else None),
             current_task_id=(int(_get("current_task_id")) if _get("current_task_id") is not None else None),
+            primary_task=_get("primary_task"),
+            assignment=_get("assignment"),
             team_leader_id=(int(_get("team_leader")) if _get("team_leader") is not None else None),
+            team_leader_phone=_get("leader_phone"),
             phone=_get("phone"),
             notes=_get("notes"),
             last_update_ts=last_ts,
@@ -138,7 +147,10 @@ class Team:
             "status": self.status,
             "priority": self.priority,
             "current_task_id": self.current_task_id,
+            "primary_task": self.primary_task,
+            "assignment": self.assignment,
             "team_leader_id": self.team_leader_id,
+            "team_leader_phone": self.team_leader_phone,
             "phone": self.phone,
             "notes": self.notes,
             "last_update_ts": (self.last_update_ts or datetime.utcnow()).isoformat(),

--- a/modules/operations/teams/panels/team_detail_window.py
+++ b/modules/operations/teams/panels/team_detail_window.py
@@ -211,6 +211,10 @@ class TeamDetailBridge(QObject):
             self._team.role = data.get("role") or None
             self._team.priority = int(data.get("priority")) if data.get("priority") not in (None, "") else None
             self._team.team_leader_id = int(data.get("team_leader_id")) if data.get("team_leader_id") not in (None, "") else None
+            self._team.team_type = data.get("team_type", self._team.team_type)
+            self._team.primary_task = data.get("primary_task") or None
+            self._team.assignment = data.get("assignment") or None
+            self._team.team_leader_phone = data.get("team_leader_phone") or None
             self._team.phone = data.get("phone") or None
             self._team.notes = data.get("notes") or None
             lat = data.get("last_known_lat")

--- a/modules/operations/teams/qml/TeamDetailWindow.qml
+++ b/modules/operations/teams/qml/TeamDetailWindow.qml
@@ -45,6 +45,27 @@ Window {
                         onTextChanged: if (teamBridge) teamBridge.updateFromQml({ name: text })
                     }
                 }
+                // Team Type dropdown
+                ColumnLayout {
+                    spacing: 4
+                    Text { text: "Team Type"; font.pixelSize: 12 }
+                    ComboBox {
+                        id: cbTeamType
+                        model: ["New Team", "Ground", "Aircraft"]
+                        onActivated: {
+                            var key = (index === 1) ? "ground" : (index === 2 ? "aircraft" : "")
+                            if (teamBridge) teamBridge.updateFromQml({ team_type: key })
+                        }
+                        Component.onCompleted: {
+                            if (teamBridge && teamBridge.team) {
+                                var tt = (teamBridge.team.team_type || "").toLowerCase()
+                                if (tt === "ground") currentIndex = 1
+                                else if (tt === "aircraft") currentIndex = 2
+                                else currentIndex = 0
+                            }
+                        }
+                    }
+                }
                 // Leader chip (readonly button placeholder)
                 ColumnLayout {
                     spacing: 4
@@ -52,6 +73,17 @@ Window {
                     Button {
                         text: (teamBridge && teamBridge.team && teamBridge.team.team_leader_id) ? `#${teamBridge.team.team_leader_id}` : "Not Set"
                         onClicked: tabs.currentIndex = 0 // focus personnel tab
+                    }
+                }
+                // Leader Phone input
+                ColumnLayout {
+                    spacing: 4
+                    Text { text: "Leader Phone"; font.pixelSize: 12 }
+                    TextField {
+                        id: tfLeaderPhone
+                        Layout.preferredWidth: 120
+                        text: (teamBridge && teamBridge.team) ? (teamBridge.team.team_leader_phone || "") : ""
+                        onTextChanged: if (teamBridge) teamBridge.updateFromQml({ team_leader_phone: text })
                     }
                 }
                 // Status pill + dropdown
@@ -87,6 +119,36 @@ Window {
                                 }
                             }
                         }
+                    }
+                }
+                // Last Contact timestamp
+                ColumnLayout {
+                    spacing: 4
+                    Text { text: "Last Contact"; font.pixelSize: 12 }
+                    Text { text: (teamBridge && teamBridge.team) ? (teamBridge.team.last_update_ts || "") : "" }
+                }
+                // Primary Task field
+                ColumnLayout {
+                    spacing: 4
+                    Text { text: "Primary Task"; font.pixelSize: 12 }
+                    TextField {
+                        id: tfPrimaryTask
+                        Layout.preferredWidth: 150
+                        enabled: (teamBridge && teamBridge.team && teamBridge.team.current_task_id)
+                        text: (teamBridge && teamBridge.team && teamBridge.team.current_task_id) ? (teamBridge.team.primary_task || "") : ""
+                        onTextChanged: if (teamBridge) teamBridge.updateFromQml({ primary_task: text })
+                    }
+                }
+                // Assignment field
+                ColumnLayout {
+                    spacing: 4
+                    Text { text: "Assignment"; font.pixelSize: 12 }
+                    TextField {
+                        id: tfAssignment
+                        Layout.preferredWidth: 180
+                        enabled: (teamBridge && teamBridge.team && teamBridge.team.current_task_id)
+                        text: (teamBridge && teamBridge.team && teamBridge.team.current_task_id) ? (teamBridge.team.assignment || "") : ""
+                        onTextChanged: if (teamBridge) teamBridge.updateFromQml({ assignment: text })
                     }
                 }
                 // Clocks (local/UTC) simple labels


### PR DESCRIPTION
## Summary
- add team type, leader phone, task and assignment fields to team header
- update Team model and repository for new fields
- wire new header inputs to team bridge

## Testing
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68b66a405b2c832b89044a4371aa18ce