### PR TITLE
Add ICS-205 communications planning module

### DIFF
--- a/modules/communications/__init__.py
+++ b/modules/communications/__init__.py
@@ -25,6 +25,16 @@ def get_comms_panel(parent=None):
     return ChannelsPanel(parent)
 
 
+def create_ics205_panel(parent=None):
+    """Create the ICS-205 panel as a standalone window."""
+    from PySide6.QtCore import Qt
+    from .panels.ICS205Panel import ICS205Panel
+
+    panel = ICS205Panel(parent)
+    panel.setWindowFlag(Qt.Window)
+    return panel
+
+
 def notify_message_logged(sender: str, recipient: str) -> None:
     """Emit a global signal that a comms message was logged.
 

--- a/modules/communications/controller.py
+++ b/modules/communications/controller.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+"""Qt controller and data models for the ICS-205 module."""
+
+from typing import Any, Dict, List
+
+from PySide6.QtCore import (
+    QAbstractListModel,
+    QAbstractTableModel,
+    QModelIndex,
+    QObject,
+    Property,
+    Qt,
+    Signal,
+    Slot,
+    QByteArray,
+)
+
+from utils.state import AppState
+
+from .models.master_repo import MasterRepository
+from .models.incident_repo import IncidentRepository
+from .models import db
+
+
+# ---------------------------------------------------------------------------
+# List model helpers
+# ---------------------------------------------------------------------------
+
+class MasterListModel(QAbstractListModel):
+    """List model exposing channels from the master database."""
+
+    roles = ["id", "display_name", "function", "rx_freq", "tx_freq", "mode", "band"]
+
+    def __init__(self, rows: List[Dict[str, Any]] | None = None, parent=None):
+        super().__init__(parent)
+        self._rows: List[Dict[str, Any]] = rows or []
+
+    # Qt model implementation ----------------------------------------------
+    def rowCount(self, parent=QModelIndex()):  # type: ignore[override]
+        return len(self._rows)
+
+    def data(self, index, role=Qt.DisplayRole):  # type: ignore[override]
+        if not index.isValid():
+            return None
+        row = self._rows[index.row()]
+        key = self.roles[role - Qt.UserRole]
+        return row.get(key)
+
+    def roleNames(self):  # type: ignore[override]
+        return {Qt.UserRole + i: QByteArray(r.encode()) for i, r in enumerate(self.roles)}
+
+    # Helpers ---------------------------------------------------------------
+    def replace(self, rows: List[Dict[str, Any]]):
+        self.beginResetModel()
+        self._rows = rows
+        self.endResetModel()
+
+    def get(self, row: int) -> Dict[str, Any]:
+        return self._rows[row] if 0 <= row < len(self._rows) else {}
+
+
+PLAN_COLUMNS = [
+    ("channel", "Channel"),
+    ("function", "Function"),
+    ("assignment_division", "Division"),
+    ("assignment_team", "Team"),
+    ("rx_freq", "RX"),
+    ("tx_freq", "TX"),
+    ("mode", "Mode"),
+    ("band", "Band"),
+    ("priority", "Priority"),
+    ("include_on_205", "205"),
+    ("remarks", "Remarks"),
+]
+
+
+class PlanModel(QAbstractTableModel):
+    """Editable table model for the incident plan."""
+
+    def __init__(self, repo: IncidentRepository, parent=None):
+        super().__init__(parent)
+        self.repo = repo
+        self._rows: List[Dict[str, Any]] = []
+
+    # Basic model API ------------------------------------------------------
+    def rowCount(self, parent=QModelIndex()):  # type: ignore[override]
+        return len(self._rows)
+
+    def columnCount(self, parent=QModelIndex()):  # type: ignore[override]
+        return len(PLAN_COLUMNS)
+
+    def roleNames(self):  # type: ignore[override]
+        roles = {Qt.UserRole + i: QByteArray(col[0].encode()) for i, col in enumerate(PLAN_COLUMNS)}
+        return roles
+
+    def data(self, index, role=Qt.DisplayRole):  # type: ignore[override]
+        if not index.isValid():
+            return None
+        row = self._rows[index.row()]
+        if role >= Qt.UserRole:
+            key = PLAN_COLUMNS[role - Qt.UserRole][0]
+            return row.get(key)
+        if role == Qt.DisplayRole:
+            key = PLAN_COLUMNS[index.column()][0]
+            return row.get(key)
+        return None
+
+    def setData(self, index, value, role=Qt.EditRole):  # type: ignore[override]
+        if not index.isValid():
+            return False
+        key = PLAN_COLUMNS[index.column()][0]
+        row = self._rows[index.row()]
+        self.repo.update_row(row["id"], {key: value})
+        row[key] = value
+        self.dataChanged.emit(index, index, [role])
+        return True
+
+    def flags(self, index):  # type: ignore[override]
+        if not index.isValid():
+            return Qt.ItemIsEnabled
+        return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
+
+    # Helpers ---------------------------------------------------------------
+    def replace(self, rows: List[Dict[str, Any]]):
+        self.beginResetModel()
+        self._rows = rows
+        self.endResetModel()
+
+    def row_dict(self, row: int) -> Dict[str, Any]:
+        return self._rows[row] if 0 <= row < len(self._rows) else {}
+
+
+class ValidationModel(QAbstractListModel):
+    roles = ["level", "text"]
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._rows: List[Dict[str, Any]] = []
+
+    def rowCount(self, parent=QModelIndex()):  # type: ignore[override]
+        return len(self._rows)
+
+    def data(self, index, role=Qt.DisplayRole):  # type: ignore[override]
+        if not index.isValid():
+            return None
+        key = self.roles[role - Qt.UserRole]
+        return self._rows[index.row()].get(key)
+
+    def roleNames(self):  # type: ignore[override]
+        return {Qt.UserRole + i: QByteArray(r.encode()) for i, r in enumerate(self.roles)}
+
+    def replace(self, rows: List[Dict[str, Any]]):
+        self.beginResetModel()
+        self._rows = rows
+        self.endResetModel()
+
+
+# ---------------------------------------------------------------------------
+# Controller
+# ---------------------------------------------------------------------------
+
+
+class ICS205Controller(QObject):
+    filtersChanged = Signal()
+    statusLineChanged = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._filters: Dict[str, Any] = {}
+        self._status = ""
+
+        incident = AppState.get_active_incident()
+        if incident is None:
+            raise RuntimeError("Active incident not set")
+        db.ensure_incident_schema(incident)
+        self.master_repo = MasterRepository()
+        self.incident_repo = IncidentRepository(incident)
+
+        self._masterModel = MasterListModel([])
+        self._planModel = PlanModel(self.incident_repo)
+        self._validationModel = ValidationModel()
+
+        self.refreshMaster()
+        self.refreshPlan()
+
+    # Properties -----------------------------------------------------------
+    @Property("QVariantMap", notify=filtersChanged)
+    def filters(self):  # type: ignore[override]
+        return self._filters
+
+    @Property(str, notify=statusLineChanged)
+    def statusLine(self):  # type: ignore[override]
+        return self._status
+
+    @Property(QObject, constant=True)
+    def masterModel(self):  # type: ignore[override]
+        return self._masterModel
+
+    @Property(QObject, constant=True)
+    def planModel(self):  # type: ignore[override]
+        return self._planModel
+
+    @Property(QObject, constant=True)
+    def validationModel(self):  # type: ignore[override]
+        return self._validationModel
+
+    # Slots ----------------------------------------------------------------
+    @Slot()
+    def refreshMaster(self):
+        rows = self.master_repo.list_channels(self._filters)
+        self._masterModel.replace(rows)
+
+    @Slot()
+    def refreshPlan(self):
+        rows = self.incident_repo.list_plan()
+        self._planModel.replace(rows)
+
+    @Slot(str, "QVariant")
+    def setFilter(self, key: str, value: Any):
+        self._filters[key] = value
+        self.filtersChanged.emit()
+        self.refreshMaster()
+
+    @Slot(int)
+    def addMasterIdToPlan(self, master_id: int):
+        row = self.master_repo.get_channel(master_id)
+        if row:
+            self.incident_repo.add_from_master(row, {})
+            self.refreshPlan()
+
+    @Slot(int, str, "QVariant")
+    def updatePlanCell(self, row: int, column: str, value: Any):
+        rows = self._planModel._rows
+        if 0 <= row < len(rows):
+            row_id = rows[row]["id"]
+            self.incident_repo.update_row(row_id, {column: value})
+            self.refreshPlan()
+
+    @Slot(int)
+    def deletePlanRow(self, row: int):
+        rows = self._planModel._rows
+        if 0 <= row < len(rows):
+            row_id = rows[row]["id"]
+            self.incident_repo.delete_row(row_id)
+            self.refreshPlan()
+
+    @Slot(int, str)
+    def moveRow(self, row: int, direction: str):
+        rows = self._planModel._rows
+        if 0 <= row < len(rows):
+            row_id = rows[row]["id"]
+            self.incident_repo.reorder(row_id, direction)
+            self.refreshPlan()
+
+    @Slot()
+    def runValidation(self):
+        report = self.incident_repo.validate_plan()
+        self._validationModel.replace(report["messages"])
+        self._status = f"{report['conflicts']} conflicts • {report['warnings']} warnings"
+        self.statusLineChanged.emit()
+
+    @Slot(result="QVariantList")
+    def getPreviewRows(self):
+        return self.incident_repo.preview_rows()
+
+    @Slot(int, result="QVariantMap")
+    def getPlanRow(self, row: int):
+        return self._planModel.row_dict(row)

--- a/modules/communications/models/db.py
+++ b/modules/communications/models/db.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""Database helpers for the communications module.
+
+This module centralises access to the master channel catalog and the
+incident specific communications plan.  All functions return SQLite
+``Connection`` objects with ``row_factory`` configured to ``sqlite3.Row``
+so rows may be treated as dictionaries.
+
+The incident database path is resolved via :mod:`utils.mission_db` to
+avoid hard coding any file system locations.
+"""
+
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+import sqlite3
+from typing import Iterator
+
+from utils import mission_db
+
+MASTER_DB_PATH = Path("data") / "master.db"
+
+
+# ---------------------------------------------------------------------------
+# Connection helpers
+# ---------------------------------------------------------------------------
+
+def _conn(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def get_master_conn() -> sqlite3.Connection:
+    """Return a connection to the read-only master database."""
+    return _conn(MASTER_DB_PATH)
+
+
+def get_incident_conn(incident_number: str | int) -> sqlite3.Connection:
+    """Return a connection to the current incident database."""
+    path = mission_db.get_incident_db_path(incident_number)
+    return _conn(path)
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+def verify_master_access() -> bool:
+    """Return ``True`` if the master database is reachable."""
+    try:
+        with get_master_conn() as c:
+            c.execute("SELECT 1 FROM comms_resources LIMIT 1")
+        return True
+    except Exception:
+        return False
+
+
+def ensure_incident_schema(incident_number: str | int) -> None:
+    """Ensure the ``incident_channels`` table exists for ``incident_number``."""
+    with get_incident_conn(incident_number) as c:
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS incident_channels (
+                id INTEGER PRIMARY KEY,
+                master_id INTEGER,
+                channel TEXT NOT NULL,
+                function TEXT NOT NULL,
+                band TEXT NOT NULL,
+                system TEXT,
+                mode TEXT NOT NULL,
+                rx_freq REAL NOT NULL,
+                tx_freq REAL,
+                rx_tone TEXT,
+                tx_tone TEXT,
+                squelch_type TEXT,
+                squelch_value TEXT,
+                repeater INTEGER NOT NULL DEFAULT 0,
+                offset REAL,
+                encryption TEXT DEFAULT 'None',
+                assignment_division TEXT,
+                assignment_team TEXT,
+                priority TEXT DEFAULT 'Normal',
+                include_on_205 INTEGER NOT NULL DEFAULT 1,
+                remarks TEXT,
+                sort_index INTEGER NOT NULL DEFAULT 1000,
+                line_a INTEGER DEFAULT 0,
+                line_c INTEGER DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        # Helpful indexes ---------------------------------------------------
+        c.execute("CREATE INDEX IF NOT EXISTS idx_ic_function ON incident_channels(function)")
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ic_assign ON incident_channels(assignment_division, assignment_team)"
+        )
+        c.execute("CREATE INDEX IF NOT EXISTS idx_ic_band_mode ON incident_channels(band, mode)")
+        c.execute("CREATE INDEX IF NOT EXISTS idx_ic_rx ON incident_channels(rx_freq)")
+        c.execute("CREATE INDEX IF NOT EXISTS idx_ic_tx ON incident_channels(tx_freq)")
+        c.execute("CREATE INDEX IF NOT EXISTS idx_ic_sort ON incident_channels(sort_index)")
+
+
+# Context managers -----------------------------------------------------------
+
+@contextmanager
+def master_cursor() -> Iterator[sqlite3.Cursor]:
+    with get_master_conn() as c:
+        yield c.cursor()
+
+
+@contextmanager
+def incident_cursor(incident_number: str | int) -> Iterator[sqlite3.Cursor]:
+    with get_incident_conn(incident_number) as c:
+        yield c.cursor()

--- a/modules/communications/models/incident_repo.py
+++ b/modules/communications/models/incident_repo.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+"""Repository managing incident specific communication plans."""
+
+from datetime import datetime
+from typing import Any, Dict, List
+
+from . import db
+from modules.communications.util import geo_line_rules
+
+UTC = "%Y-%m-%dT%H:%M:%S"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def infer_band(freq: float | None) -> str:
+    """Infer a band string from ``freq`` in MHz."""
+    if freq is None:
+        return "Other"
+    f = float(freq)
+    if 3 <= f < 30:
+        return "HF"
+    if 30 <= f < 54:
+        return "VHF-LOW"
+    if 118 <= f <= 137:
+        return "Air"
+    if 156 <= f <= 163:
+        return "Marine"
+    if 54 <= f < 300:
+        return "VHF"
+    if 300 <= f < 700:
+        return "UHF"
+    if 700 <= f <= 869:
+        return "700/800"
+    return "Other"
+
+
+def _now() -> str:
+    return datetime.utcnow().strftime(UTC)
+
+
+def _squelch(tone: str | None) -> tuple[str | None, str | None]:
+    if tone in (None, "", "CSQ"):
+        return "None", None
+    try:
+        float(tone)
+        return "CTCSS", tone
+    except (TypeError, ValueError):
+        pass
+    if tone and tone.upper().startswith("F"):
+        return "NAC", tone
+    if tone and tone.isdigit():
+        return "DCS", tone
+    return None, None
+
+
+# ---------------------------------------------------------------------------
+# Repository
+# ---------------------------------------------------------------------------
+
+class IncidentRepository:
+    def __init__(self, incident_number: str | int):
+        self.incident = incident_number
+
+    # Basic operations ------------------------------------------------------
+    def list_plan(self) -> List[Dict[str, Any]]:
+        with db.get_incident_conn(self.incident) as conn:
+            rows = conn.execute(
+                "SELECT * FROM incident_channels ORDER BY sort_index, id"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def add_from_master(self, master_row: Dict[str, Any], defaults: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        defaults = defaults or {}
+        band = infer_band(master_row.get("rx_freq") or master_row.get("tx_freq"))
+        rx_tone = master_row.get("rx_tone")
+        tx_tone = master_row.get("tx_tone")
+        squelch_type, squelch_value = (None, None)
+        if rx_tone == tx_tone:
+            squelch_type, squelch_value = _squelch(rx_tone)
+        repeater = 1 if master_row.get("tx_freq") and master_row.get("rx_freq") and master_row["tx_freq"] != master_row["rx_freq"] else 0
+        offset = None
+        if repeater:
+            try:
+                offset = float(master_row["tx_freq"]) - float(master_row["rx_freq"])
+            except Exception:
+                offset = None
+        now = _now()
+        with db.get_incident_conn(self.incident) as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO incident_channels (
+                    master_id, channel, function, band, system, mode,
+                    rx_freq, tx_freq, rx_tone, tx_tone, squelch_type, squelch_value,
+                    repeater, offset, encryption, assignment_division, assignment_team,
+                    priority, include_on_205, remarks, sort_index, line_a, line_c,
+                    created_at, updated_at
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    master_row.get("id"),
+                    master_row.get("name"),
+                    master_row.get("function", "Tactical"),
+                    band,
+                    master_row.get("system"),
+                    master_row.get("mode"),
+                    master_row.get("rx_freq"),
+                    master_row.get("tx_freq"),
+                    rx_tone,
+                    tx_tone,
+                    squelch_type,
+                    squelch_value,
+                    repeater,
+                    offset,
+                    defaults.get("encryption", "None"),
+                    defaults.get("assignment_division"),
+                    defaults.get("assignment_team"),
+                    defaults.get("priority", "Normal"),
+                    defaults.get("include_on_205", 1),
+                    defaults.get("remarks"),
+                    defaults.get("sort_index", 1000),
+                    master_row.get("line_a", 0),
+                    master_row.get("line_c", 0),
+                    now,
+                    now,
+                ),
+            )
+            conn.commit()
+            new_id = cur.lastrowid
+        row = self.get_row(new_id)
+        return row
+
+    def get_row(self, row_id: int) -> Dict[str, Any]:
+        with db.get_incident_conn(self.incident) as conn:
+            row = conn.execute(
+                "SELECT * FROM incident_channels WHERE id=?", (row_id,)
+            ).fetchone()
+        return dict(row) if row else {}
+
+    def update_row(self, row_id: int, patch: Dict[str, Any]) -> None:
+        patch = patch.copy()
+        patch["updated_at"] = _now()
+        cols = ", ".join(f"{k}=?" for k in patch.keys())
+        values = list(patch.values()) + [row_id]
+        with db.get_incident_conn(self.incident) as conn:
+            conn.execute(f"UPDATE incident_channels SET {cols} WHERE id=?", values)
+            conn.commit()
+
+    def delete_row(self, row_id: int) -> None:
+        with db.get_incident_conn(self.incident) as conn:
+            conn.execute("DELETE FROM incident_channels WHERE id=?", (row_id,))
+            conn.commit()
+
+    def reorder(self, row_id: int, direction: str) -> None:
+        row = self.get_row(row_id)
+        if not row:
+            return
+        delta = -1 if direction == "up" else 1
+        new_index = row.get("sort_index", 1000) + delta
+        self.update_row(row_id, {"sort_index": new_index})
+
+    # Validation ------------------------------------------------------------
+    def validate_plan(self) -> Dict[str, Any]:
+        rows = self.list_plan()
+        messages: List[Dict[str, str]] = []
+        # Duplicate frequency
+        for i, a in enumerate(rows):
+            for b in rows[i + 1 :]:
+                if (
+                    a["band"] == b["band"]
+                    and a["mode"] == b["mode"]
+                    and a["rx_freq"] == b["rx_freq"]
+                    and (a.get("tx_freq") or 0) == (b.get("tx_freq") or 0)
+                    and a.get("rx_tone") == b.get("rx_tone")
+                    and a.get("tx_tone") == b.get("tx_tone")
+                ):
+                    messages.append(
+                        {
+                            "level": "conflict",
+                            "text": f"Duplicate freq {a['rx_freq']} ({a['channel']} & {b['channel']})",
+                        }
+                    )
+        for r in rows:
+            if not r.get("function"):
+                messages.append({"level": "warning", "text": f"{r['channel']} missing function"})
+            if r.get("function", "").lower() == "tactical" and (
+                not r.get("assignment_division") or not r.get("assignment_team")
+            ):
+                messages.append(
+                    {"level": "warning", "text": f"{r['channel']} missing assignment"}
+                )
+            if r.get("repeater") == 0 and r.get("offset"):
+                messages.append(
+                    {"level": "warning", "text": f"{r['channel']} offset with no repeater"}
+                )
+            inferred = infer_band(r.get("rx_freq") or r.get("tx_freq"))
+            if inferred != r.get("band"):
+                messages.append(
+                    {"level": "warning", "text": f"{r['channel']} out of band"}
+                )
+            if r.get("line_a"):
+                if geo_line_rules.line_a_applies(None, None):
+                    messages.append(
+                        {"level": "warning", "text": f"{r['channel']} Line A coordination"}
+                    )
+            if r.get("line_c"):
+                if geo_line_rules.line_c_applies(None, None):
+                    messages.append(
+                        {"level": "warning", "text": f"{r['channel']} Line C coordination"}
+                    )
+
+        conflicts = sum(1 for m in messages if m["level"] == "conflict")
+        warnings = sum(1 for m in messages if m["level"] == "warning")
+        return {"messages": messages, "conflicts": conflicts, "warnings": warnings}
+
+    # Preview ---------------------------------------------------------------
+    def preview_rows(self) -> List[Dict[str, Any]]:
+        rows = self.list_plan()
+        preview: List[Dict[str, Any]] = []
+        for r in rows:
+            assignment = " / ".join(
+                [p for p in [r.get("assignment_division"), r.get("assignment_team")] if p]
+            )
+            tone = r.get("rx_tone")
+            if r.get("rx_tone") == r.get("tx_tone"):
+                tone = r.get("rx_tone") or ""
+            else:
+                tone = "/".join(filter(None, [r.get("rx_tone"), r.get("tx_tone")]))
+            preview.append(
+                {
+                    "Function": r.get("function"),
+                    "Channel": r.get("channel"),
+                    "Assignment": assignment,
+                    "RX": r.get("rx_freq"),
+                    "TX": r.get("tx_freq"),
+                    "ToneNAC": tone or "",
+                    "Mode": r.get("mode"),
+                    "Encryption": r.get("encryption", "None"),
+                    "Notes": r.get("remarks", ""),
+                }
+            )
+        return preview
+
+
+__all__ = ["IncidentRepository", "infer_band"]

--- a/modules/communications/models/master_repo.py
+++ b/modules/communications/models/master_repo.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Read-only repository for the master communications catalog."""
+
+from typing import Any, Dict, List
+
+from . import db
+from .incident_repo import infer_band  # reuse band inference
+
+
+def _map_row(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Map a SQLite row from ``comms_resources`` to canonical keys."""
+    lower = {k.lower(): row[k] for k in row.keys()}
+
+    def pick(*names: str, default: Any = None) -> Any:
+        for n in names:
+            if n in lower and lower[n] not in (None, ""):
+                return lower[n]
+        return default
+
+    name = pick("alpha tag", "alpha_tag", "name") or ""
+    rx = pick("freq rx", "freq_rx", default=0)
+    tx = pick("freq tx", "freq_tx", default=None)
+    try:
+        rx_freq = float(rx) if rx is not None else 0.0
+    except (TypeError, ValueError):
+        rx_freq = 0.0
+    try:
+        tx_freq = float(tx) if tx not in (None, "") else None
+    except (TypeError, ValueError):
+        tx_freq = None
+
+    mapped = {
+        "id": row["id"],
+        "name": name,
+        "function": pick("function", default="Tactical"),
+        "rx_freq": rx_freq,
+        "tx_freq": tx_freq,
+        "rx_tone": pick("rx tone", "rx_tone"),
+        "tx_tone": pick("tx tone", "tx_tone"),
+        "system": pick("system"),
+        "mode": pick("mode", default="FM"),
+        "notes": pick("notes"),
+        "line_a": int(pick("line_a", default=0) or 0),
+        "line_c": int(pick("line_c", default=0) or 0),
+    }
+    mapped["display_name"] = mapped["name"] or f"Ch-{mapped['id']}"
+    mapped["band"] = infer_band(mapped["rx_freq"] or mapped["tx_freq"] or 0)
+    return mapped
+
+
+class MasterRepository:
+    """Repository interface for the master catalog."""
+
+    def list_channels(self, filters: Dict[str, Any] | None = None) -> List[Dict[str, Any]]:
+        filters = filters or {}
+        rows: List[Dict[str, Any]] = []
+        with db.get_master_conn() as conn:
+            for r in conn.execute("SELECT * FROM comms_resources").fetchall():
+                rows.append(_map_row(dict(r)))
+
+        # Apply filters ------------------------------------------------------
+        def match(row: Dict[str, Any]) -> bool:
+            if val := filters.get("search"):
+                text = " ".join(str(row.get(k, "")) for k in ("name", "function", "notes")).lower()
+                if val.lower() not in text:
+                    return False
+            if val := filters.get("band"):
+                if row.get("band") != val:
+                    return False
+            if val := filters.get("mode"):
+                if row.get("mode") != val:
+                    return False
+            return True
+
+        return [r for r in rows if match(r)]
+
+    def get_channel(self, channel_id: int) -> Dict[str, Any] | None:
+        with db.get_master_conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM comms_resources WHERE id=?", (channel_id,)
+            ).fetchone()
+            return _map_row(dict(row)) if row else None
+
+
+__all__ = ["MasterRepository"]

--- a/modules/communications/panels/ICS205Panel.py
+++ b/modules/communications/panels/ICS205Panel.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""PySide6 widget embedding the ICS-205 QML view."""
+
+from pathlib import Path
+
+from PySide6.QtCore import QUrl, Qt
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+from PySide6.QtQuickWidgets import QQuickWidget
+from PySide6.QtQml import QQmlContext
+
+from utils.state import AppState
+
+from ..controller import ICS205Controller
+from ..models import db
+
+
+class ICS205Panel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+
+        incident = AppState.get_active_incident()
+        if incident is None or not db.verify_master_access():
+            layout.addWidget(
+                QLabel("Select or create an incident to edit ICS-205."), alignment=Qt.AlignCenter
+            )
+            self.setEnabled(False)
+            return
+
+        # Ensure schema exists
+        db.ensure_incident_schema(incident)
+
+        controller = ICS205Controller(self)
+
+        qml_path = Path(__file__).resolve().parent.parent / "qml" / "ICS205View.qml"
+        view = QQuickWidget(self)
+        view.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        context: QQmlContext = view.rootContext()
+        context.setContextProperty("ics205", controller)
+        view.setSource(QUrl.fromLocalFile(str(qml_path)))
+        layout.addWidget(view)
+
+        self._controller = controller

--- a/modules/communications/qml/ICS205Preview.qml
+++ b/modules/communications/qml/ICS205Preview.qml
@@ -1,0 +1,62 @@
+import QtQuick 6.5
+import QtQuick.Controls 6.5
+import QtQuick.Layouts 1.15
+
+Item {
+    id: root
+    width: 800; height: 600
+
+    signal back()
+    signal exportPdf()
+    signal printRequested()
+    signal closeRequested()
+
+    ListModel { id: previewModel }
+
+    Component.onCompleted: {
+        var rows = ics205.getPreviewRows();
+        for (var i = 0; i < rows.length; ++i) {
+            previewModel.append(rows[i]);
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 4
+
+        TableView {
+            id: table
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            model: previewModel
+            clip: true
+            columnSpacing: 1
+            rowSpacing: 1
+            delegate: Rectangle {
+                implicitHeight: 28
+                border.color: "#cccccc"
+                Text { anchors.centerIn: parent; text: model.display || model[table.columns[column].role] }
+            }
+            columns: [
+                TableViewColumn { role: "Function"; title: "Function"; width: 120 },
+                TableViewColumn { role: "Channel"; title: "Channel"; width: 100 },
+                TableViewColumn { role: "Assignment"; title: "Assignment"; width: 120 },
+                TableViewColumn { role: "RX"; title: "RX"; width: 100 },
+                TableViewColumn { role: "TX"; title: "TX"; width: 100 },
+                TableViewColumn { role: "ToneNAC"; title: "Tone/NAC"; width: 100 },
+                TableViewColumn { role: "Mode"; title: "Mode"; width: 80 },
+                TableViewColumn { role: "Encryption"; title: "Encryption"; width: 100 },
+                TableViewColumn { role: "Notes"; title: "Notes"; width: 160 }
+            ]
+        }
+
+        Row {
+            Layout.alignment: Qt.AlignRight
+            spacing: 6
+            Button { text: "Back"; onClicked: root.back() }
+            Button { text: "Export PDF"; onClicked: root.exportPdf() }
+            Button { text: "Print"; onClicked: root.printRequested() }
+            Button { text: "Close"; onClicked: root.closeRequested() }
+        }
+    }
+}

--- a/modules/communications/qml/ICS205View.qml
+++ b/modules/communications/qml/ICS205View.qml
@@ -1,0 +1,153 @@
+import QtQuick 6.5
+import QtQuick.Controls 6.5
+import QtQuick.Layouts 1.15
+
+Item {
+    id: root
+    width: 1000; height: 600
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        ToolBar {
+            Layout.fillWidth: true
+            Row {
+                spacing: 6
+                ToolButton { text: "Validate"; onClicked: ics205.runValidation() }
+                ToolButton { text: "Close"; onClicked: root.Window.window.close() }
+            }
+        }
+
+        SplitView {
+            id: split
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            // Master list -------------------------------------------------
+            ListView {
+                id: masterList
+                model: ics205.masterModel
+                clip: true
+                width: 200
+                header: TextField {
+                    placeholderText: "Search"
+                    onTextChanged: ics205.setFilter("search", text)
+                }
+                delegate: ItemDelegate {
+                    width: ListView.view.width
+                    text: model.display_name
+                    onDoubleClicked: ics205.addMasterIdToPlan(model.id)
+                }
+            }
+
+            // Plan table --------------------------------------------------
+            TableView {
+                id: planView
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                model: ics205.planModel
+                clip: true
+                selectionModel: ItemSelectionModel {}
+                columnSpacing: 1
+                rowSpacing: 1
+
+                delegate: Rectangle {
+                    implicitHeight: 28
+                    color: (planView.selectionModel.currentIndex.row === row && planView.selectionModel.currentIndex.column === column) ? "#d0eaff" : "transparent"
+                    border.color: "#cccccc"
+                    Text {
+                        anchors.centerIn: parent
+                        text: model.display || model[planView.columns[column].role] || ""
+                    }
+                }
+
+                columns: [
+                    TableViewColumn { role: "channel"; title: "Chan"; width: 100 },
+                    TableViewColumn { role: "function"; title: "Function"; width: 120 },
+                    TableViewColumn { role: "assignment_division"; title: "Div"; width: 80 },
+                    TableViewColumn { role: "assignment_team"; title: "Team"; width: 80 },
+                    TableViewColumn { role: "rx_freq"; title: "RX"; width: 100 },
+                    TableViewColumn { role: "tx_freq"; title: "TX"; width: 100 },
+                    TableViewColumn { role: "mode"; title: "Mode"; width: 80 },
+                    TableViewColumn { role: "band"; title: "Band"; width: 80 }
+                ]
+            }
+        }
+
+        // Status line ----------------------------------------------------
+        Label {
+            Layout.fillWidth: true
+            text: ics205.statusLine
+            padding: 4
+        }
+
+        // Bottom editor ---------------------------------------------------
+        Rectangle {
+            Layout.fillWidth: true
+            color: "#f0f0f0"
+            height: 120
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 4
+                spacing: 4
+
+                Row {
+                    spacing: 6
+                    Label { text: "Channel:" }
+                    TextField {
+                        width: 150
+                        text: ics205.getPlanRow(planView.selectionModel.currentIndex.row).channel || ""
+                        onEditingFinished: ics205.updatePlanCell(planView.selectionModel.currentIndex.row, "channel", text)
+                    }
+                    Label { text: "Function:" }
+                    TextField {
+                        width: 120
+                        text: ics205.getPlanRow(planView.selectionModel.currentIndex.row).function || ""
+                        onEditingFinished: ics205.updatePlanCell(planView.selectionModel.currentIndex.row, "function", text)
+                    }
+                    Label { text: "Division:" }
+                    TextField {
+                        width: 80
+                        text: ics205.getPlanRow(planView.selectionModel.currentIndex.row).assignment_division || ""
+                        onEditingFinished: ics205.updatePlanCell(planView.selectionModel.currentIndex.row, "assignment_division", text)
+                    }
+                    Label { text: "Team:" }
+                    TextField {
+                        width: 80
+                        text: ics205.getPlanRow(planView.selectionModel.currentIndex.row).assignment_team || ""
+                        onEditingFinished: ics205.updatePlanCell(planView.selectionModel.currentIndex.row, "assignment_team", text)
+                    }
+                }
+
+                Row {
+                    spacing: 6
+                    Label { text: "RX:" }
+                    TextField {
+                        width: 100
+                        text: ics205.getPlanRow(planView.selectionModel.currentIndex.row).rx_freq || ""
+                        onEditingFinished: ics205.updatePlanCell(planView.selectionModel.currentIndex.row, "rx_freq", parseFloat(text))
+                    }
+                    Label { text: "TX:" }
+                    TextField {
+                        width: 100
+                        text: ics205.getPlanRow(planView.selectionModel.currentIndex.row).tx_freq || ""
+                        onEditingFinished: ics205.updatePlanCell(planView.selectionModel.currentIndex.row, "tx_freq", parseFloat(text))
+                    }
+                    Label { text: "Mode:" }
+                    TextField {
+                        width: 80
+                        text: ics205.getPlanRow(planView.selectionModel.currentIndex.row).mode || ""
+                        onEditingFinished: ics205.updatePlanCell(planView.selectionModel.currentIndex.row, "mode", text)
+                    }
+                    CheckBox {
+                        text: "Include on 205"
+                        checked: ics205.getPlanRow(planView.selectionModel.currentIndex.row).include_on_205 || false
+                        onToggled: ics205.updatePlanCell(planView.selectionModel.currentIndex.row, "include_on_205", checked ? 1 : 0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/communications/util/geo_line_rules.py
+++ b/modules/communications/util/geo_line_rules.py
@@ -1,0 +1,34 @@
+"""Helpers determining whether FCC Lines A or C apply.
+
+Currently these functions return ``False`` for all inputs.  They serve as
+placeholders until detailed boundary data is incorporated into the
+project.  The interfaces are stable so calling code may rely on them and
+later be extended with geographic logic without changes.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def line_a_applies(lat: Optional[float], lon: Optional[float]) -> bool:
+    """Return ``True`` if Line A coordination rules apply.
+
+    The implementation is a stub and always returns ``False``.  Real logic
+    will be added once boundary datasets are available.
+    """
+
+    return False
+
+
+def line_c_applies(lat: Optional[float], lon: Optional[float]) -> bool:
+    """Return ``True`` if Line C coordination rules apply.
+
+    The implementation is a stub and always returns ``False``.  Real logic
+    will be added once boundary datasets are available.
+    """
+
+    return False
+
+
+__all__ = ["line_a_applies", "line_c_applies"]

--- a/utils/mission_db.py
+++ b/utils/mission_db.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Utility helpers for locating incident databases.
+
+This module provides a small shim used by a number of modules to resolve the
+path to the incident specific SQLite database.  The implementation mirrors the
+behaviour expected by the rest of the application but intentionally contains
+very little logic so tests may easily override paths if required.
+"""
+
+from pathlib import Path
+import os
+
+# Base directory where incident databases are stored.  This mirrors the
+# behaviour of :mod:`utils.incident_context` which honours the
+# ``CHECKIN_DATA_DIR`` environment variable used during tests.
+_DATA_DIR = Path(os.environ.get("CHECKIN_DATA_DIR", "data"))
+
+
+def get_incident_db_path(incident_number: str | int | None) -> Path:
+    """Return the filesystem path for ``incident_number``'s database.
+
+    Parameters
+    ----------
+    incident_number:
+        Identifier for the incident.  ``None`` will raise ``RuntimeError``.
+
+    Returns
+    -------
+    Path
+        Fully qualified path to the incident SQLite database.  The path is not
+        created automatically; callers are expected to ensure the file exists
+        before attempting to connect.
+    """
+    if incident_number is None:
+        raise RuntimeError("Incident number is required")
+
+    base = _DATA_DIR / "incidents"
+    base.mkdir(parents=True, exist_ok=True)
+    safe = str(incident_number).strip().replace("/", "-")
+    return base / f"{safe}.db"
+
+
+__all__ = ["get_incident_db_path"]


### PR DESCRIPTION
## Summary
- add mission DB shim and incident channel schema utilities
- implement master and incident repositories with validation and preview support
- provide Qt controller, panel widget, and QML views for ICS-205 communications plan
- include geographic line rules helper stubs

## Testing
- `pytest -q` *(interrupt: ran for ~3min before manual stop)*

------
https://chatgpt.com/codex/tasks/task_b_68c107f581b8832b85b846ca83d8977b