### PR TITLE
Use AppState for incident-aware check-in

### DIFF
--- a/modules/logistics/checkin/api.py
+++ b/modules/logistics/checkin/api.py
@@ -17,7 +17,7 @@ FIND_BY_NAME = {
     "personnel": repository.find_personnel_by_name,
     "equipment": repository.find_equipment_by_name,
     "vehicle": repository.find_vehicle_by_name,
-    "aircraft": repository.find_aircraft_by_tail,
+    "aircraft": repository.find_aircraft_by_callsign,
 }
 
 COPY_TO_INCIDENT = {

--- a/modules/logistics/checkin/qml/CheckInWindow.qml
+++ b/modules/logistics/checkin/qml/CheckInWindow.qml
@@ -52,7 +52,10 @@ Item {
                 id: refreshBtn
                 text: "Refresh"
                 onClicked: {
-                    swipeView.itemAt(tabBar.currentIndex).refresh()
+                    var loader = stackLayout.children[tabBar.currentIndex]
+                    if (loader && loader.item && loader.item.refresh) {
+                        loader.item.refresh()
+                    }
                 }
             }
             Button {
@@ -79,15 +82,11 @@ Item {
             TabButton { text: "Equipment" }
             TabButton { text: "Vehicles" }
             TabButton { text: "Aircraft" }
-            onCurrentIndexChanged: {
-                swipeView.currentIndex = currentIndex
-                // reset any per-tab overlays if needed
-            }
         }
 
         // Pages that change with the TabBar
-        SwipeView {
-            id: swipeView
+        StackLayout {
+            id: stackLayout
             Layout.fillWidth: true
             Layout.fillHeight: true
             currentIndex: tabBar.currentIndex

--- a/tests/test_checkin_api.py
+++ b/tests/test_checkin_api.py
@@ -15,8 +15,10 @@ def setup_api(tmp_path, monkeypatch):
     monkeypatch.setenv("CHECKIN_DATA_DIR", str(tmp_path))
     import utils.incident_context as ic
     import utils.db as db
+    import utils.state as state
     importlib.reload(ic)
     importlib.reload(db)
+    importlib.reload(state)
 
     modules_pkg = types.ModuleType("modules")
     modules_pkg.__path__ = []
@@ -44,12 +46,12 @@ def setup_api(tmp_path, monkeypatch):
     sys.modules[spec_api.name] = api
     spec_api.loader.exec_module(api)
 
-    ic.set_active_incident("m1")
-    return api, repo, ic
+    state.AppState.set_active_incident("m1")
+    return api, repo
 
 
 def test_check_in_flow(tmp_path, monkeypatch):
-    api, repo, ic = setup_api(tmp_path, monkeypatch)
+    api, repo = setup_api(tmp_path, monkeypatch)
     master_payload = {"id": "P2", "first_name": "Bob", "last_name": "Jones"}
     repo.create_or_update_personnel_master(master_payload)
 

--- a/tests/test_checkin_repository.py
+++ b/tests/test_checkin_repository.py
@@ -15,8 +15,10 @@ def setup_repo(tmp_path, monkeypatch):
     monkeypatch.setenv("CHECKIN_DATA_DIR", str(tmp_path))
     import utils.incident_context as ic
     import utils.db as db
+    import utils.state as state
     importlib.reload(ic)
     importlib.reload(db)
+    importlib.reload(state)
 
     # Create lightweight package hierarchy to avoid heavy imports
     modules_pkg = types.ModuleType("modules")
@@ -37,12 +39,12 @@ def setup_repo(tmp_path, monkeypatch):
     sys.modules[spec.name] = repo
     spec.loader.exec_module(repo)
 
-    ic.set_active_incident("test_incident")
-    return repo, ic
+    state.AppState.set_active_incident("test_incident")
+    return repo
 
 
 def test_tables_created_and_copy(tmp_path, monkeypatch):
-    repo, ic = setup_repo(tmp_path, monkeypatch)
+    repo = setup_repo(tmp_path, monkeypatch)
 
     payload = {
         "id": "P1",


### PR DESCRIPTION
## Summary
- Read active incident from AppState when copying records into incident databases
- Support aircraft lookup by callsign and allow creating assets with minimal fields
- Update tests to initialize AppState

## Testing
- `pytest tests/test_checkin_repository.py tests/test_checkin_api.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b7b44d8980832b80861e13c716983a