### PR TITLE
feat(ui): scaffold QtWidgets edit dialogs

### DIFF
--- a/ui/edit/base_dialog.py
+++ b/ui/edit/base_dialog.py
@@ -140,9 +140,17 @@ class BaseEditDialog(QDialog):
         self.search.setShortcut(QKeySequence.Find)
         self.table.addAction(self.act_delete)
 
+        self._connect_selection_model()
+
         self._update_action_states()
 
     # ------------------------------------------------------------------ configuration
+
+    def _connect_selection_model(self) -> None:
+        self.table.selectionModel().selectionChanged.connect(
+            lambda *_: self._update_action_states()
+        )
+
     def set_columns(self, columns: Iterable[tuple[str, str]]) -> None:
         self._columns = [ColumnSpec(*c) for c in columns]
         self._model = DictTableModel(self._columns, [])
@@ -151,6 +159,7 @@ class BaseEditDialog(QDialog):
         self._proxy.setFilterCaseSensitivity(Qt.CaseInsensitive)
         self._proxy.setFilterKeyColumn(-1)  # search all
         self.table.setModel(self._proxy)
+        self._connect_selection_model()
 
     def set_adapter(self, adapter: Any) -> None:
         self._adapter = adapter


### PR DESCRIPTION
## Summary
- add BaseEditDialog framework and SearchLineEdit widget
- implement RolesEditor backed by master database
- wire Edit menu to new QtWidgets dialogs
- update toolbar actions when table selection changes

## Testing
- `python -m py_compile ui/edit/*.py`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_68c21d7a7e98832b9673bc3480b5f44a