### PR TITLE
Rename quick entry permission exception

### DIFF
--- a/tests/test_quick_entry.py
+++ b/tests/test_quick_entry.py
@@ -1,4 +1,8 @@
-from ui.actions.quick_entry_actions import dispatch, execute_cli, PermissionError
+from ui.actions.quick_entry_actions import (
+    QuickEntryPermissionError,
+    dispatch,
+    execute_cli,
+)
 
 
 def test_quick_entry_dispatch_known_actions():
@@ -17,8 +21,8 @@ def test_quick_entry_dispatch_known_actions():
 def test_quick_entry_dispatch_unknown_action():
     try:
         dispatch("unknown.action", {})
-        assert False, "Expected PermissionError"
-    except PermissionError:
+        assert False, "Expected QuickEntryPermissionError"
+    except QuickEntryPermissionError:
         pass
 
 

--- a/ui/actions/quick_entry_actions.py
+++ b/ui/actions/quick_entry_actions.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 from typing import Dict
 
 
-class PermissionError(Exception):
+class QuickEntryPermissionError(Exception):
+    """Raised when a quick entry action is not permitted."""
+
     pass
 
 
 def dispatch(action: str, payload: Dict):
     """Route quick entry actions to modules. Replace with real integrations.
 
-    Do not hide options by role; raise PermissionError at action time when needed.
+    Do not hide options by role; raise :class:`QuickEntryPermissionError` at
+    action time when needed.
     """
     # TODO: integrate with actual panels/modules
     # For now, just simulate success for known actions
@@ -24,7 +27,9 @@ def dispatch(action: str, payload: Dict):
         "files.upload",
     }
     if action not in allowed:
-        raise PermissionError(f"Action not permitted or unknown: {action}")
+        raise QuickEntryPermissionError(
+            f"Action not permitted or unknown: {action}"
+        )
     # In a real implementation, open the relevant wizard/panel here
     return True
 


### PR DESCRIPTION
## Summary
- rename custom PermissionError to QuickEntryPermissionError
- update dispatch and tests to use QuickEntryPermissionError

## Testing
- `PYTHONPATH=. pytest tests/test_quick_entry.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6cffb15c0832b88a2b5f9fdcf79bb