### PR TITLE
Refine team detail tabs and role-based filtering

### DIFF
--- a/modules/common/dialogs/PersonnelPicker.qml
+++ b/modules/common/dialogs/PersonnelPicker.qml
@@ -7,6 +7,9 @@ Dialog {
     modal: true
     standardButtons: Dialog.Ok | Dialog.Cancel
     property int selectedId: -1
+    // Optional role filter used by TeamDetailWindow to restrict
+    // personnel selection based on team type (e.g. aircrew vs ground).
+    property string roleFilter: ""
     signal picked(int personId)
 
     contentItem: Column {


### PR DESCRIPTION
## Summary
- Distinguish air and ground assets in Team Detail tabs with dynamic loaders
- Expose role filter and member validation through teamBridge
- Allow Personnel picker to accept role-based filtering hints

## Testing
- `pytest` *(fails: KeyboardInterrupt after 133s)*

------
https://chatgpt.com/codex/tasks/task_b_68b66a3c7468832bb642c0ae54e1f269