### PR TITLE
Add basic forms-to-PDF renderer with template registry

### DIFF
--- a/data/templates/ics/ICS_205_v2023.10.map.yaml
+++ b/data/templates/ics/ICS_205_v2023.10.map.yaml
@@ -1,0 +1,5 @@
+form: ics_205
+version: 2023.10
+fields:
+  "Incident Name": incident.name
+  "Operational Period": operational_period.label

--- a/data/templates/registry.json
+++ b/data/templates/registry.json
@@ -1,0 +1,9 @@
+{
+  "ics_205": {
+    "2023.10": {
+      "mapping": "data/templates/ics/ICS_205_v2023.10.map.yaml",
+      "schema": "modules/forms/schemas/ics_205.schema.json"
+    },
+    "latest": "2023.10"
+  }
+}

--- a/modules/forms/README.md
+++ b/modules/forms/README.md
@@ -1,0 +1,19 @@
+# Forms Renderer
+
+Utility package for converting ICS JSON form exports into PDF documents. This
+implementation is intentionally small and focuses on the minimal features needed
+for tests. Templates are discovered via ``data/templates/registry.json`` and
+mapped using a small YAML based DSL.
+
+Example:
+
+```python
+from modules.forms import render_form
+from modules.forms.examples import ics_205_example
+
+pdf_bytes = render_form(
+    form_id="ics_205",
+    form_version="2023.10",
+    data=ics_205_example,
+)
+```

--- a/modules/forms/__init__.py
+++ b/modules/forms/__init__.py
@@ -1,0 +1,8 @@
+"""Forms-to-PDF rendering package.
+
+Provides :func:`render_form` for filling ICS forms to PDF.
+"""
+
+from .render import render_form
+
+__all__ = ["render_form"]

--- a/modules/forms/__main__.py
+++ b/modules/forms/__main__.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .render import render_form
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render ICS forms to PDF")
+    parser.add_argument("--form", required=True, help="Form id, e.g., ics_205")
+    parser.add_argument("--version", required=True, help="Template version, e.g., 2023.10")
+    parser.add_argument("--infile", dest="in_file", required=True, help="Input JSON file")
+    parser.add_argument("--out", dest="out_file", required=True, help="Output PDF path")
+    parser.add_argument("--no-flatten", dest="flatten", action="store_false", help="Do not flatten form fields")
+    args = parser.parse_args()
+
+    data = json.loads(Path(args.in_file).read_text())
+    pdf_bytes = render_form(args.form, args.version, data, options={"flatten": args.flatten})
+    out_path = Path(args.out_file)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(pdf_bytes)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/forms/examples/__init__.py
+++ b/modules/forms/examples/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_205_path = Path(__file__).with_name("ics_205.example.json")
+ics_205_example = json.loads(_205_path.read_text())
+
+__all__ = ["ics_205_example"]

--- a/modules/forms/examples/ics_205.example.json
+++ b/modules/forms/examples/ics_205.example.json
@@ -1,0 +1,8 @@
+{
+  "incident": {
+    "name": "Example Incident"
+  },
+  "operational_period": {
+    "label": "OP1"
+  }
+}

--- a/modules/forms/overlay.py
+++ b/modules/forms/overlay.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Dict, Any
+
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+
+def render_overlay(field_values: Dict[str, Any]) -> bytes:
+    """Simple overlay renderer used when no template is available.
+
+    Draws each field on its own line. This is a minimal implementation
+    intended primarily for tests and as a fallback.
+    """
+    buffer = BytesIO()
+    c = canvas.Canvas(buffer, pagesize=letter)
+    y = 750
+    for key, value in field_values.items():
+        c.drawString(72, y, f"{key}: {value}")
+        y -= 20
+        if y < 72:
+            c.showPage()
+            y = 750
+    c.save()
+    return buffer.getvalue()

--- a/modules/forms/pdf_fill.py
+++ b/modules/forms/pdf_fill.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+from typing import Dict, Any
+
+from pypdf import PdfReader, PdfWriter
+
+
+def fill_pdf(template_path: Path, field_values: Dict[str, Any], flatten: bool = True) -> bytes:
+    """Fill ``field_values`` into ``template_path`` and return PDF bytes."""
+    reader = PdfReader(str(template_path))
+    writer = PdfWriter()
+    writer.clone_reader_document_root(reader)
+    writer.update_page_form_field_values(writer.pages[0], field_values)
+    if flatten:
+        writer.remove_annotations(None)
+    buffer = BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()

--- a/modules/forms/render.py
+++ b/modules/forms/render.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+import json
+
+from .templating import resolve_template, load_mapping
+from .pdf_fill import fill_pdf
+from .overlay import render_overlay
+
+try:
+    from jsonschema import Draft7Validator
+except Exception:  # pragma: no cover - jsonschema is required
+    Draft7Validator = None  # type: ignore
+
+
+class FormValidationError(Exception):
+    """Raised when input JSON fails schema validation."""
+
+
+@dataclass
+class RenderOptions:
+    flatten: bool = True
+    preview_png: bool = False
+
+
+# helper to access nested dict via dot notation
+
+def _get_value(data: Dict[str, Any], path: str) -> Any:
+    current: Any = data
+    for part in path.split('.'):  # simple dot notation
+        if isinstance(current, list):
+            # allow numeric index
+            try:
+                idx = int(part)
+            except ValueError:
+                raise KeyError(path)
+            current = current[idx]
+        else:
+            current = current.get(part)
+        if current is None:
+            break
+    return current
+
+
+def _apply_mapping(data: Dict[str, Any], mapping: Dict[str, Any]) -> Dict[str, Any]:
+    values: Dict[str, Any] = {}
+    fields = mapping.get('fields', {})
+    for target, source in fields.items():
+        if isinstance(source, str):
+            values[target] = _get_value(data, source)
+        else:
+            # unsupported expression; ignore for now
+            values[target] = None
+    return values
+
+
+def render_form(
+    form_id: str,
+    form_version: str,
+    data: Dict[str, Any],
+    options: Optional[Dict[str, Any]] = None,
+) -> bytes:
+    """Render ``data`` for the given ``form_id`` and ``form_version``.
+
+    Parameters
+    ----------
+    form_id: str
+        Identifier such as ``"ics_205"``.
+    form_version: str
+        Template version, e.g. ``"2023.10"`` or ``"latest"``.
+    data: Dict[str, Any]
+        JSON-like dictionary with form values.
+    options: Optional[Dict[str, Any]]
+        Rendering options. Currently supports ``flatten``.
+    """
+
+    template = resolve_template(form_id, form_version)
+
+    # Schema validation
+    if template.schema_path and Draft7Validator is not None:
+        schema = json.loads(template.schema_path.read_text())
+        validator = Draft7Validator(schema)
+        errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+        if errors:
+            messages = "; ".join(f"{'.'.join(str(x) for x in err.path)}: {err.message}" for err in errors)
+            raise FormValidationError(messages)
+
+    mapping = load_mapping(template.mapping_path)
+    field_values = _apply_mapping(data, mapping)
+
+    if template.pdf_path and template.pdf_path.exists():
+        pdf_bytes = fill_pdf(template.pdf_path, field_values, flatten=options.get('flatten', True) if options else True)
+    else:
+        pdf_bytes = render_overlay(field_values)
+    return pdf_bytes
+

--- a/modules/forms/schemas/ics_205.schema.json
+++ b/modules/forms/schemas/ics_205.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ICS 205 Communications Plan",
+  "type": "object",
+  "required": ["incident", "operational_period"],
+  "properties": {
+    "incident": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {"type": "string"}
+      }
+    },
+    "operational_period": {
+      "type": "object",
+      "required": ["label"],
+      "properties": {
+        "label": {"type": "string"}
+      }
+    }
+  }
+}

--- a/modules/forms/templating.py
+++ b/modules/forms/templating.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+import yaml
+
+REGISTRY_PATH = Path("data/templates/registry.json")
+
+
+@dataclass
+class TemplateInfo:
+    pdf_path: Optional[Path]
+    mapping_path: Path
+    schema_path: Path
+
+
+def load_registry() -> Dict[str, Any]:
+    if not REGISTRY_PATH.exists():
+        return {}
+    with REGISTRY_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def resolve_template(form_id: str, version: str) -> TemplateInfo:
+    registry = load_registry()
+    form_entry = registry.get(form_id)
+    if not form_entry:
+        raise KeyError(f"Unknown form: {form_id}")
+    info = form_entry.get(version)
+    if isinstance(info, str):  # alias e.g. "latest"
+        info = form_entry.get(info)
+    if not info:
+        raise KeyError(f"Unknown version: {form_id}:{version}")
+    pdf = Path(info["pdf"]) if "pdf" in info else None
+    mapping = Path(info["mapping"])
+    schema = Path(info["schema"])
+    return TemplateInfo(pdf, mapping, schema)
+
+
+def load_mapping(mapping_path: Path) -> Dict[str, Any]:
+    with mapping_path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@ PySide6
 fastapi
 pydantic
 reportlab
+pypdf
+jsonschema
+PyYAML
 PySide6-QtAds
 httpx
 sqlalchemy

--- a/tests/test_forms_module.py
+++ b/tests/test_forms_module.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.forms import render_form
+from modules.forms.templating import resolve_template
+from modules.forms.render import FormValidationError
+from modules.forms.examples import ics_205_example
+
+
+def test_registry_resolution():
+    info = resolve_template("ics_205", "latest")
+    assert info.pdf_path is None or not info.pdf_path.exists()
+    assert info.mapping_path.exists()
+    assert info.schema_path.exists()
+
+
+def test_render_form_produces_pdf(tmp_path: Path):
+    pdf_bytes = render_form("ics_205", "2023.10", ics_205_example)
+    out = tmp_path / "out.pdf"
+    out.write_bytes(pdf_bytes)
+    assert out.stat().st_size > 0
+
+
+def test_schema_validation_error():
+    bad = json.loads(json.dumps(ics_205_example))
+    del bad["incident"]["name"]
+    with pytest.raises(FormValidationError):
+        render_form("ics_205", "2023.10", bad)


### PR DESCRIPTION
## Summary
- introduce `forms_renderer` package with registry and mapping support
- add minimal PDF filler/overlay engines and example ICS-205 template
- provide CLI entry point and basic unit tests
- move renderer package under `modules/forms`
- remove bundled PDF template and handle missing templates in registry and renderer

## Testing
- `pytest tests/test_forms_module.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c51b744278832b89266ca816a6ce2c