### PR TITLE
Add ObjectiveBridge and strategic objectives module skeleton

### DIFF
--- a/bridge/objectives_bridge.py
+++ b/bridge/objectives_bridge.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from datetime import datetime, timezone
+
+from PySide6.QtCore import QObject, Slot, Signal, Property
+
+from modules.planning.models.objectives_models import ObjectiveListModel, SimpleListModel
+
+UTC = timezone.utc
+STATUS_VALUES = ["Pending", "Approved", "Assigned", "In Progress", "Completed", "Cancelled"]
+PRIORITY_VALUES = ["Low", "Normal", "High", "Urgent"]
+
+
+class ObjectiveBridge(QObject):
+    """QObject bridge exposing incident objectives to QML.
+
+    The bridge performs light-weight CRUD operations directly against the
+    mission database.  All methods interact with SQLite and update the
+    backing list models which are exposed to QML via ``Property``.
+    """
+
+    objectivesChanged = Signal()
+    detailChanged = Signal()
+    toast = Signal(str)
+
+    def __init__(self, mission_db_path: str, current_user_id: int, parent=None):
+        super().__init__(parent)
+        self._db_path = Path(mission_db_path)
+        self._uid = current_user_id
+        self._list_model = ObjectiveListModel([])
+        self._narrative = SimpleListModel(["ts", "text", "user", "critical"], [])
+        self._strategies = SimpleListModel(["text", "user", "ts"], [])
+        self._linked = SimpleListModel(["id", "summary", "team", "status"], [])
+        self._approvals = SimpleListModel(["ts", "user", "action", "note"], [])
+        self._log = SimpleListModel(["type", "ts", "user", "text", "details"], [])
+        self.ensure_migration()
+
+    # ------------------------------------------------------------------
+    def conn(self) -> sqlite3.Connection:
+        con = sqlite3.connect(str(self._db_path))
+        con.row_factory = sqlite3.Row
+        return con
+
+    def now(self) -> str:
+        return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def ensure_migration(self) -> None:
+        sql = r"""
+        CREATE TABLE IF NOT EXISTS objective_comments (
+            id INTEGER PRIMARY KEY,
+            objective_id INTEGER NOT NULL,
+            user_id INTEGER NOT NULL,
+            timestamp TEXT NOT NULL,
+            text TEXT NOT NULL,
+            parent_id INTEGER NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_objective_comments_obj ON objective_comments(objective_id);
+        CREATE TABLE IF NOT EXISTS objective_logs (
+            objective_id INTEGER NOT NULL,
+            planning_log_id INTEGER NOT NULL,
+            PRIMARY KEY (objective_id, planning_log_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_incident_objectives_mission ON incident_objectives(mission_id);
+        CREATE INDEX IF NOT EXISTS idx_incident_objectives_status ON incident_objectives(status);
+        CREATE INDEX IF NOT EXISTS idx_planning_logs_incident ON planning_logs(incident_id);
+        """
+        with self.conn() as c:
+            c.executescript(sql)
+            c.commit()
+
+    # ------------------------------------------------------------------
+    @Property(QObject, notify=objectivesChanged)
+    def objectivesModel(self):  # pragma: no cover - simple property
+        return self._list_model
+
+    @Property(QObject, notify=detailChanged)
+    def narrativeModel(self):  # pragma: no cover - simple property
+        return self._narrative
+
+    @Property(QObject, notify=detailChanged)
+    def strategiesModel(self):  # pragma: no cover - simple property
+        return self._strategies
+
+    @Property(QObject, notify=detailChanged)
+    def linkedTasksModel(self):  # pragma: no cover - simple property
+        return self._linked
+
+    @Property(QObject, notify=detailChanged)
+    def approvalsModel(self):  # pragma: no cover - simple property
+        return self._approvals
+
+    @Property(QObject, notify=detailChanged)
+    def logModel(self):  # pragma: no cover - simple property
+        return self._log
+
+    # ------------------------------------------------------------------
+    @Slot(str, str, str)
+    def loadObjectives(self, status_filter: str = "All", priority_filter: str = "All", section_filter: str = "All") -> None:
+        q = [
+            "SELECT id, printf('%s-%02d', CASE WHEN assigned_section IS 'AIR' THEN 'A' ELSE 'G' END, id) AS code,",
+            "CASE WHEN priority IS NULL THEN 'Normal' ELSE priority END AS priority,",
+            "status, customer, COALESCE(due_time,'') AS due",
+            "FROM incident_objectives",
+        ]
+        where, params = [], []
+        if status_filter != "All":
+            where.append("status=?")
+            params.append(status_filter)
+        if priority_filter != "All":
+            where.append("priority=?")
+            params.append(priority_filter)
+        if section_filter != "All":
+            where.append("assigned_section=?")
+            params.append(section_filter)
+        if where:
+            q.append("WHERE " + " AND ".join(where))
+        q.append("ORDER BY id DESC")
+        sql = "\n".join(q)
+        with self.conn() as c:
+            rows = [dict(r) for r in c.execute(sql, params)]
+        self._list_model.replace(rows)
+        self.objectivesChanged.emit()
+
+    @Slot(str, str, int)
+    def createObjective(self, description: str, priority: str = "Normal", mission_id: int = 1) -> None:
+        ts = self.now()
+        with self.conn() as c:
+            cur = c.execute(
+                "INSERT INTO incident_objectives (mission_id, description, status, priority, created_by, created_at) VALUES (?,?,?,?,?,?)",
+                (mission_id, description, "Pending", priority, self._uid, ts),
+            )
+            oid = cur.lastrowid
+            c.execute(
+                "INSERT INTO audit_logs (taskid, field_changed, old_value, new_value, changed_by, timestamp) VALUES (?,?,?,?,?,?)",
+                (oid, "objective.action", "", "create", self._uid, ts),
+            )
+            c.commit()
+        self.toast.emit("Objective created")
+        self.loadObjectives()
+        self.loadObjectiveDetail(oid)
+
+    @Slot(int, str)
+    def changeStatus(self, oid: int, new_status: str) -> None:
+        ts = self.now()
+        with self.conn() as c:
+            c.execute(
+                "UPDATE incident_objectives SET status=?, closed_at=CASE WHEN ? IN ('Completed','Cancelled') THEN ? ELSE closed_at END WHERE id=?",
+                (new_status, new_status, ts, oid),
+            )
+            c.execute(
+                "INSERT INTO audit_logs (taskid,field_changed,old_value,new_value,changed_by,timestamp) VALUES (?,?,?,?,?,?)",
+                (oid, "objective.action", "", f"status:{new_status}", self._uid, ts),
+            )
+            c.commit()
+        self.toast.emit(f"Status → {new_status}")
+        self.loadObjectiveDetail(oid)
+        self.loadObjectives()
+
+    # Detail operations --------------------------------------------------
+    @Slot(int)
+    def loadObjectiveDetail(self, oid: int) -> None:
+        """Populate detail models for objective ``oid``."""
+        with self.conn() as c:
+            narr = [
+                dict(r)
+                for r in c.execute(
+                    """
+                    SELECT pl.timestamp AS ts, pl.text, pl.entered_by AS user, 0 AS critical
+                    FROM planning_logs pl
+                    JOIN objective_logs ol ON pl.id = ol.planning_log_id
+                    WHERE ol.objective_id=?
+                    ORDER BY pl.timestamp DESC
+                    """,
+                    (oid,),
+                )
+            ]
+            comments = [
+                dict(r)
+                for r in c.execute(
+                    "SELECT timestamp AS ts, text, user_id AS user, 0 AS critical FROM objective_comments WHERE objective_id=? ORDER BY timestamp",
+                    (oid,),
+                )
+            ]
+            log_rows = [
+                dict(r)
+                for r in c.execute(
+                    """
+                    SELECT field_changed AS type, timestamp AS ts, changed_by AS user, new_value AS text, old_value AS details
+                    FROM audit_logs
+                    WHERE taskid=?
+                    ORDER BY timestamp
+                    """,
+                    (oid,),
+                )
+            ]
+        # narrative combines planning_logs and objective_comments
+        self._narrative.replace(narr + comments)
+        self._strategies.replace([])
+        self._linked.replace([])
+        self._approvals.replace([])
+        self._log.replace(log_rows)
+        self.detailChanged.emit()
+
+    @Slot(int, str)
+    def addComment(self, oid: int, text: str) -> None:
+        ts = self.now()
+        with self.conn() as c:
+            c.execute(
+                "INSERT INTO objective_comments (objective_id, user_id, timestamp, text, parent_id) VALUES (?,?,?,?,NULL)",
+                (oid, self._uid, ts, text),
+            )
+            c.commit()
+        self.loadObjectiveDetail(oid)
+        self.toast.emit("Comment added")
+
+    @Slot(int, str)
+    def addNarrative(self, oid: int, text: str) -> None:
+        ts = self.now()
+        with self.conn() as c:
+            cur = c.execute(
+                "INSERT INTO planning_logs (incident_id, text, timestamp, entered_by) VALUES (?,?,?,?)",
+                (1, text, ts, self._uid),
+            )
+            log_id = cur.lastrowid
+            c.execute(
+                "INSERT INTO objective_logs (objective_id, planning_log_id) VALUES (?,?)",
+                (oid, log_id),
+            )
+            c.commit()
+        self.loadObjectiveDetail(oid)
+        self.toast.emit("Narrative added")
+
+    # Additional slots such as addStrategy or linking tasks could be added
+    # here following the same pattern.

--- a/modules/planning/api.py
+++ b/modules/planning/api.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from typing import Dict, Any, List
+
+from modules.planning.models.objectives import Objective, ObjectiveComment, AuditLog
+
+router = APIRouter(prefix="/api/planning/objectives", tags=["planning-objectives"])
+
+# In-memory stores for demonstration purposes
+_OBJECTIVES: Dict[int, Objective] = {}
+_COMMENTS: Dict[int, List[ObjectiveComment]] = {}
+_LOGS: Dict[int, List[AuditLog]] = {}
+_next_id = 1
+
+
+@router.get("")
+def list_objectives() -> Dict[str, Any]:
+    """Return all objectives currently in memory."""
+    return {"objectives": list(_OBJECTIVES.values())}
+
+
+@router.post("")
+def create_objective(payload: Dict[str, Any]) -> Objective:
+    """Create a new objective."""
+    global _next_id
+    obj = Objective(
+        id=_next_id,
+        mission_id=payload.get("mission_id", 1),
+        description=payload.get("description", ""),
+        status="Pending",
+        priority=payload.get("priority", "Normal"),
+        created_by=payload.get("created_by", 0),
+        created_at=payload.get("created_at", ""),
+    )
+    _OBJECTIVES[obj.id] = obj
+    _COMMENTS[obj.id] = []
+    _LOGS[obj.id] = []
+    _next_id += 1
+    return obj
+
+
+@router.put("/{obj_id}")
+def update_objective(obj_id: int, payload: Dict[str, Any]) -> Objective:
+    obj = _OBJECTIVES.get(obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Objective not found")
+    for field_name in ["description", "priority", "customer", "due_time"]:
+        if field_name in payload:
+            setattr(obj, field_name, payload[field_name])
+    return obj
+
+
+@router.post("/{obj_id}/status")
+def set_status(obj_id: int, payload: Dict[str, Any]) -> Objective:
+    obj = _OBJECTIVES.get(obj_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Objective not found")
+    status = payload.get("status")
+    if not status:
+        raise HTTPException(status_code=400, detail="Missing status")
+    obj.status = status
+    return obj
+
+
+@router.post("/{obj_id}/comment")
+def add_comment(obj_id: int, payload: Dict[str, Any]) -> ObjectiveComment:
+    comments = _COMMENTS.setdefault(obj_id, [])
+    comment = ObjectiveComment(
+        id=len(comments) + 1,
+        objective_id=obj_id,
+        user_id=payload.get("user_id", 0),
+        timestamp=payload.get("timestamp", ""),
+        text=payload.get("text", ""),
+        parent_id=payload.get("parent_id"),
+    )
+    comments.append(comment)
+    return comment
+
+
+@router.get("/{obj_id}/history")
+def get_history(obj_id: int) -> Dict[str, Any]:
+    return {"logs": _LOGS.get(obj_id, [])}

--- a/modules/planning/models/objectives.py
+++ b/modules/planning/models/objectives.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class AuditLog:
+    """Simple audit trail entry for an objective."""
+
+    id: int
+    objective_id: int
+    timestamp: str
+    user_id: int
+    action: str
+    note: str | None = None
+
+
+@dataclass
+class ObjectiveComment:
+    """Threaded comment on an objective."""
+
+    id: int
+    objective_id: int
+    user_id: int
+    timestamp: str
+    text: str
+    parent_id: Optional[int] = None
+
+
+@dataclass
+class Objective:
+    """Incident objective stored in the mission database."""
+
+    id: int
+    mission_id: int
+    description: str
+    status: str
+    priority: str
+    created_by: int
+    created_at: str
+    assigned_section: Optional[str] = None
+    customer: Optional[str] = None
+    due_time: Optional[str] = None
+    closed_at: Optional[str] = None
+
+    comments: List[ObjectiveComment] = field(default_factory=list)
+    logs: List[AuditLog] = field(default_factory=list)

--- a/modules/planning/models/objectives_models.py
+++ b/modules/planning/models/objectives_models.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+from PySide6.QtCore import QAbstractListModel, QModelIndex, Qt
+
+
+class SimpleListModel(QAbstractListModel):
+    """Generic list model exposing rows of dictionaries to QML.
+
+    The model is initialised with a sequence of role names; each row is a
+    ``dict`` mapping those role names to values.  Convenience methods ``replace``
+    and ``append`` are provided for bulk updates.
+    """
+
+    def __init__(self, roles: Sequence[str], rows: List[Dict[str, Any]] | None = None, parent=None) -> None:
+        super().__init__(parent)
+        self._roles = list(roles)
+        self._data: List[Dict[str, Any]] = rows or []
+        self._role_map = {Qt.UserRole + i + 1: role.encode() for i, role in enumerate(self._roles)}
+
+    # Qt model interface -------------------------------------------------
+    def rowCount(self, parent: QModelIndex | None = QModelIndex()) -> int:  # type: ignore[override]
+        return len(self._data)
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole) -> Any:  # type: ignore[override]
+        if not index.isValid() or role < Qt.UserRole + 1:
+            return None
+        key = self._roles[role - Qt.UserRole - 1]
+        return self._data[index.row()].get(key)
+
+    def roleNames(self) -> Dict[int, bytes]:  # type: ignore[override]
+        return self._role_map
+
+    # Convenience API ----------------------------------------------------
+    def replace(self, rows: List[Dict[str, Any]]) -> None:
+        """Replace the entire model contents with ``rows``."""
+        self.beginResetModel()
+        self._data = list(rows)
+        self.endResetModel()
+
+    def append(self, row: Dict[str, Any]) -> None:
+        """Append a single row to the model."""
+        position = len(self._data)
+        self.beginInsertRows(QModelIndex(), position, position)
+        self._data.append(row)
+        self.endInsertRows()
+
+
+class ObjectiveListModel(SimpleListModel):
+    """List model for incident objectives shown in the objective panel."""
+
+    def __init__(self, rows: List[Dict[str, Any]] | None = None, parent=None) -> None:
+        roles = ["id", "code", "priority", "status", "customer", "due"]
+        super().__init__(roles, rows or [], parent)

--- a/modules/planning/panels/objectives_panel.py
+++ b/modules/planning/panels/objectives_panel.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import QPushButton, QTableWidget, QVBoxLayout, QWidget
+from PySide6.QtQml import QQmlApplicationEngine
+
+
+class ObjectivesPanel(QWidget):
+    """Simple table panel listing incident objectives."""
+
+    def __init__(self, mission_id: int):
+        super().__init__()
+        self.mission_id = mission_id
+        self.setWindowTitle("Objectives")
+
+        layout = QVBoxLayout(self)
+        self.table = QTableWidget()
+        layout.addWidget(self.table)
+
+        self.new_btn = QPushButton("New Objective")
+        layout.addWidget(self.new_btn)
+        self.new_btn.clicked.connect(self.open_detail)
+
+    def open_detail(self) -> None:
+        """Open the detail dialog defined in QML."""
+        engine = QQmlApplicationEngine()
+        qml_path = Path(__file__).resolve().parents[1] / "qml" / "ObjectiveDetail.qml"
+        engine.load(str(qml_path))

--- a/modules/planning/qml/ObjectiveDetail.qml
+++ b/modules/planning/qml/ObjectiveDetail.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 400
+    height: 300
+    Column {
+        anchors.centerIn: parent
+        Text { text: "Objective Detail" }
+    }
+}

--- a/modules/planning/qml/ObjectiveList.qml
+++ b/modules/planning/qml/ObjectiveList.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    width: 600
+    height: 400
+
+    Component.onCompleted: objectiveBridge.loadObjectives()
+
+    ListView {
+        anchors.fill: parent
+        model: objectiveBridge.objectivesModel
+        delegate: Text { text: code + " - " + status }
+    }
+}


### PR DESCRIPTION
## Summary
- add Qt list models for objectives and simple dictionaries
- create ObjectiveBridge to expose incident objectives and perform DB operations
- add dataclasses, FastAPI endpoints, PySide6 panel, and QML skeletons for strategic objectives module

## Testing
- `pytest tests/test_state.py`
- `pytest` *(fails: KeyboardInterrupt after 43s)*

------
https://chatgpt.com/codex/tasks/task_b_68bfb57ce168832b8a71aca786168e0a