### PR TITLE
Add isNew state to TeamDetailWindow

### DIFF
--- a/modules/operations/teams/qml/TeamDetailWindow.qml
+++ b/modules/operations/teams/qml/TeamDetailWindow.qml
@@ -12,9 +12,27 @@ Window {
     title: (teamBridge && teamBridge.team && teamBridge.team.name) ? `Team Detail - ${teamBridge.team.name}` : "Team Detail"
 
     property int teamId: -1
+    property bool isNew: true
+
+    onTeamIdChanged: isNew = teamId <= 0
 
     Component.onCompleted: {
-        if (teamId > 0 && teamBridge && teamBridge.loadTeam) teamBridge.loadTeam(teamId)
+        if (teamId > 0 && teamBridge && teamBridge.loadTeam) {
+            teamBridge.loadTeam(teamId)
+            isNew = false
+        } else {
+            isNew = true
+        }
+    }
+
+    Connections {
+        target: teamBridge
+        function onSaved() {
+            if (isNew && teamBridge && teamBridge.team && teamBridge.team.team_id) {
+                teamId = teamBridge.team.team_id
+                isNew = false
+            }
+        }
     }
 
     Rectangle { anchors.fill: parent; color: "#ffffff" }
@@ -42,6 +60,7 @@ Window {
                         id: tfName
                         Layout.fillWidth: true
                         text: (teamBridge && teamBridge.team) ? (teamBridge.team.name || "") : ""
+                        readOnly: !isNew
                         onTextChanged: if (teamBridge) teamBridge.updateFromQml({ name: text })
                     }
                 }
@@ -51,6 +70,7 @@ Window {
                     Text { text: "Team Leader"; font.pixelSize: 12 }
                     Button {
                         text: (teamBridge && teamBridge.team && teamBridge.team.team_leader_id) ? `#${teamBridge.team.team_leader_id}` : "Not Set"
+                        enabled: isNew
                         onClicked: tabs.currentIndex = 0 // focus personnel tab
                     }
                 }
@@ -125,7 +145,9 @@ Window {
                     Rectangle {
                         Layout.fillWidth: true
                         border.color: "#cccccc"; radius: 4
-                        ColumnLayout { anchors.fill: parent; anchors.margins: 8; spacing: 6
+                        ColumnLayout {
+                            anchors.fill: parent; anchors.margins: 8; spacing: 6
+                            enabled: isNew
                             RowLayout {
                                 spacing: 12
                         Text { text: `Team Type: ${((teamBridge && teamBridge.isAircraftTeam)? 'Aircraft':'Ground')}` }
@@ -135,28 +157,28 @@ Window {
                         Button { text: (teamBridge && teamBridge.team && teamBridge.team.current_task_id) ? `#${teamBridge.team.current_task_id}`: "Link…"; onClicked: {/* placeholder */} }
                         Text { text: "Priority:" }
                         SpinBox { id: sbPriority; from: 0; to: 5; value: (teamBridge && teamBridge.team && teamBridge.team.priority) ? teamBridge.team.priority : 0; onValueChanged: if (teamBridge) teamBridge.updateFromQml({ priority: value }) }
-                    }
-                    RowLayout {
-                        spacing: 12
+                            }
+                            RowLayout {
+                                spacing: 12
                         Text { text: "Callsign:" }
                         TextField { id: tfCall; width: 160; text: (teamBridge && teamBridge.team) ? (teamBridge.team.callsign || "") : ""; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ callsign: text }) }
                         Text { text: "Phone:" }
                         TextField { id: tfPhone; width: 160; text: (teamBridge && teamBridge.team) ? (teamBridge.team.phone || "") : ""; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ phone: text }) }
-                    }
-                    ColumnLayout {
-                        spacing: 4
+                            }
+                            ColumnLayout {
+                                spacing: 4
                         Text { text: "Notes:" }
                         TextArea { id: taNotes; Layout.fillWidth: true; Layout.preferredHeight: 100; text: (teamBridge && teamBridge.team) ? (teamBridge.team.notes || "") : ""; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ notes: text }) }
+                            }
+                        }
                     }
-                }
-            }
 
                     // Tabs (Ground vs Aircraft) using TabBar + StackLayout
                     ColumnLayout {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
                         spacing: 0
-                        TabBar { id: tabs; Layout.fillWidth: true
+                        TabBar { id: tabs; Layout.fillWidth: true; enabled: !isNew
                             TabButton { text: (teamBridge && teamBridge.isAircraftTeam) ? "Aircrew" : "Personnel" }
                             TabButton { text: (teamBridge && teamBridge.isAircraftTeam) ? "Aircraft" : "Vehicles" }
                             TabButton { text: "Equipment" }
@@ -164,7 +186,7 @@ Window {
                             TabButton { text: "Log" }
                             TabButton { text: "Attachments" }
                         }
-                        StackLayout { id: tabStack; Layout.fillWidth: true; Layout.fillHeight: true; currentIndex: tabs.currentIndex
+                        StackLayout { id: tabStack; Layout.fillWidth: true; Layout.fillHeight: true; currentIndex: tabs.currentIndex; enabled: !isNew
                             // 0: Personnel / Aircrew
                             ColumnLayout { Layout.margins: 8; spacing: 6; Layout.fillWidth: true; Layout.fillHeight: true
                                 property int selectedMemberId: -1
@@ -295,22 +317,22 @@ Window {
                 contentWidth: rightCol.implicitWidth
                 contentHeight: rightCol.implicitHeight
                 clip: true
-                ColumnLayout { id: rightCol; width: parent.width; spacing: 8
+                ColumnLayout { id: rightCol; width: parent.width; spacing: 8; enabled: !isNew
                     // Location & Movement
                     Rectangle { Layout.fillWidth: true; border.color: "#ccc"; radius: 4
                         ColumnLayout { anchors.fill: parent; anchors.margins: 8; spacing: 6
                             Text { text: "Location & Movement"; font.bold: true }
                             RowLayout { spacing: 8
                                 Text { text: "Lat:" }
-                                TextField { width: 100; text: (teamBridge && teamBridge.team) ? (teamBridge.team.last_known_lat || "") : ""; inputMethodHints: Qt.ImhFormattedNumbersOnly; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ last_known_lat: text }) }
+                                TextField { width: 100; text: (teamBridge && teamBridge.team) ? (teamBridge.team.last_known_lat || "") : ""; inputMethodHints: Qt.ImhFormattedNumbersOnly; readOnly: isNew; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ last_known_lat: text }) }
                                 Text { text: "Lon:" }
-                                TextField { width: 100; text: (teamBridge && teamBridge.team) ? (teamBridge.team.last_known_lon || "") : ""; inputMethodHints: Qt.ImhFormattedNumbersOnly; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ last_known_lon: text }) }
+                                TextField { width: 100; text: (teamBridge && teamBridge.team) ? (teamBridge.team.last_known_lon || "") : ""; inputMethodHints: Qt.ImhFormattedNumbersOnly; readOnly: isNew; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ last_known_lon: text }) }
                                 Text { text: "Updated:" }
                                 Text { text: (teamBridge && teamBridge.team) ? (teamBridge.team.last_update_ts || "") : "" }
                             }
                             RowLayout { spacing: 8
                                 Text { text: "Route/ETA:" }
-                                TextField { Layout.fillWidth: true; text: (teamBridge && teamBridge.team) ? (teamBridge.team.route || "") : ""; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ route: text }) }
+                                TextField { Layout.fillWidth: true; text: (teamBridge && teamBridge.team) ? (teamBridge.team.route || "") : ""; readOnly: isNew; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ route: text }) }
                             }
                             ColumnLayout { spacing: 4
                                 Text { text: "Recent Updates:" }
@@ -324,11 +346,11 @@ Window {
                             Text { text: "Communications"; font.bold: true }
                             RowLayout { spacing: 8
                                 Text { text: "Radio IDs:" }
-                                TextField { Layout.fillWidth: true; text: (teamBridge && teamBridge.team) ? (teamBridge.team.radio_ids || "") : ""; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ radio_ids: text }) }
+                                TextField { Layout.fillWidth: true; text: (teamBridge && teamBridge.team) ? (teamBridge.team.radio_ids || "") : ""; readOnly: isNew; onTextChanged: if (teamBridge) teamBridge.updateFromQml({ radio_ids: text }) }
                             }
                             RowLayout { spacing: 8
                                 Text { text: "Preset:" }
-                                ComboBox { width: 240; model: ["(placeholder)"] }
+                                ComboBox { width: 240; model: ["(placeholder)"]; enabled: !isNew }
                                 Button { text: "Open ICS 205"; onClicked: if (teamBridge) teamBridge.openICS205Preview() }
                             }
                         }
@@ -340,12 +362,13 @@ Window {
         // Footer -------------------------------------------------------------
         Rectangle { Layout.fillWidth: true; height: 56; color: "#f7f7f7"; border.color: "#cccccc"; radius: 4
             RowLayout { anchors.fill: parent; anchors.margins: 8; spacing: 8
-                Button { id: btnSave; text: "Save"; onClicked: if (teamBridge) teamBridge.save() }
-                Button { id: btnSaveClose; text: "Save & Close"; onClicked: { if (teamBridge) teamBridge.save(); win.close(); } }
-                Button { id: btnCancel; text: "Cancel"; onClicked: win.close() }
+                Button { id: btnCreate; text: "Create"; visible: isNew; onClicked: if (teamBridge) teamBridge.save() }
+                Button { id: btnSave; text: "Save"; visible: !isNew; onClicked: if (teamBridge) teamBridge.save() }
+                Button { id: btnSaveClose; text: "Save & Close"; visible: !isNew; onClicked: { if (teamBridge) teamBridge.save(); win.close(); } }
+                Button { id: btnCancel; text: isNew ? "Cancel" : "Close"; onClicked: win.close() }
                 Item { Layout.fillWidth: true }
-                Button { id: btnQuickStatus; text: "Quick Status Change"; onClicked: cbStatus.popup.open() }
-                Button { id: btnPrint; text: "Print Summary"; onClicked: if (teamBridge) teamBridge.printSummary() }
+                Button { id: btnQuickStatus; text: "Quick Status Change"; onClicked: cbStatus.popup.open(); visible: !isNew }
+                Button { id: btnPrint; text: "Print Summary"; onClicked: if (teamBridge) teamBridge.printSummary(); visible: !isNew }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `isNew` state to control creation workflow
- disable tabs and non-overview fields until team is created
- show Create button and lock overview fields after save

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68b66a3d388c832bb1e6542600bf56c4