### PR TITLE
Add sqlmodel dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project provides tooling and user interface components for incident management workflows.
 
+## Dependencies
+
+Core dependencies are listed in `requirements.txt`, including the `sqlmodel>=0.0.8` package.
+
 ## Team Communication Timers
 
 Radio traffic can be logged using the communications module. When a radio log entry references a known team in the `sender` or `recipient` fields, that team's `last_comm_ping` timestamp is updated. This timer allows operators to track when each team last made contact over the radio.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ reportlab
 PySide6-QtAds
 httpx
 sqlalchemy
+sqlmodel>=0.0.8


### PR DESCRIPTION
## Summary
- include sqlmodel>=0.0.8 in requirements
- document sqlmodel dependency in README

## Testing
- `pip install -r requirements.txt`
- `apt-get update`
- `apt-get install -y libgl1`
- `apt-get install -y libxkbcommon0`
- `apt-get install -y libegl1`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68b6cff4974c832bb5fbaadb10a80e9e