### PR TITLE
Address feedback for Add ICS-205 communications planning module

### DIFF
--- a/modules/communications/models/incident_repo.py
+++ b/modules/communications/models/incident_repo.py
@@ -97,7 +97,7 @@ class IncidentRepository:
                     repeater, offset, encryption, assignment_division, assignment_team,
                     priority, include_on_205, remarks, sort_index, line_a, line_c,
                     created_at, updated_at
-                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """,
                 (
                     master_row.get("id"),


### PR DESCRIPTION
## Summary
- fix placeholder mismatch in incident channel insertion

## Testing
- `python -m py_compile modules/communications/models/incident_repo.py`
- `pytest -q` *(fails: KeyboardInterrupt after 5+ min)*

------
https://chatgpt.com/codex/tasks/task_b_68c1102a13d8832bb734135766d08acc