### PR TITLE
Add notifications subsystem with toast and activity feed

### DIFF
--- a/notifications/__init__.py
+++ b/notifications/__init__.py
@@ -1,0 +1,3 @@
+from .services import Notifier, get_notifier
+
+__all__ = ["Notifier", "get_notifier"]

--- a/notifications/assets/sounds/README.md
+++ b/notifications/assets/sounds/README.md
@@ -1,0 +1,3 @@
+# Sound Assets
+
+Place notification sound files here, such as `notify_chime.wav`. These assets are not tracked in version control.

--- a/notifications/models/__init__.py
+++ b/notifications/models/__init__.py
@@ -1,0 +1,4 @@
+from .notification import Notification, Severity, ToastMode
+from .schema_sql import ensure_master_schema, ensure_mission_schema
+
+__all__ = ["Notification", "Severity", "ToastMode", "ensure_master_schema", "ensure_mission_schema"]

--- a/notifications/models/notification.py
+++ b/notifications/models/notification.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import Optional, Literal
+
+Severity = Literal['info', 'success', 'warning', 'error']
+ToastMode = Literal['auto', 'sticky']
+
+
+@dataclass
+class Notification:
+    title: str
+    message: str
+    severity: Severity = 'info'
+    source: str = 'System'
+    entity_type: Optional[str] = None
+    entity_id: Optional[str] = None
+    toast_mode: Optional[ToastMode] = None
+    toast_duration_ms: Optional[int] = None

--- a/notifications/models/schema_sql.py
+++ b/notifications/models/schema_sql.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterable
+
+
+MASTER_PREFS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS notification_preferences (
+    id INTEGER PRIMARY KEY,
+    toast_mode TEXT DEFAULT 'auto',
+    toast_duration_ms INTEGER DEFAULT 4500
+);
+"""
+
+MISSION_NOTIFICATIONS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS notifications (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts INTEGER,
+    title TEXT,
+    message TEXT,
+    severity TEXT,
+    source TEXT,
+    entity_type TEXT,
+    entity_id TEXT,
+    toast_mode TEXT,
+    toast_duration_ms INTEGER
+);
+"""
+
+MASTER_TABLES: Iterable[str] = (
+    """
+    CREATE TABLE IF NOT EXISTS notification_channels (
+        id INTEGER PRIMARY KEY,
+        name TEXT UNIQUE
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS notification_rules (
+        id INTEGER PRIMARY KEY,
+        channel TEXT,
+        rule TEXT
+    );
+    """,
+    MASTER_PREFS_SCHEMA,
+)
+
+
+def _ensure_column(conn: sqlite3.Connection, table: str, column: str, decl: str) -> None:
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    cols = [row[1] for row in cur]
+    if column not in cols:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+
+
+def ensure_master_schema(conn: sqlite3.Connection) -> None:
+    """Create master tables and new columns idempotently."""
+    for sql in MASTER_TABLES:
+        conn.execute(sql)
+    _ensure_column(conn, "notification_preferences", "toast_mode", "TEXT DEFAULT 'auto'")
+    _ensure_column(conn, "notification_preferences", "toast_duration_ms", "INTEGER DEFAULT 4500")
+
+
+def ensure_mission_schema(conn: sqlite3.Connection) -> None:
+    """Create mission notifications table and columns idempotently."""
+    conn.execute(MISSION_NOTIFICATIONS_SCHEMA)
+    _ensure_column(conn, "notifications", "toast_mode", "TEXT")
+    _ensure_column(conn, "notifications", "toast_duration_ms", "INTEGER")

--- a/notifications/panels/__init__.py
+++ b/notifications/panels/__init__.py
@@ -1,0 +1,3 @@
+from .notifications_panel import NotificationsPanel, get_notifications_panel
+
+__all__ = ["NotificationsPanel", "get_notifications_panel"]

--- a/notifications/panels/notifications_panel.py
+++ b/notifications/panels/notifications_panel.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from PySide6.QtCore import QUrl
+from PySide6.QtWidgets import QWidget, QVBoxLayout
+from PySide6.QtQuickWidgets import QQuickWidget
+
+from notifications.services import get_notifier
+from utils.app_signals import app_signals
+
+
+class NotificationsPanel(QWidget):
+    """Panel showing the notification activity feed."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.notifier = get_notifier()
+        layout = QVBoxLayout(self)
+        try:
+            layout.setContentsMargins(0, 0, 0, 0)
+        except Exception:
+            pass
+        self.view = QQuickWidget()
+        self.view.setResizeMode(QQuickWidget.SizeRootObjectToView)
+        qml_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "qml", "NotificationFeed.qml")
+        )
+        self.view.setSource(QUrl.fromLocalFile(qml_path))
+        layout.addWidget(self.view)
+
+        self.notifier.notificationCreated.connect(lambda *_: self.reload())
+        app_signals.incidentChanged.connect(lambda *_: self.reload())
+        self.reload()
+
+    def reload(self) -> None:
+        entries = self.notifier.recent()
+        root = self.view.rootObject()
+        if root is not None:
+            try:
+                root.setEntries(entries)
+            except Exception:
+                pass
+        self.notifier.clear_badge()
+
+
+def get_notifications_panel(parent: QWidget | None = None) -> NotificationsPanel:
+    return NotificationsPanel(parent)

--- a/notifications/qml/NotificationBanner.qml
+++ b/notifications/qml/NotificationBanner.qml
@@ -1,0 +1,24 @@
+import QtQuick 6.5
+import QtQuick.Controls 6.5
+
+Rectangle {
+    id: banner
+    width: parent.width
+    color: severity === "error" ? "#8B1E2D" : severity === "warning" ? "#9C6F19" : severity === "success" ? "#1E7F4F" : "#2C2C2C"
+    property string title
+    property string message
+    property string severity: "info"
+    signal dismissed
+    height: content.implicitHeight + 16
+
+    Column {
+        id: content
+        anchors.fill: parent
+        anchors.margins: 8
+        spacing: 4
+        Label { text: banner.title; color: "white"; font.bold: true }
+        Label { text: banner.message; color: "white"; wrapMode: Text.WordWrap }
+    }
+
+    MouseArea { anchors.fill: parent; onClicked: banner.dismissed() }
+}

--- a/notifications/qml/NotificationFeed.qml
+++ b/notifications/qml/NotificationFeed.qml
@@ -1,0 +1,32 @@
+import QtQuick 6.5
+import QtQuick.Controls 6.5
+
+ListView {
+    id: feed
+    width: parent.width
+    height: parent.height
+
+    model: feedModel
+    delegate: Rectangle {
+        width: parent.width
+        color: index % 2 === 0 ? "#2C2C2C" : "#333"
+        height: content.implicitHeight + 12
+        Column {
+            id: content
+            anchors.fill: parent
+            anchors.margins: 6
+            spacing: 2
+            Label { text: title; color: "white"; font.bold: true }
+            Label { text: message; color: "white"; wrapMode: Text.WordWrap }
+        }
+    }
+
+    ListModel { id: feedModel }
+
+    function setEntries(entries) {
+        feedModel.clear()
+        for (var i = 0; i < entries.length; ++i) {
+            feedModel.append(entries[i])
+        }
+    }
+}

--- a/notifications/qml/NotificationIcon.qml
+++ b/notifications/qml/NotificationIcon.qml
@@ -1,0 +1,14 @@
+import QtQuick 6.5
+
+Item {
+    id: icon
+    width: 16
+    height: 16
+    property string severity: "info"
+
+    Rectangle {
+        anchors.fill: parent
+        radius: 8
+        color: severity === "error" ? "#8B1E2D" : severity === "warning" ? "#9C6F19" : severity === "success" ? "#1E7F4F" : "#2C2C2C"
+    }
+}

--- a/notifications/qml/NotificationToast.qml
+++ b/notifications/qml/NotificationToast.qml
@@ -1,0 +1,37 @@
+import QtQuick 6.5
+import QtQuick.Controls 6.5
+
+Popup {
+    id: toast
+    property string mode: "auto"
+    property int durationMs: 4500
+    property string title
+    property string message
+    property string severity: "info"
+
+    signal dismissed
+
+    background: Rectangle {
+        radius: 10
+        color: severity === "error" ? "#8B1E2D" : severity === "warning" ? "#9C6F19" : severity === "success" ? "#1E7F4F" : "#2C2C2C"
+        opacity: 0.95
+    }
+    contentItem: Column {
+        spacing: 6; padding: 14
+        Row {
+            spacing: 10
+            Label { text: toast.title; font.bold: true; color: "white" }
+            Button { text: "✕"; onClicked: toast.close() }
+        }
+        Label { text: toast.message; color: "white"; wrapMode: Text.WordWrap; width: 320 }
+    }
+
+    Timer {
+        interval: toast.durationMs
+        running: toast.visible && toast.mode === "auto"
+        repeat: false
+        onTriggered: toast.close()
+    }
+
+    onClosed: dismissed()
+}

--- a/notifications/qml/ToastContainer.qml
+++ b/notifications/qml/ToastContainer.qml
@@ -1,0 +1,36 @@
+import QtQuick 6.5
+import QtQuick.Controls 6.5
+
+Item {
+    id: container
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    width: 360; height: parent.height
+
+    property int spacing: 8
+
+    Column {
+        id: stack
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        spacing: container.spacing
+        Repeater {
+            id: repeater
+            model: toastModel
+            delegate: NotificationToast {
+                mode: model.mode
+                durationMs: model.durationMs
+                title: model.title
+                message: model.message
+                severity: model.severity
+                onDismissed: toastModel.remove(index)
+            }
+        }
+    }
+
+    ListModel { id: toastModel }
+
+    function pushToast(payload) {
+        toastModel.insert(0, payload)
+    }
+}

--- a/notifications/services/__init__.py
+++ b/notifications/services/__init__.py
@@ -1,0 +1,12 @@
+from .notifier import Notifier, get_notifier
+from .rules_engine import RulesEngine
+from .scheduler import NotificationScheduler
+from .sound_player import SoundPlayer
+
+__all__ = [
+    "Notifier",
+    "get_notifier",
+    "RulesEngine",
+    "NotificationScheduler",
+    "SoundPlayer",
+]

--- a/notifications/services/notifier.py
+++ b/notifications/services/notifier.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import dataclasses
+import time
+from typing import List, Dict, Any
+
+from PySide6.QtCore import QObject, Signal
+
+from notifications.models.notification import Notification
+from notifications.models.schema_sql import ensure_master_schema, ensure_mission_schema
+from utils.context import master_db, require_incident_db
+from .sound_player import SoundPlayer
+from .rules_engine import RulesEngine
+from .scheduler import NotificationScheduler
+
+
+class Notifier(QObject):
+    """Central service for emitting notifications toasts/banners/feed."""
+
+    notificationCreated = Signal(dict)
+    showToast = Signal(dict)
+    showBanner = Signal(dict)
+    badgeCountChanged = Signal(int)
+
+    _instance: "Notifier | None" = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._recent: List[Dict[str, Any]] = []
+        self._badge = 0
+        self._throttle: Dict[tuple[str, str], float] = {}
+        self._load_preferences()
+        self.rules = RulesEngine(self)
+        self.scheduler = NotificationScheduler(self)
+
+        try:
+            from utils.app_signals import app_signals
+
+            app_signals.incidentChanged.connect(self._on_incident_changed)
+        except Exception:
+            pass
+
+    # ---- Singleton helpers -------------------------------------------------
+    @classmethod
+    def instance(cls) -> "Notifier":
+        if cls._instance is None:
+            cls._instance = Notifier()
+        return cls._instance
+
+    # ---- Preferences -------------------------------------------------------
+    def _load_preferences(self) -> None:
+        try:
+            conn = master_db()
+            ensure_master_schema(conn)
+            row = conn.execute(
+                "SELECT toast_mode, toast_duration_ms FROM notification_preferences LIMIT 1"
+            ).fetchone()
+            if not row:
+                conn.execute(
+                    "INSERT INTO notification_preferences (toast_mode, toast_duration_ms) VALUES ('auto', 4500)"
+                )
+                conn.commit()
+                row = conn.execute(
+                    "SELECT toast_mode, toast_duration_ms FROM notification_preferences LIMIT 1"
+                ).fetchone()
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        self._default_mode = row[0] if row and row[0] else "auto"
+        self._default_duration = row[1] if row and row[1] else 4500
+        self._play_sound = True
+
+    # ---- Incident change ---------------------------------------------------
+    def _on_incident_changed(self, *_: object) -> None:
+        # rebind or preload mission schema
+        try:
+            conn = require_incident_db()
+            ensure_mission_schema(conn)
+            conn.close()
+        except Exception:
+            pass
+
+    # ---- Public API --------------------------------------------------------
+    def notify(self, note: Notification) -> None:
+        payload = dataclasses.asdict(note)
+        if payload.get("toast_mode") is None:
+            payload["toast_mode"] = self._default_mode
+        if payload.get("toast_duration_ms") is None:
+            payload["toast_duration_ms"] = self._default_duration
+
+        key = (payload["title"], payload["message"])
+        now = time.time()
+        if key in self._throttle and now - self._throttle[key] < 2:
+            return
+        self._throttle[key] = now
+
+        self._recent.append(payload)
+        self._badge += 1
+        self.notificationCreated.emit(payload)
+        self.showToast.emit(payload)
+        self.badgeCountChanged.emit(self._badge)
+
+        if self._play_sound:
+            try:
+                SoundPlayer.instance().play()
+            except Exception:
+                pass
+
+        try:
+            self._persist(payload)
+        except Exception:
+            pass
+
+    def _persist(self, payload: Dict[str, Any]) -> None:
+        conn = require_incident_db()
+        ensure_mission_schema(conn)
+        conn.execute(
+            "INSERT INTO notifications (ts, title, message, severity, source, entity_type, entity_id, toast_mode, toast_duration_ms)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                int(time.time()),
+                payload.get("title"),
+                payload.get("message"),
+                payload.get("severity"),
+                payload.get("source"),
+                payload.get("entity_type"),
+                payload.get("entity_id"),
+                payload.get("toast_mode"),
+                payload.get("toast_duration_ms"),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+    def recent(self, limit: int = 50) -> List[Dict[str, Any]]:
+        try:
+            conn = require_incident_db()
+            ensure_mission_schema(conn)
+            cur = conn.execute(
+                "SELECT ts, title, message, severity, source, entity_type, entity_id, toast_mode, toast_duration_ms"
+                " FROM notifications ORDER BY ts DESC LIMIT ?",
+                (limit,),
+            )
+            rows = [dict(r) for r in cur.fetchall()]
+            conn.close()
+            return rows
+        except Exception:
+            return self._recent[-limit:]
+
+    def clear_badge(self) -> None:
+        self._badge = 0
+        self.badgeCountChanged.emit(0)
+
+
+# convenient alias
+get_notifier = Notifier.instance

--- a/notifications/services/rules_engine.py
+++ b/notifications/services/rules_engine.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, Any, List
+
+
+class RulesEngine:
+    """Very small rules engine placeholder."""
+
+    def __init__(self, notifier) -> None:
+        self.notifier = notifier
+        self._rules: List[Callable[[Dict[str, Any]], None]] = []
+
+    def add_rule(self, func: Callable[[Dict[str, Any]], None]) -> None:
+        self._rules.append(func)
+
+    def evaluate(self, context: Dict[str, Any]) -> None:
+        for rule in list(self._rules):
+            try:
+                rule(context)
+            except Exception:
+                pass

--- a/notifications/services/scheduler.py
+++ b/notifications/services/scheduler.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import threading
+from typing import Callable, List
+
+
+class NotificationScheduler:
+    """Simple scheduler for delayed notifications."""
+
+    def __init__(self, notifier) -> None:
+        self.notifier = notifier
+        self._timers: List[threading.Timer] = []
+
+    def schedule(self, seconds: float, func: Callable, *args, **kwargs) -> threading.Timer:
+        timer = threading.Timer(seconds, func, args=args, kwargs=kwargs)
+        timer.start()
+        self._timers.append(timer)
+        return timer
+
+    def cancel_all(self) -> None:
+        for t in self._timers:
+            t.cancel()
+        self._timers.clear()

--- a/notifications/services/sound_player.py
+++ b/notifications/services/sound_player.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+
+from PySide6.QtCore import QObject, QUrl
+from PySide6.QtMultimedia import QSoundEffect
+
+
+class SoundPlayer(QObject):
+    """Play notification sounds respecting user preferences."""
+
+    _instance: "SoundPlayer | None" = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._effect = QSoundEffect()
+        try:
+            base = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "assets", "sounds", "notify_chime.wav"))
+            self._effect.setSource(QUrl.fromLocalFile(base))
+        except Exception:
+            pass
+
+    def play(self) -> None:
+        try:
+            self._effect.play()
+        except Exception:
+            pass
+
+    @classmethod
+    def instance(cls) -> "SoundPlayer":
+        if cls._instance is None:
+            cls._instance = SoundPlayer()
+        return cls._instance


### PR DESCRIPTION
## Summary
- Introduce modular `notifications/` package with data models, services, QML, and sound assets
- Implement `Notifier` singleton with toast, banner, feed signals and mission DB persistence
- Add QML toast stack and activity feed panel; integrate toast overlay into main window
- Replace committed `notify_chime.wav` with documentation so sound files can be supplied externally

## Testing
- `python -m py_compile notifications/models/notification.py notifications/models/schema_sql.py notifications/services/notifier.py notifications/services/rules_engine.py notifications/services/scheduler.py notifications/services/sound_player.py notifications/panels/notifications_panel.py`
- `pytest tests/test_state.py`


------
https://chatgpt.com/codex/tasks/task_b_68c10bd9df10832bbfc15c36862cc951