### PR TITLE
Fix personnel availability widget identifier

### DIFF
--- a/tests/test_widgets_registry.py
+++ b/tests/test_widgets_registry.py
@@ -6,7 +6,7 @@ def test_registry_contains_all_ids():
         # Incident Context
         "incidentinfo",
         # Status & Operations
-        "teamstatusboard", "taskstatusboard", "personnelavailablility", "equipmentsnapshot", "vehairsnapshot", "opsDashboardFeed",
+        "teamstatusboard", "taskstatusboard", "personnelavailability", "equipmentsnapshot", "vehairsnapshot", "opsDashboardFeed",
         # Communications
         "recentmessages", "notifications", "ics205commplan", "commlogfeed",
         # Planning & Documentation

--- a/ui/widgets/registry.py
+++ b/ui/widgets/registry.py
@@ -82,8 +82,8 @@ REGISTRY: Dict[str, WidgetSpec] = {
         component=lambda: TaskStatusBoardWidget(title="Task Status", items=_task_status_items()),  # type: ignore
         data_hooks={"tasks.getSummary": dp.tasks_getSummary_active},
     ),
-    "personnelavailablility": WidgetSpec(
-        id="personnelavailablility",
+    "personnelavailability": WidgetSpec(
+        id="personnelavailability",
         title="Personnel Checked In",
         default_size=Size(4, 1),
         min_size=Size(3, 1),


### PR DESCRIPTION
## Summary
- rename personnel availability widget key and id
- update registry tests for corrected identifier

## Testing
- `PYTHONPATH=. pytest tests/test_widgets_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b915ae7298832b8c714a9c42a7a29c