### PR TITLE
Fix Tab component errors in TeamDetail and ICS-214 views

### DIFF
--- a/modules/ics214/qml/Ics214StreamView.qml
+++ b/modules/ics214/qml/Ics214StreamView.qml
@@ -4,11 +4,33 @@ import QtQuick.Controls
 Item {
     width: 600
     height: 400
-    TabView {
+    ColumnLayout {
         anchors.fill: parent
-        Tab { title: "Narrative"; ListView { anchors.fill: parent } }
-        Tab { title: "Related" }
-        Tab { title: "Rules" }
-        Tab { title: "Export"; Ics214ExportDialog { anchors.fill: parent } }
+        spacing: 0
+        TabBar {
+            id: tabs
+            Layout.fillWidth: true
+            TabButton { text: "Narrative" }
+            TabButton { text: "Related" }
+            TabButton { text: "Rules" }
+            TabButton { text: "Export" }
+        }
+        StackLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            currentIndex: tabs.currentIndex
+            ListView {
+                anchors.fill: parent
+            }
+            Item {
+                anchors.fill: parent
+            }
+            Item {
+                anchors.fill: parent
+            }
+            Ics214ExportDialog {
+                anchors.fill: parent
+            }
+        }
     }
 }

--- a/modules/operations/teams/qml/TeamDetailWindow.qml
+++ b/modules/operations/teams/qml/TeamDetailWindow.qml
@@ -375,34 +375,35 @@ Window {
                                 }
                             }
                             // 4: Log
-                            TabView {
+                            ColumnLayout {
                                 Layout.margins: 8
                                 Layout.fillWidth: true
                                 Layout.fillHeight: true
-
-                                Tab {
-                                    title: "Unit Log"
+                                spacing: 0
+                                TabBar {
+                                    id: logTabs
+                                    Layout.fillWidth: true
+                                    TabButton { text: "Unit Log" }
+                                    TabButton { text: "Task History" }
+                                    TabButton { text: "Status History" }
+                                    TabButton { text: "ICS-214" }
+                                }
+                                StackLayout {
+                                    Layout.fillWidth: true
+                                    Layout.fillHeight: true
+                                    currentIndex: logTabs.currentIndex
                                     ListView {
                                         anchors.fill: parent
                                         model: teamBridge ? teamBridge.unitLog() : []
                                     }
-                                }
-                                Tab {
-                                    title: "Task History"
                                     ListView {
                                         anchors.fill: parent
                                         model: teamBridge ? teamBridge.taskHistory() : []
                                     }
-                                }
-                                Tab {
-                                    title: "Status History"
                                     ListView {
                                         anchors.fill: parent
                                         model: teamBridge ? teamBridge.statusHistory() : []
                                     }
-                                }
-                                Tab {
-                                    title: "ICS-214"
                                     ColumnLayout {
                                         anchors.fill: parent
                                         spacing: 6
@@ -411,7 +412,8 @@ Window {
                                             Layout.fillHeight: true
                                             model: teamBridge ? teamBridge.ics214Entries() : []
                                         }
-                                        RowLayout { spacing: 6
+                                        RowLayout {
+                                            spacing: 6
                                             Button {
                                                 text: "➕ Add ICS 214 Note"
                                                 onClicked: if (teamBridge) teamBridge.addIcs214Note()


### PR DESCRIPTION
## Summary
- avoid `Tab` runtime error by replacing `TabView` with `TabBar` and `StackLayout` in Ics214StreamView
- replace remaining `Tab` usages so repo no longer references the missing `Tab` type

## Testing
- `rg 'Tab\s*\{' -n`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68b7cf0e078c832ba5b69ed7fa72c525