### PR TITLE
Improve master catalog dialogs and limit status dropdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -1341,6 +1341,15 @@ class MainWindow(QMainWindow):
         # Expose bridges and models to QML
         ctx = view.rootContext()
         ctx.setContextProperty("catalogBridge", self._catalog_bridge)
+
+        base = os.path.basename(qml_rel_path)
+        if base == "CannedCommEntriesWindow.qml":
+            try:
+                from utils.constants import TEAM_STATUSES
+                ctx.setContextProperty("teamStatuses", TEAM_STATUSES)
+            except Exception:
+                pass
+
         # Incident bridge (incident-scoped CRUD)
         try:
             if not hasattr(self, "_incident_bridge"):
@@ -1351,7 +1360,6 @@ class MainWindow(QMainWindow):
 
         # Inject a per-window SqliteTableModel when we can map the window to a table
         try:
-            base = os.path.basename(qml_rel_path)
             # Strip the full suffix "Window.qml" (10 chars) to get the base name
             name = base[:-10] if base.endswith("Window.qml") else os.path.splitext(base)[0]
             table = self._resolve_master_table(name)
@@ -1909,9 +1917,16 @@ class MetricWidget(QWidget):
         ctx = view.rootContext()
         ctx.setContextProperty("catalogBridge", self._catalog_bridge)
 
+        base = os.path.basename(qml_rel_path)
+        if base == "CannedCommEntriesWindow.qml":
+            try:
+                from utils.constants import TEAM_STATUSES
+                ctx.setContextProperty("teamStatuses", TEAM_STATUSES)
+            except Exception:
+                pass
+
         # Inject per-window SQLite models for master catalog windows
         try:
-            base = os.path.basename(qml_rel_path)
             # Strip the full suffix "Window.qml" (10 chars) to get the base name
             name = base[:-10] if base.endswith("Window.qml") else os.path.splitext(base)[0]
             # Map window base name -> table name (validate against sqlite_master)

--- a/qml/CannedCommEntriesWindow.qml
+++ b/qml/CannedCommEntriesWindow.qml
@@ -20,7 +20,7 @@ Shared.MasterTableWindow {
     { key: "category", label: "Category", type: "text", editable: true, width: 160 },
     { key: "message", label: "Message", type: "multiline", editable: true, required: true, width: 420 },
     { key: "notification_level", label: "Notify Level", type: "enum", editable: true, width: 200, valueMap: ({ 0: "None", 1: "Notification", 2: "Emergency Alert" }) },
-    { key: "status_update", label: "Status Update", type: "enum", editable: true, width: 220, options: ["", "Active", "Resolved", "Closed"] }
+    { key: "status_update", label: "Status Update", type: "enum", editable: true, width: 220, options: [""].concat(teamStatuses) }
   ]
   // Hint for model-driven ORDER BY sorting
   tableName: "canned_comm_entries"

--- a/qml/MasterEditDialog.qml
+++ b/qml/MasterEditDialog.qml
@@ -64,7 +64,7 @@ Dialog {
                                               : (col && col.type === "int") ? intDelegate
                                               : (col && col.type === "float") ? floatDelegate
                                               : textDelegate
-                            onLoaded: {
+                            function _apply() {
                                 if (!item) return;
                                 if (item.hasOwnProperty('col')) { item.col = col; }
 
@@ -76,10 +76,15 @@ Dialog {
                                         if (item.hasOwnProperty('text')) item.text = String(root.data[col.key] === undefined ? "" : root.data[col.key]);
                                         if (item.hasOwnProperty('value')) item.value = root.data[col.key];
                                     }
+                                } else {
+                                    if (item.hasOwnProperty('text')) item.text = "";
+                                    if (item.hasOwnProperty('value')) item.value = null;
                                 }
                                 if (item && item.rebuild) { item.rebuild(); }
                                 item.objectName = "field::" + col.key;
                             }
+                            onLoaded: _apply()
+                            Connections { target: root; function onDataChanged() { _apply() } }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Reload master catalog edit dialog fields whenever selected record changes so edits prefill correctly
- Scope team status dropdown to the Canned Communications window and remove unrelated Team Detail tweaks

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68b9566f9c0c832b8c62a5c0cc78715d