### PR TITLE
Add tabbed log view with ICS-214 note support

### DIFF
--- a/modules/operations/teams/panels/team_detail_window.py
+++ b/modules/operations/teams/panels/team_detail_window.py
@@ -228,6 +228,31 @@ class TeamDetailBridge(QObject):
         # Future: open Canned Comm Entry dialog
         pass
 
+    @Slot(result='QVariant')
+    def unitLog(self) -> list[dict]:
+        """Return unit log entries for the team."""
+        return []
+
+    @Slot(result='QVariant')
+    def taskHistory(self) -> list[dict]:
+        """Return task history entries for the team."""
+        return []
+
+    @Slot(result='QVariant')
+    def statusHistory(self) -> list[dict]:
+        """Return status history entries for the team."""
+        return []
+
+    @Slot(result='QVariant')
+    def ics214Entries(self) -> list[dict]:
+        """Return ICS 214 note entries for the team."""
+        return []
+
+    @Slot()
+    def addIcs214Note(self) -> None:  # placeholder
+        """Open dialog to add an ICS 214 note."""
+        pass
+
     @Slot(int)
     def setTeamLeader(self, person_id: int) -> None:
         try:

--- a/modules/operations/teams/qml/TeamDetailWindow.qml
+++ b/modules/operations/teams/qml/TeamDetailWindow.qml
@@ -267,11 +267,49 @@ Window {
                                 }
                             }
                             // 4: Log
-                            ColumnLayout { Layout.margins: 8; spacing: 6; Layout.fillWidth: true; Layout.fillHeight: true
-                                ListView { Layout.fillWidth: true; Layout.fillHeight: true; model: [] }
-                                RowLayout { spacing: 6
-                                    Button { text: "Quick Log Entry"; onClicked: if (teamBridge) teamBridge.openQuickLog(null) }
-                                    Button { text: "Filter…" }
+                            TabView {
+                                Layout.margins: 8
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+
+                                Tab {
+                                    title: "Unit Log"
+                                    ListView {
+                                        anchors.fill: parent
+                                        model: teamBridge ? teamBridge.unitLog() : []
+                                    }
+                                }
+                                Tab {
+                                    title: "Task History"
+                                    ListView {
+                                        anchors.fill: parent
+                                        model: teamBridge ? teamBridge.taskHistory() : []
+                                    }
+                                }
+                                Tab {
+                                    title: "Status History"
+                                    ListView {
+                                        anchors.fill: parent
+                                        model: teamBridge ? teamBridge.statusHistory() : []
+                                    }
+                                }
+                                Tab {
+                                    title: "ICS-214"
+                                    ColumnLayout {
+                                        anchors.fill: parent
+                                        spacing: 6
+                                        ListView {
+                                            Layout.fillWidth: true
+                                            Layout.fillHeight: true
+                                            model: teamBridge ? teamBridge.ics214Entries() : []
+                                        }
+                                        RowLayout { spacing: 6
+                                            Button {
+                                                text: "➕ Add ICS 214 Note"
+                                                onClicked: if (teamBridge) teamBridge.addIcs214Note()
+                                            }
+                                        }
+                                    }
                                 }
                             }
                             // 5: Attachments


### PR DESCRIPTION
## Summary
- Replace team log area with TabView for unit log, task history, status history, and ICS-214 notes
- Stub out bridge methods for new log and history data sources
- Add button to add ICS-214 notes

## Testing
- `pytest` *(fails: httpx, sqlalchemy, libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_b_68b66a3f0150832b818959d6e69b9e8a