### PR TITLE
Fix apply handler scope in MasterEditDialog

### DIFF
--- a/qml/MasterEditDialog.qml
+++ b/qml/MasterEditDialog.qml
@@ -84,7 +84,10 @@ Dialog {
                                 item.objectName = "field::" + col.key;
                             }
                             onLoaded: _apply()
-                            Connections { target: root; function onDataChanged() { _apply() } }
+                            Connections {
+                                target: root
+                                function onDataChanged() { parent._apply() }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure loader reload function uses correct scope

## Testing
- `pytest` *(fails: hung after collecting 26 items; KeyboardInterrupt)*
- `PYTHONPATH=. pytest tests/test_widgets_registry.py -q`
- `PYTHONPATH=. pytest tests/public_info/test_repository.py -q`
- `PYTHONPATH=. pytest tests/logistics/test_service.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b95f831d1c832bacd1e0f348cef176