### PR TITLE
Add notifications subsystem with toast and activity feed

### DIFF
--- a/notifications/qml/NotificationToast.qml
+++ b/notifications/qml/NotificationToast.qml
@@ -33,5 +33,7 @@ Popup {
         onTriggered: toast.close()
     }
 
+    Component.onCompleted: toast.open()
+
     onClosed: dismissed()
 }


### PR DESCRIPTION
## Summary
- open toast popup on completion so notifications are visible

## Testing
- `python -m py_compile notifications/models/notification.py notifications/models/schema_sql.py notifications/services/notifier.py notifications/services/rules_engine.py notifications/services/scheduler.py notifications/services/sound_player.py notifications/panels/notifications_panel.py`
- `pytest tests/test_state.py`


------
https://chatgpt.com/codex/tasks/task_b_68c1145de838832b91ffc1018f932cd1