### PR TITLE
Add toolbar icon assets for form creator

### DIFF
--- a/modules/forms_creator/__init__.py
+++ b/modules/forms_creator/__init__.py
@@ -1,0 +1,5 @@
+"""SARApp Form Creator package."""
+
+from .services.templates import FormService
+
+__all__ = ["FormService"]

--- a/modules/forms_creator/assets/__init__.py
+++ b/modules/forms_creator/assets/__init__.py
@@ -1,0 +1,14 @@
+"""Asset utilities for the form creator module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_ASSET_ROOT = Path(__file__).resolve().parent
+
+
+def get_asset_path(name: str) -> Path:
+    """Return the absolute path to an asset bundled with the module."""
+
+    return _ASSET_ROOT / name

--- a/modules/forms_creator/assets/export.svg
+++ b/modules/forms_creator/assets/export.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#b02a37"/>
+  <path d="M15 6h2v12.2l4.1-4.1 1.4 1.4L16 22l-6.5-6.5 1.4-1.4 4.1 4.1z" fill="#ffffff"/>
+  <rect x="8" y="22" width="16" height="4" rx="1" fill="#f2a3ac"/>
+</svg>

--- a/modules/forms_creator/assets/new.svg
+++ b/modules/forms_creator/assets/new.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1b6ef3"/>
+  <path d="M15 8h2v6h6v2h-6v6h-2v-6H9v-2h6z" fill="#ffffff"/>
+</svg>

--- a/modules/forms_creator/assets/open.svg
+++ b/modules/forms_creator/assets/open.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0a8f6a"/>
+  <path d="M7 10.5h8l1.4 2.8H25l-2 10.7a2 2 0 0 1-2 1.6H9a2 2 0 0 1-2-2z" fill="#ffffff"/>
+  <path d="M7 9a2 2 0 0 1 2-2h6l1.5 3H7z" fill="#c2f1de"/>
+</svg>

--- a/modules/forms_creator/assets/preview.svg
+++ b/modules/forms_creator/assets/preview.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#6f42c1"/>
+  <path d="M5.5 16c2.4-4.7 6.4-7.5 10.5-7.5S24 11.3 26.5 16c-2.4 4.7-6.4 7.5-10.5 7.5S7.9 20.7 5.5 16z" fill="#ffffff"/>
+  <circle cx="16" cy="16" r="4" fill="#6f42c1"/>
+  <circle cx="16" cy="16" r="2" fill="#ffffff"/>
+</svg>

--- a/modules/forms_creator/assets/save.svg
+++ b/modules/forms_creator/assets/save.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#f08a24"/>
+  <path d="M9 6h13l3 3v17a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2z" fill="#ffffff"/>
+  <rect x="11" y="11" width="10" height="8" rx="1" fill="#f08a24" opacity="0.35"/>
+  <path d="M11 6h8v6h-8z" fill="#fbd3aa"/>
+</svg>

--- a/modules/forms_creator/assets/zoom_in.svg
+++ b/modules/forms_creator/assets/zoom_in.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1f9ed0"/>
+  <circle cx="14" cy="14" r="8" fill="#ffffff"/>
+  <path d="M13 10h2v3h3v2h-3v3h-2v-3H10v-2h3z" fill="#1f9ed0"/>
+  <rect x="20" y="20" width="8" height="2" rx="1" transform="rotate(45 24 21)" fill="#ffffff"/>
+</svg>

--- a/modules/forms_creator/assets/zoom_out.svg
+++ b/modules/forms_creator/assets/zoom_out.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#157291"/>
+  <circle cx="14" cy="14" r="8" fill="#ffffff"/>
+  <rect x="11" y="13" width="6" height="2" rx="1" fill="#157291"/>
+  <rect x="20" y="20" width="8" height="2" rx="1" transform="rotate(45 24 21)" fill="#ffffff"/>
+</svg>

--- a/modules/forms_creator/assets/zoom_reset.svg
+++ b/modules/forms_creator/assets/zoom_reset.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0d6efd"/>
+  <circle cx="16" cy="16" r="10" fill="#ffffff"/>
+  <circle cx="16" cy="16" r="4" fill="#0d6efd"/>
+  <path d="M16 8v2m0 12v2m8-8h-2M10 16H8" stroke="#0d6efd" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/modules/forms_creator/models/__init__.py
+++ b/modules/forms_creator/models/__init__.py
@@ -1,0 +1,124 @@
+"""Datamodels for the SARApp form creator module.
+
+The dataclasses defined in this module describe the hybrid JSON structures
+stored in the SQLite databases.  They are intentionally lightweight so they
+can be easily serialised/deserialised without pulling in heavy ORM
+dependencies.  The service layer primarily works with primitive dictionaries
+so that existing modules that expect JSON friendly structures can continue to
+operate without modification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal, Optional
+
+
+BindingSource = Literal["static", "system"]
+ValidationType = Literal["required", "regex", "range", "set"]
+FieldType = Literal[
+    "text",
+    "multiline",
+    "date",
+    "time",
+    "checkbox",
+    "radio",
+    "dropdown",
+    "signature",
+    "image",
+    "table",
+]
+
+
+@dataclass(slots=True)
+class Binding:
+    """Describes a binding between a field and a data source."""
+
+    source_type: BindingSource
+    source_ref: str
+    value: Optional[str] = None
+
+
+@dataclass(slots=True)
+class ValidationRule:
+    """Validation rule to be applied to a field value."""
+
+    rule_type: ValidationType
+    rule_config: dict[str, Any]
+    error_message: str
+
+
+@dataclass(slots=True)
+class FieldConfig:
+    """Holds additional configuration for a field."""
+
+    bindings: list[Binding] = field(default_factory=list)
+    validations: list[ValidationRule] = field(default_factory=list)
+    dropdown: Optional[dict[str, Any]] = None
+    table: Optional[dict[str, Any]] = None
+
+
+@dataclass(slots=True)
+class Field:
+    """Representation of a single form field."""
+
+    id: Optional[int]
+    page: int
+    name: str
+    type: FieldType
+    x: float
+    y: float
+    width: float
+    height: float
+    font_family: str = ""
+    font_size: int = 10
+    align: str = "left"
+    required: bool = False
+    placeholder: str = ""
+    mask: str = ""
+    default_value: str = ""
+    config: FieldConfig = field(default_factory=FieldConfig)
+
+
+@dataclass(slots=True)
+class Template:
+    """Template metadata stored in the master database."""
+
+    id: Optional[int]
+    name: str
+    category: Optional[str]
+    subcategory: Optional[str]
+    version: int
+    background_path: str
+    page_count: int
+    schema_version: int
+    fields: list[Field]
+    created_at: datetime
+    updated_at: datetime
+    is_active: bool = True
+
+
+@dataclass(slots=True)
+class FormInstance:
+    """Concrete instance of a template stored within an incident database."""
+
+    id: Optional[int]
+    incident_id: str
+    template_id: int
+    template_version: int
+    status: str
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(slots=True)
+class InstanceValue:
+    """Value captured for a field within a form instance."""
+
+    id: Optional[int]
+    instance_id: int
+    field_id: int
+    value: Any
+    created_at: datetime
+    updated_at: datetime

--- a/modules/forms_creator/run_forms_creator.py
+++ b/modules/forms_creator/run_forms_creator.py
@@ -1,0 +1,20 @@
+"""Development launcher for the form creator workspace."""
+
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtWidgets import QApplication
+
+from .ui.MainWindow import MainWindow
+
+
+def main() -> int:
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch helper
+    raise SystemExit(main())

--- a/modules/forms_creator/scripts/dev_seed.py
+++ b/modules/forms_creator/scripts/dev_seed.py
@@ -1,0 +1,102 @@
+"""Seed the databases with a minimal demo template and instance."""
+
+from __future__ import annotations
+
+import struct
+import sys
+import uuid
+import zlib
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.append(str(Path(__file__).resolve().parents[3]))
+    from modules.forms_creator.services.templates import FormService  # type: ignore  # noqa: E402
+else:
+    from ..services.templates import FormService
+
+
+def main() -> None:
+    try:
+        service = FormService()
+    except RuntimeError as exc:
+        print(f"Unable to initialise form service: {exc}")
+        return
+
+    template_uuid = uuid.uuid4().hex
+    template_dir = service.templates_dir / template_uuid
+    template_dir.mkdir(parents=True, exist_ok=True)
+
+    background = template_dir / "background_page_001.png"
+    _write_blank_png(background, 800, 600)
+
+    field = {
+        "id": 1,
+        "page": 1,
+        "name": "incident_commander",
+        "type": "text",
+        "x": 120,
+        "y": 140,
+        "width": 260,
+        "height": 28,
+        "font_family": "",
+        "font_size": 12,
+        "align": "left",
+        "required": True,
+        "placeholder": "",
+        "mask": "",
+        "default_value": "",
+        "config": {
+            "bindings": [
+                {"source_type": "system", "source_ref": "incident.ic_name"},
+            ],
+            "validations": [
+                {"rule_type": "required", "rule_config": {}, "error_message": "Provide a name"}
+            ],
+            "dropdown": None,
+            "table": None,
+        },
+    }
+
+    background_rel = Path("forms") / "templates" / template_uuid
+    template_id = service.save_template(
+        name="ICS 201 Demo",
+        category="ICS",
+        subcategory="Cover",
+        background_path=str(background_rel),
+        page_count=1,
+        fields=[field],
+    )
+
+    context = {"incident": {"ic_name": "Chief Ranger"}}
+    incident_id = "INC-DEMO"
+    instance_id = service.create_instance(incident_id, template_id, context)
+    service.save_instance_value(instance_id, field["id"], "Chief Ranger", incident_id=incident_id)
+
+    output_pdf = template_dir / "demo_instance.pdf"
+    try:
+        service.export_instance_pdf(incident_id, instance_id, output_pdf)
+        print(f"Seeded template {template_id} with instance {instance_id} → {output_pdf}")
+    except RuntimeError as exc:
+        print(f"Seeded template {template_id} with instance {instance_id} (PDF export skipped: {exc})")
+
+
+def _write_blank_png(path: Path, width: int, height: int, color: tuple[int, int, int] = (255, 255, 255)) -> None:
+    """Write a simple opaque PNG without relying on GUI libraries."""
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return struct.pack("!I", len(data)) + tag + data + struct.pack("!I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+    raw = bytearray()
+    row = bytes(color) * width
+    for _ in range(height):
+        raw.append(0)
+        raw.extend(row)
+    png = bytearray(b"\x89PNG\r\n\x1a\n")
+    png.extend(chunk(b"IHDR", struct.pack("!IIBBBBB", width, height, 8, 2, 0, 0, 0)))
+    png.extend(chunk(b"IDAT", zlib.compress(bytes(raw))))
+    png.extend(chunk(b"IEND", b""))
+    path.write_bytes(bytes(png))
+
+
+if __name__ == "__main__":  # pragma: no cover - helper script
+    main()

--- a/modules/forms_creator/services/__init__.py
+++ b/modules/forms_creator/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer helpers for the form creator."""
+
+from .templates import FormService
+
+__all__ = ["FormService"]

--- a/modules/forms_creator/services/binder.py
+++ b/modules/forms_creator/services/binder.py
@@ -1,0 +1,98 @@
+"""Binding utilities used by the form creator module.
+
+Bindings allow authors to connect a field to structured data that is available
+elsewhere in the application.  The implementation below purposefully keeps the
+resolver tiny yet expressive: dotted paths are expanded against regular Python
+mappings and attribute-bearing objects.  Additional providers can be registered
+at runtime to support dynamic keys (for example, computed summaries).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class SystemBinding:
+    """Simple descriptor used to populate UI widgets."""
+
+    key: str
+    label: str
+    description: str | None = None
+
+
+class Binder:
+    """Resolve dotted keys against context dictionaries."""
+
+    #: Minimal catalogue of useful keys.  Additional items may be registered at
+    #: runtime by instantiating :class:`Binder` with custom ``system_keys``.
+    DEFAULT_SYSTEM_KEYS: tuple[SystemBinding, ...] = (
+        SystemBinding("incident.ic_name", "Incident Commander", "Primary incident commander name"),
+        SystemBinding("incident.number", "Incident Number", "Official incident identifier"),
+        SystemBinding("incident.op_period", "Operational Period", None),
+        SystemBinding("incident.location", "Incident Location", None),
+        SystemBinding("planning.scribe", "Planning Scribe", None),
+        SystemBinding("teams.current.team_id", "Current Team ID", None),
+    )
+
+    def __init__(self, *, system_keys: tuple[SystemBinding, ...] | None = None):
+        self._system_keys = system_keys or self.DEFAULT_SYSTEM_KEYS
+        self._providers: dict[str, Callable[[Mapping[str, Any]], Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Registration helpers
+    # ------------------------------------------------------------------
+    def register_provider(self, prefix: str, provider: Callable[[Mapping[str, Any]], Any]) -> None:
+        """Register a callable that resolves dotted keys with the given prefix."""
+
+        self._providers[prefix] = provider
+
+    # ------------------------------------------------------------------
+    # Lookup helpers
+    # ------------------------------------------------------------------
+    def available_keys(self) -> list[SystemBinding]:
+        """Return the list of known system binding keys."""
+
+        return list(self._system_keys)
+
+    # ------------------------------------------------------------------
+    def resolve(self, context: Mapping[str, Any], dotted_key: str) -> Any:
+        """Resolve ``dotted_key`` using ``context`` and registered providers."""
+
+        dotted_key = dotted_key.strip()
+        if not dotted_key:
+            raise ValueError("binding key cannot be blank")
+
+        # Provider lookup
+        for prefix, provider in self._providers.items():
+            if dotted_key == prefix or dotted_key.startswith(prefix + "."):
+                return provider(context)
+
+        parts = dotted_key.split(".")
+        current: Any = context
+        for part in parts:
+            if isinstance(current, Mapping):
+                if part not in current:
+                    raise KeyError(f"Unable to resolve '{dotted_key}' (missing key '{part}')")
+                current = current[part]
+            else:
+                if not hasattr(current, part):
+                    raise KeyError(
+                        f"Unable to resolve '{dotted_key}' (object {current!r} has no attribute '{part}')"
+                    )
+                current = getattr(current, part)
+                if callable(current):
+                    current = current()
+        return current
+
+
+# Convenience singleton for modules that prefer a simple functional interface.
+_default_binder = Binder()
+
+
+def resolve(context: Mapping[str, Any], dotted_key: str) -> Any:
+    """Resolve a dotted key using the default binder instance."""
+
+    return _default_binder.resolve(context, dotted_key)

--- a/modules/forms_creator/services/db.py
+++ b/modules/forms_creator/services/db.py
@@ -1,0 +1,133 @@
+"""SQLite helper utilities for the form creator module.
+
+The module exposes convenience functions that return SQLite connections with
+consistent pragmas and schema initialisation logic.  All paths are resolved
+relative to the repository's ``data`` directory to keep the application
+self-contained and offline friendly.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator, Iterable
+
+
+DATA_DIR = Path("data")
+MASTER_DB_PATH = DATA_DIR / "master.db"
+INCIDENTS_DIR = DATA_DIR / "incidents"
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    """Return a SQLite connection with standard pragmas enabled."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON;")
+    conn.execute("PRAGMA journal_mode = WAL;")
+    return conn
+
+
+def init_master_db() -> None:
+    """Initialise the master database schema if it does not already exist."""
+
+    with get_master_connection() as conn:
+        try:
+            conn.executescript(_create_template_sql("form_templates"))
+        except sqlite3.OperationalError:
+            # Existing projects may already have a legacy table named ``form_templates``.
+            # The service layer will detect this situation and fall back to an
+            # alternate table name without raising during initialisation.
+            pass
+
+
+def ensure_incident_db(incident_id: str) -> Path:
+    """Ensure the database for ``incident_id`` exists and has the proper schema."""
+
+    safe_id = incident_id.strip()
+    if not safe_id:
+        raise ValueError("incident_id cannot be empty")
+
+    db_path = INCIDENTS_DIR / f"{safe_id}.db"
+    with get_incident_connection(safe_id) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS form_instances (
+              id INTEGER PRIMARY KEY,
+              incident_id TEXT NOT NULL,
+              template_id INTEGER NOT NULL,
+              template_version INTEGER NOT NULL,
+              status TEXT NOT NULL DEFAULT 'draft',
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS instance_values (
+              id INTEGER PRIMARY KEY,
+              instance_id INTEGER NOT NULL,
+              field_id INTEGER NOT NULL,
+              value TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL,
+              FOREIGN KEY(instance_id) REFERENCES form_instances(id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_instance_values_instance ON instance_values(instance_id);
+            """
+        )
+    return db_path
+
+
+@contextmanager
+def get_master_connection() -> Generator[sqlite3.Connection, None, None]:
+    """Yield a connection to the master database, ensuring the schema exists."""
+
+    conn = _connect(MASTER_DB_PATH)
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@contextmanager
+def get_incident_connection(incident_id: str) -> Generator[sqlite3.Connection, None, None]:
+    """Yield a connection to the per-incident database."""
+
+    safe_id = incident_id.strip()
+    if not safe_id:
+        raise ValueError("incident_id cannot be empty")
+
+    conn = _connect(INCIDENTS_DIR / f"{safe_id}.db")
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def iter_dict_rows(cursor: sqlite3.Cursor, columns: Iterable[str]) -> list[dict]:
+    """Helper that converts a cursor result set to dictionaries."""
+
+    return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+
+def _create_template_sql(table_name: str) -> str:
+    return f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+          id INTEGER PRIMARY KEY,
+          name TEXT NOT NULL,
+          category TEXT,
+          subcategory TEXT,
+          version INTEGER NOT NULL DEFAULT 1,
+          background_path TEXT NOT NULL,
+          page_count INTEGER NOT NULL,
+          schema_version INTEGER NOT NULL DEFAULT 1,
+          fields_json TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          is_active INTEGER NOT NULL DEFAULT 1
+        );
+        CREATE INDEX IF NOT EXISTS idx_{table_name}_name ON {table_name}(name);
+        CREATE INDEX IF NOT EXISTS idx_{table_name}_cat ON {table_name}(category, subcategory);
+    """

--- a/modules/forms_creator/services/exporter.py
+++ b/modules/forms_creator/services/exporter.py
@@ -1,0 +1,174 @@
+"""PDF export utilities for the form creator module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+
+class PDFExporter:
+    """Render form instances to PDF using QPainter."""
+
+    def __init__(self, *, base_data_dir: Path | str = Path("data")) -> None:
+        self.base_data_dir = Path(base_data_dir)
+        self._qt = None
+
+    # ------------------------------------------------------------------
+    def export_instance(self, template: dict[str, Any], values: dict[int, Any], out_path: Path) -> Path:
+        """Composite background pages with field overlays."""
+
+        out_path = Path(out_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+        qt = self._require_qt()
+
+        writer = qt.QPdfWriter(str(out_path))
+        writer.setResolution(300)
+
+        painter = qt.QPainter(writer)
+        try:
+            for index in range(template.get("page_count", 1)):
+                page_number = index + 1
+                background = self._page_background(template, page_number)
+                image = qt.QImage(str(background))
+                if image.isNull():
+                    raise FileNotFoundError(f"Background image missing: {background}")
+
+                if index == 0:
+                    page_size = qt.QPageSize(qt.QSizeF(image.width(), image.height()), qt.QPageSize.Unit.Point)
+                    layout = qt.QPageLayout(
+                        page_size, qt.QPageLayout.Orientation.Portrait, qt.QMarginsF(0, 0, 0, 0)
+                    )
+                    writer.setPageLayout(layout)
+                else:
+                    writer.newPage()
+
+                painter.drawImage(qt.QRectF(0, 0, image.width(), image.height()), image)
+                self._paint_fields(painter, template.get("fields", []), values, page_number)
+        finally:
+            painter.end()
+
+        return out_path
+
+    # ------------------------------------------------------------------
+    def _page_background(self, template: dict[str, Any], page_number: int) -> Path:
+        base = Path(template.get("background_path", ""))
+        if not base.is_absolute():
+            base = self.base_data_dir / base
+        file_name = f"background_page_{page_number:03d}.png"
+        return base / file_name
+
+    def _paint_fields(
+        self,
+        painter,
+        fields: list[dict[str, Any]],
+        values: dict[int, Any],
+        page_number: int,
+    ) -> None:
+        qt = self._require_qt()
+        for field in fields:
+            if int(field.get("page", 1)) != page_number:
+                continue
+            rect = qt.QRectF(
+                float(field.get("x", 0)),
+                float(field.get("y", 0)),
+                float(field.get("width", 0)),
+                float(field.get("height", 0)),
+            )
+            value = values.get(field.get("id"))
+            if value is None:
+                value = field.get("default_value")
+            field_type = field.get("type", "text")
+            if field_type in {"text", "multiline", "date", "time", "dropdown"}:
+                self._draw_text_field(painter, field, rect, value)
+            elif field_type in {"checkbox", "radio"}:
+                self._draw_checkbox(painter, field, rect, value, is_radio=field_type == "radio")
+            elif field_type == "signature":
+                self._draw_placeholder(painter, rect, "Signature")
+            elif field_type == "image":
+                self._draw_placeholder(painter, rect, "Image")
+            elif field_type == "table":
+                self._draw_placeholder(painter, rect, "Table rows")
+            else:
+                self._draw_text_field(painter, field, rect, value)
+
+    def _draw_text_field(self, painter, field: dict[str, Any], rect, value: Any) -> None:
+        qt = self._require_qt()
+        font = qt.QFont()
+        if field.get("font_family"):
+            font.setFamily(field["font_family"])
+        font.setPointSize(int(field.get("font_size", 10)))
+        painter.save()
+        painter.setFont(font)
+        painter.setPen(qt.QColor(0, 0, 0))
+
+        alignment = field.get("align", "left")
+        flags = qt.Qt.AlignmentFlag.AlignLeft | qt.Qt.AlignmentFlag.AlignVCenter
+        if alignment == "center":
+            flags = qt.Qt.AlignmentFlag.AlignHCenter | qt.Qt.AlignmentFlag.AlignVCenter
+        elif alignment == "right":
+            flags = qt.Qt.AlignmentFlag.AlignRight | qt.Qt.AlignmentFlag.AlignVCenter
+        if field.get("type") == "multiline":
+            flags = flags | qt.Qt.TextFlag.TextWordWrap
+
+        text = "" if value is None else str(value)
+        painter.drawText(rect, flags, text)
+        painter.restore()
+
+    def _draw_checkbox(self, painter, field: dict[str, Any], rect, value: Any, *, is_radio: bool = False) -> None:
+        qt = self._require_qt()
+        painter.save()
+        painter.setPen(qt.QColor(0, 0, 0))
+        painter.drawRect(rect)
+        if self._is_checked(value):
+            if is_radio:
+                painter.setBrush(qt.QColor(0, 0, 0))
+                painter.drawEllipse(rect.center(), rect.width() / 4, rect.height() / 4)
+            else:
+                painter.drawLine(rect.topLeft(), rect.bottomRight())
+                painter.drawLine(rect.bottomLeft(), rect.topRight())
+        painter.restore()
+
+    def _draw_placeholder(self, painter, rect, text: str) -> None:
+        qt = self._require_qt()
+        painter.save()
+        painter.setPen(qt.QColor(80, 80, 80))
+        painter.drawRect(rect)
+        painter.drawText(rect, qt.Qt.AlignmentFlag.AlignCenter, text)
+        painter.restore()
+
+    def _is_checked(self, value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return value != 0
+        value_str = str(value).strip().lower()
+        return value_str in {"true", "yes", "1", "x", "checked"}
+
+    def _require_qt(self) -> SimpleNamespace:
+        if self._qt is not None:
+            return self._qt
+        try:
+            from PySide6.QtCore import QMarginsF, QRectF, QSizeF, Qt  # type: ignore
+            from PySide6.QtGui import QColor, QFont, QImage, QPainter, QPageLayout, QPageSize, QPdfWriter  # type: ignore
+        except ImportError as exc:  # pragma: no cover - dependency guard
+            raise RuntimeError(
+                "PySide6 is required for PDF export. Install the Qt bindings or provide a custom exporter."
+            ) from exc
+        self._qt = SimpleNamespace(
+            QMarginsF=QMarginsF,
+            QRectF=QRectF,
+            QSizeF=QSizeF,
+            Qt=Qt,
+            QColor=QColor,
+            QFont=QFont,
+            QImage=QImage,
+            QPainter=QPainter,
+            QPageLayout=QPageLayout,
+            QPageSize=QPageSize,
+            QPdfWriter=QPdfWriter,
+        )
+        return self._qt

--- a/modules/forms_creator/services/ocr.py
+++ b/modules/forms_creator/services/ocr.py
@@ -1,0 +1,38 @@
+"""Optional OCR helpers for the form creator module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(slots=True)
+class OCRConfig:
+    """Configuration flagging whether OCR support is enabled."""
+
+    enabled: bool = False
+    tessdata_path: Path | None = None
+
+
+class OCRService:
+    """Very small facade around an optional OCR backend."""
+
+    def __init__(self, config: OCRConfig | None = None):
+        self.config = config or OCRConfig()
+
+    def suggest_fields(self, image_path: Path) -> list[dict[str, Any]]:
+        """Return suggested field bounding boxes for ``image_path``.
+
+        The default implementation simply returns an empty list.  It exists to
+        provide a well defined hook should the desktop build bundle Tesseract in
+        the future.  Keeping the API synchronous avoids threading issues in the
+        UI layer.
+        """
+
+        if not self.config.enabled:
+            return []
+        raise RuntimeError(
+            "OCR support is disabled in this build. Provide a custom OCRService "
+            "with enabled=True and an engine implementation."
+        )

--- a/modules/forms_creator/services/rasterizer.py
+++ b/modules/forms_creator/services/rasterizer.py
@@ -1,0 +1,42 @@
+"""PDF to PNG rasterisation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+class RasterizerError(RuntimeError):
+    """Raised when rasterisation fails or is unavailable."""
+
+
+class RasterizeEngine(Protocol):
+    """Protocol describing a rasterisation backend."""
+
+    def __call__(self, pdf_path: Path, output_dir: Path) -> list[Path]:
+        ...
+
+
+@dataclass(slots=True)
+class Rasterizer:
+    """Dependency injectable PDF rasteriser.
+
+    The default configuration intentionally does not provide a concrete engine
+    because QtPdf/Poppler bindings may not be available in all deployments.  UI
+    callers should catch :class:`RasterizerError` and present a friendly message
+    with steps to enable a rasterisation backend.
+    """
+
+    engine: RasterizeEngine | None = None
+
+    def rasterize_pdf(self, pdf_path: Path, output_dir: Path) -> list[Path]:
+        """Convert ``pdf_path`` into PNG images under ``output_dir``."""
+
+        if self.engine is None:
+            raise RasterizerError(
+                "No PDF rasterisation backend configured. Install QtPdf or poppler "
+                "and pass an engine callable to Rasterizer(engine=...)."
+            )
+        output_dir.mkdir(parents=True, exist_ok=True)
+        return self.engine(pdf_path, output_dir)

--- a/modules/forms_creator/services/templates.py
+++ b/modules/forms_creator/services/templates.py
@@ -1,0 +1,390 @@
+"""High level service API for the form creator module.
+
+The :class:`FormService` encapsulates the persistence, binding and exporting
+behaviour required by both the Qt authoring UI and other application modules.
+It intentionally avoids any Qt specific code so the service can be reused from
+command line utilities and tests.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from ..models import Field
+from . import db
+from .binder import Binder
+from .exporter import PDFExporter
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+
+def _utcnow() -> str:
+    """Return a UTC timestamp suitable for storage in SQLite."""
+
+    return datetime.now(timezone.utc).strftime(ISO_FORMAT)
+
+
+def _serialise_value(value: Any) -> str | None:
+    """Serialise a Python value for storage in the ``instance_values`` table."""
+
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return "__JSON__" + json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def _deserialise_value(value: str | None) -> Any:
+    """Inverse operation of :func:`_serialise_value`."""
+
+    if value is None:
+        return None
+    if value.startswith("__JSON__"):
+        try:
+            return json.loads(value[len("__JSON__") :])
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+class FormService:
+    """Service facade that manages templates and form instances."""
+
+    def __init__(self, *, data_dir: Path | str = Path("data"), binder: Binder | None = None, exporter: PDFExporter | None = None):
+        self.data_dir = Path(data_dir)
+        self.templates_dir = self.data_dir / "forms" / "templates"
+        self.templates_dir.mkdir(parents=True, exist_ok=True)
+        self.binder = binder or Binder()
+        self.exporter = exporter or PDFExporter(base_data_dir=self.data_dir)
+        db.init_master_db()
+        self.template_table = self._ensure_template_table()
+
+    # ------------------------------------------------------------------
+    # Template helpers
+    # ------------------------------------------------------------------
+    def list_templates(self, category: str | None = None) -> list[dict[str, Any]]:
+        """Return template dictionaries from the master database."""
+
+        with db.get_master_connection() as conn:
+            query = f"SELECT * FROM {self.template_table}"
+            params: tuple[Any, ...] = ()
+            if category:
+                query += " WHERE category = ?"
+                params = (category,)
+            query += " ORDER BY name ASC, version DESC"
+            cursor = conn.execute(query, params)
+            rows = cursor.fetchall()
+        return [self._row_to_template_dict(row) for row in rows]
+
+    def get_template(self, template_id: int) -> dict[str, Any]:
+        """Fetch a specific template as a dictionary."""
+
+        with db.get_master_connection() as conn:
+            row = conn.execute(
+                f"SELECT * FROM {self.template_table} WHERE id = ?",
+                (template_id,),
+            ).fetchone()
+        if row is None:
+            raise ValueError(f"Template {template_id} not found")
+        return self._row_to_template_dict(row)
+
+    def save_template(
+        self,
+        *,
+        name: str,
+        category: str | None,
+        subcategory: str | None,
+        background_path: str,
+        page_count: int,
+        fields: Iterable[dict[str, Any] | Field],
+        version: int | None = None,
+        template_id: int | None = None,
+        schema_version: int = 1,
+    ) -> int:
+        """Insert or update a template.
+
+        Parameters mirror the master schema.  ``fields`` should be an iterable
+        of dictionaries (or :class:`~modules.forms_creator.models.Field`
+        instances) that are JSON serialisable.
+        """
+
+        fields_payload = [self._normalise_field(field) for field in fields]
+        serialised_fields = json.dumps(fields_payload, ensure_ascii=False)
+        now = _utcnow()
+
+        with db.get_master_connection() as conn:
+            if template_id is None:
+                new_version = version or 1
+                cursor = conn.execute(
+                    f"""
+                    INSERT INTO {self.template_table}
+                      (name, category, subcategory, version, background_path, page_count, schema_version, fields_json, created_at, updated_at, is_active)
+                    VALUES
+                      (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+                    """,
+                    (
+                        name,
+                        category,
+                        subcategory,
+                        new_version,
+                        background_path,
+                        page_count,
+                        schema_version,
+                        serialised_fields,
+                        now,
+                        now,
+                    ),
+                )
+                template_id = cursor.lastrowid
+            else:
+                existing = conn.execute(
+                    f"SELECT * FROM {self.template_table} WHERE id = ?",
+                    (template_id,),
+                ).fetchone()
+                if existing is None:
+                    raise ValueError(f"Template {template_id} not found")
+                self._archive_template_snapshot(existing)
+                current_version = existing["version"]
+                new_version = version or (current_version + 1)
+                conn.execute(
+                    f"""
+                    UPDATE {self.template_table}
+                       SET name = ?,
+                           category = ?,
+                           subcategory = ?,
+                           version = ?,
+                           background_path = ?,
+                           page_count = ?,
+                           schema_version = ?,
+                           fields_json = ?,
+                           updated_at = ?
+                     WHERE id = ?
+                    """,
+                    (
+                        name,
+                        category,
+                        subcategory,
+                        new_version,
+                        background_path,
+                        page_count,
+                        schema_version,
+                        serialised_fields,
+                        now,
+                        template_id,
+                    ),
+                )
+        return template_id
+
+    # ------------------------------------------------------------------
+    # Instance helpers
+    # ------------------------------------------------------------------
+    def create_instance(self, incident_id: str, template_id: int, prefill_ctx: dict[str, Any] | None = None) -> int:
+        """Create a form instance for the specified incident."""
+
+        template_row = self.get_template(template_id)
+        db.ensure_incident_db(incident_id)
+        now = _utcnow()
+        template_version = template_row["version"]
+        fields = template_row["fields"]
+        ctx = prefill_ctx or {}
+
+        with db.get_incident_connection(incident_id) as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO form_instances (incident_id, template_id, template_version, status, created_at, updated_at)
+                VALUES (?, ?, ?, 'draft', ?, ?)
+                """,
+                (incident_id, template_id, template_version, now, now),
+            )
+            instance_id = cursor.lastrowid
+            for field in fields:
+                value = self._prefill_value(field, ctx)
+                if value is None:
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO instance_values (instance_id, field_id, value, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (instance_id, field["id"], _serialise_value(value), now, now),
+                )
+        return instance_id
+
+    def save_instance_value(self, instance_id: int, field_id: int, value: Any, *, incident_id: str) -> None:
+        """Persist a single field value for a form instance."""
+
+        db.ensure_incident_db(incident_id)
+        now = _utcnow()
+        serialised = _serialise_value(value)
+
+        with db.get_incident_connection(incident_id) as conn:
+            cursor = conn.execute(
+                "SELECT id FROM instance_values WHERE instance_id = ? AND field_id = ?",
+                (instance_id, field_id),
+            )
+            row = cursor.fetchone()
+            if row:
+                conn.execute(
+                    "UPDATE instance_values SET value = ?, updated_at = ? WHERE id = ?",
+                    (serialised, now, row["id"]),
+                )
+            else:
+                conn.execute(
+                    """
+                    INSERT INTO instance_values (instance_id, field_id, value, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (instance_id, field_id, serialised, now, now),
+                )
+            conn.execute(
+                "UPDATE form_instances SET updated_at = ? WHERE id = ?",
+                (now, instance_id),
+            )
+
+    def finalize_instance(self, incident_id: str, instance_id: int) -> None:
+        """Mark an instance as finalised."""
+
+        db.ensure_incident_db(incident_id)
+        now = _utcnow()
+        with db.get_incident_connection(incident_id) as conn:
+            conn.execute(
+                "UPDATE form_instances SET status = 'finalized', updated_at = ? WHERE id = ?",
+                (now, instance_id),
+            )
+
+    def export_instance_pdf(self, incident_id: str, instance_id: int, out_path: str | Path) -> str:
+        """Composite a filled template into a printable PDF."""
+
+        db.ensure_incident_db(incident_id)
+        with db.get_incident_connection(incident_id) as conn:
+            instance_row = conn.execute("SELECT * FROM form_instances WHERE id = ?", (instance_id,)).fetchone()
+            if instance_row is None:
+                raise ValueError(f"Instance {instance_id} not found for incident {incident_id}")
+            values_cursor = conn.execute(
+                "SELECT field_id, value FROM instance_values WHERE instance_id = ?",
+                (instance_id,),
+            )
+            value_map = {row["field_id"]: _deserialise_value(row["value"]) for row in values_cursor.fetchall()}
+
+        template_data = self._load_template_version(instance_row["template_id"], instance_row["template_version"])
+        output = self.exporter.export_instance(template_data, value_map, Path(out_path))
+        return str(output)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_template_table(self) -> str:
+        required = {
+            "id",
+            "name",
+            "category",
+            "subcategory",
+            "version",
+            "background_path",
+            "page_count",
+            "schema_version",
+            "fields_json",
+            "created_at",
+            "updated_at",
+            "is_active",
+        }
+        fallback_table = "form_templates_hybrid"
+        with db.get_master_connection() as conn:
+            try:
+                info = conn.execute("PRAGMA table_info(form_templates)").fetchall()
+            except Exception:
+                info = []
+            columns = {row["name"] for row in info}
+            if not info:
+                conn.executescript(db._create_template_sql("form_templates"))
+                return "form_templates"
+            if required.issubset(columns):
+                return "form_templates"
+            conn.executescript(db._create_template_sql(fallback_table))
+        return fallback_table
+
+    def _row_to_template_dict(self, row: Any) -> dict[str, Any]:
+        payload = dict(row)
+        payload["fields"] = json.loads(payload.pop("fields_json"))
+        return payload
+
+    def _normalise_field(self, field: dict[str, Any] | Field) -> dict[str, Any]:
+        if is_dataclass(field):
+            field_dict = asdict(field)
+        else:
+            field_dict = dict(field)
+        field_dict.setdefault("config", {})
+        field_dict.setdefault("bindings", field_dict.get("config", {}).get("bindings", []))
+        # Normalise config keys
+        config = field_dict.get("config") or {}
+        config.setdefault("bindings", field_dict.pop("bindings", config.get("bindings", [])))
+        config.setdefault("validations", config.get("validations", []))
+        config.setdefault("dropdown", config.get("dropdown"))
+        config.setdefault("table", config.get("table"))
+        field_dict["config"] = config
+        return field_dict
+
+    def _prefill_value(self, field: dict[str, Any], context: dict[str, Any]) -> Any:
+        value = field.get("default_value") or None
+        config = field.get("config") or {}
+        for binding in config.get("bindings", []):
+            source_type = binding.get("source_type")
+            if source_type == "static":
+                value = binding.get("value")
+            elif source_type == "system":
+                key = binding.get("source_ref")
+                if key:
+                    try:
+                        value = self.binder.resolve(context, key)
+                    except Exception:
+                        continue
+        return value
+
+    def _archive_template_snapshot(self, row: Any) -> None:
+        """Persist the previous template definition to disk for version history."""
+
+        background = Path(row["background_path"])
+        if not background.is_absolute():
+            background = self.data_dir / background
+        versions_dir = background / "versions"
+        versions_dir.mkdir(parents=True, exist_ok=True)
+        snapshot_path = versions_dir / f"template_v{row['version']:03d}.json"
+        snapshot = dict(row)
+        snapshot["fields"] = json.loads(snapshot.pop("fields_json"))
+        with snapshot_path.open("w", encoding="utf-8") as fh:
+            json.dump(snapshot, fh, ensure_ascii=False, indent=2)
+
+    def _load_template_version(self, template_id: int, version: int) -> dict[str, Any]:
+        with db.get_master_connection() as conn:
+            row = conn.execute(
+                f"SELECT * FROM {self.template_table} WHERE id = ?",
+                (template_id,),
+            ).fetchone()
+        if row is None:
+            raise ValueError(f"Template {template_id} not found")
+
+        current_version = row["version"]
+        if version == current_version:
+            return self._row_to_template_dict(row)
+
+        if version > current_version:
+            raise ValueError(
+                f"Requested template version {version} is newer than stored version {current_version}"
+            )
+
+        background = Path(row["background_path"])
+        if not background.is_absolute():
+            background = self.data_dir / background
+        snapshot_path = background / "versions" / f"template_v{version:03d}.json"
+        if not snapshot_path.exists():
+            raise FileNotFoundError(
+                f"Template version {version} for template {template_id} is not available. Expected {snapshot_path}."
+            )
+        with snapshot_path.open("r", encoding="utf-8") as fh:
+            snapshot = json.load(fh)
+        snapshot["id"] = template_id
+        return snapshot

--- a/modules/forms_creator/ui/CanvasView.py
+++ b/modules/forms_creator/ui/CanvasView.py
@@ -1,0 +1,74 @@
+"""Graphics view used as the form designer canvas."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QPoint, Qt
+from PySide6.QtGui import QMouseEvent, QPainter, QWheelEvent
+from PySide6.QtWidgets import QGraphicsScene, QGraphicsView
+
+
+class CanvasView(QGraphicsView):
+    """A QGraphicsView with handy zoom and pan controls."""
+
+    def __init__(self, scene: QGraphicsScene | None = None, parent=None) -> None:
+        super().__init__(scene or QGraphicsScene(), parent)
+        self.setRenderHints(self.renderHints() | QPainter.RenderHint.Antialiasing)
+        self.setDragMode(QGraphicsView.DragMode.RubberBandDrag)
+        self.setTransformationAnchor(QGraphicsView.ViewportAnchor.AnchorUnderMouse)
+        self.setViewportUpdateMode(QGraphicsView.ViewportUpdateMode.FullViewportUpdate)
+        self._panning = False
+        self._pan_start = QPoint()
+        self._zoom = 1.0
+
+    # ------------------------------------------------------------------
+    def wheelEvent(self, event: QWheelEvent) -> None:  # noqa: N802 (Qt naming convention)
+        if event.modifiers() & Qt.KeyboardModifier.ControlModifier:
+            delta = event.angleDelta().y()
+            factor = 1.2 if delta > 0 else 0.8
+            self._apply_zoom(factor)
+            event.accept()
+        else:
+            super().wheelEvent(event)
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:  # noqa: N802
+        if event.button() == Qt.MouseButton.MiddleButton or (
+            event.button() == Qt.MouseButton.LeftButton and event.modifiers() & Qt.KeyboardModifier.SpaceModifier
+        ):
+            self._panning = True
+            self._pan_start = event.pos()
+            self.setCursor(Qt.CursorShape.ClosedHandCursor)
+            event.accept()
+        else:
+            super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:  # noqa: N802
+        if self._panning:
+            delta = event.pos() - self._pan_start
+            self._pan_start = event.pos()
+            self.horizontalScrollBar().setValue(self.horizontalScrollBar().value() - delta.x())
+            self.verticalScrollBar().setValue(self.verticalScrollBar().value() - delta.y())
+            event.accept()
+        else:
+            super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:  # noqa: N802
+        if self._panning and event.button() in {
+            Qt.MouseButton.MiddleButton,
+            Qt.MouseButton.LeftButton,
+        }:
+            self._panning = False
+            self.setCursor(Qt.CursorShape.ArrowCursor)
+            event.accept()
+        else:
+            super().mouseReleaseEvent(event)
+
+    # ------------------------------------------------------------------
+    def reset_zoom(self) -> None:
+        """Reset the view transformation to 100%."""
+
+        self._zoom = 1.0
+        self.resetTransform()
+
+    def _apply_zoom(self, factor: float) -> None:
+        self._zoom *= factor
+        self.scale(factor, factor)

--- a/modules/forms_creator/ui/FieldItems.py
+++ b/modules/forms_creator/ui/FieldItems.py
@@ -1,0 +1,54 @@
+"""QGraphicsItem subclasses representing form fields."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QRectF
+from PySide6.QtGui import QColor, QPainter
+from PySide6.QtWidgets import QGraphicsRectItem
+
+
+class FieldItem(QGraphicsRectItem):
+    """Base graphics item carrying field metadata."""
+
+    def __init__(self, field: dict, parent=None) -> None:
+        rect = QRectF(0, 0, float(field.get("width", 0)), float(field.get("height", 0)))
+        super().__init__(rect, parent)
+        self.field = field
+        self.setFlags(
+            QGraphicsRectItem.GraphicsItemFlag.ItemIsSelectable
+            | QGraphicsRectItem.GraphicsItemFlag.ItemIsMovable
+            | QGraphicsRectItem.GraphicsItemFlag.ItemSendsGeometryChanges
+        )
+        self.setBrush(QColor(0, 120, 215, 40))
+        self.setPen(QColor(0, 120, 215))
+        self.setPos(float(field.get("x", 0)), float(field.get("y", 0)))
+
+    def itemChange(self, change, value):  # noqa: N802 - Qt API
+        if change == QGraphicsRectItem.GraphicsItemChange.ItemPositionChange:
+            pos = value
+            self.field["x"] = pos.x()
+            self.field["y"] = pos.y()
+        elif change == QGraphicsRectItem.GraphicsItemChange.ItemPositionHasChanged:
+            pos = self.pos()
+            self.field["x"] = pos.x()
+            self.field["y"] = pos.y()
+        return super().itemChange(change, value)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # noqa: D401,N802
+        painter.save()
+        painter.setPen(self.pen())
+        painter.setBrush(self.brush())
+        painter.drawRect(self.rect())
+        painter.restore()
+
+
+class TextFieldItem(FieldItem):
+    """Text entry field."""
+
+
+class CheckboxFieldItem(FieldItem):
+    """Checkbox field representation."""
+
+
+class DropdownFieldItem(FieldItem):
+    """Dropdown field representation."""

--- a/modules/forms_creator/ui/MainWindow.py
+++ b/modules/forms_creator/ui/MainWindow.py
@@ -1,0 +1,384 @@
+"""Main window for the SARApp form creator workspace."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QAction, QIcon, QPixmap
+from PySide6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QSplitter,
+    QSpinBox,
+    QDoubleSpinBox,
+    QToolBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..assets import get_asset_path
+from ..services.templates import FormService
+from .CanvasView import CanvasView
+from .FieldItems import CheckboxFieldItem, DropdownFieldItem, FieldItem, TextFieldItem
+from .dialogs.BindingDialog import BindingDialog
+from .dialogs.NewTemplateWizard import NewTemplateWizard
+from .dialogs.PreviewDialog import PreviewDialog
+from .dialogs.ValidationDialog import ValidationDialog
+
+
+FIELD_CLASSES = {
+    "text": TextFieldItem,
+    "multiline": TextFieldItem,
+    "date": TextFieldItem,
+    "time": TextFieldItem,
+    "checkbox": CheckboxFieldItem,
+    "radio": CheckboxFieldItem,
+    "dropdown": DropdownFieldItem,
+    "signature": FieldItem,
+    "image": FieldItem,
+    "table": FieldItem,
+}
+
+
+class MainWindow(QMainWindow):
+    """Three-pane designer workspace."""
+
+    def __init__(self, form_service: FormService | None = None, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Form Creator")
+        self.resize(1280, 720)
+        self.form_service = form_service or FormService()
+        self.current_template: dict[str, Any] | None = None
+        self.background_item = None
+        self.current_field_item: FieldItem | None = None
+        self.next_field_id = 1
+
+        self._build_menu()
+        self._build_central_widget()
+        self._build_toolbar()
+        self.statusBar().showMessage("Ready")
+
+    # ------------------------------------------------------------------
+    def _build_menu(self) -> None:
+        menu_reference = self.menuBar().addMenu("Reference Library")
+        forms_menu = menu_reference.addMenu("Forms")
+
+        action_template_library = QAction("Template Library", self)
+        action_template_library.triggered.connect(self.open_template)
+        forms_menu.addAction(action_template_library)
+
+        action_form_creator = QAction("Form Creator", self)
+        action_form_creator.setEnabled(False)
+        forms_menu.addAction(action_form_creator)
+
+    def _build_toolbar(self) -> None:
+        toolbar = QToolBar("Main", self)
+        toolbar.setMovable(False)
+        self.addToolBar(toolbar)
+
+        toolbar.addAction(self._make_toolbar_action("New", "new.svg", self.new_template))
+        toolbar.addAction(self._make_toolbar_action("Open", "open.svg", self.open_template))
+        toolbar.addAction(self._make_toolbar_action("Save", "save.svg", self.save_template))
+        toolbar.addAction(self._make_toolbar_action("Preview", "preview.svg", self.preview_template))
+        toolbar.addAction(self._make_toolbar_action("Export", "export.svg", self.export_current_instance))
+
+        toolbar.addSeparator()
+
+        toolbar.addAction(
+            self._make_toolbar_action("Zoom +", "zoom_in.svg", lambda: self.canvas._apply_zoom(1.2))
+        )
+        toolbar.addAction(
+            self._make_toolbar_action("Zoom -", "zoom_out.svg", lambda: self.canvas._apply_zoom(0.8))
+        )
+        toolbar.addAction(self._make_toolbar_action("Reset Zoom", "zoom_reset.svg", self.canvas.reset_zoom))
+
+    def _build_central_widget(self) -> None:
+        splitter = QSplitter(Qt.Orientation.Horizontal, self)
+
+        # Palette
+        palette_container = QWidget()
+        palette_layout = QVBoxLayout()
+        palette_container.setLayout(palette_layout)
+        palette_layout.addWidget(QLabel("Field Palette"))
+        self.palette_list = QListWidget()
+        for key in FIELD_CLASSES.keys():
+            item = QListWidgetItem(key.title())
+            item.setData(Qt.ItemDataRole.UserRole, key)
+            self.palette_list.addItem(item)
+        self.palette_list.itemDoubleClicked.connect(self._handle_palette_double_click)
+        palette_layout.addWidget(self.palette_list)
+        splitter.addWidget(palette_container)
+
+        # Canvas
+        self.canvas = CanvasView()
+        self.scene = self.canvas.scene()
+        self.scene.selectionChanged.connect(self._on_selection_changed)
+        splitter.addWidget(self.canvas)
+
+        # Properties panel
+        properties_container = QWidget()
+        self.properties_layout = QFormLayout()
+        properties_container.setLayout(self.properties_layout)
+        self._build_properties_panel()
+        splitter.addWidget(properties_container)
+
+        splitter.setSizes([200, 800, 280])
+        self.setCentralWidget(splitter)
+
+    def _build_properties_panel(self) -> None:
+        self.field_name_edit = QLineEdit()
+        self.field_name_edit.editingFinished.connect(self._apply_properties_changes)
+        self.properties_layout.addRow("Name", self.field_name_edit)
+
+        self.field_type_edit = QLineEdit()
+        self.field_type_edit.setReadOnly(True)
+        self.properties_layout.addRow("Type", self.field_type_edit)
+
+        self.field_x_spin = QDoubleSpinBox()
+        self.field_x_spin.setRange(0, 10000)
+        self.field_x_spin.valueChanged.connect(self._apply_properties_changes)
+        self.properties_layout.addRow("X", self.field_x_spin)
+
+        self.field_y_spin = QDoubleSpinBox()
+        self.field_y_spin.setRange(0, 10000)
+        self.field_y_spin.valueChanged.connect(self._apply_properties_changes)
+        self.properties_layout.addRow("Y", self.field_y_spin)
+
+        self.field_w_spin = QDoubleSpinBox()
+        self.field_w_spin.setRange(0, 10000)
+        self.field_w_spin.valueChanged.connect(self._apply_properties_changes)
+        self.properties_layout.addRow("Width", self.field_w_spin)
+
+        self.field_h_spin = QDoubleSpinBox()
+        self.field_h_spin.setRange(0, 10000)
+        self.field_h_spin.valueChanged.connect(self._apply_properties_changes)
+        self.properties_layout.addRow("Height", self.field_h_spin)
+
+        self.font_size_spin = QSpinBox()
+        self.font_size_spin.setRange(6, 72)
+        self.font_size_spin.valueChanged.connect(self._apply_properties_changes)
+        self.properties_layout.addRow("Font Size", self.font_size_spin)
+
+        self.binding_button = QPushButton("Bindings...")
+        self.binding_button.clicked.connect(self._open_binding_dialog)
+        self.binding_button.setEnabled(False)
+        self.properties_layout.addRow(self.binding_button)
+
+        self.validation_button = QPushButton("Validations...")
+        self.validation_button.clicked.connect(self._open_validation_dialog)
+        self.validation_button.setEnabled(False)
+        self.properties_layout.addRow(self.validation_button)
+
+        self.properties_layout.addRow(QLabel(""))
+
+    # ------------------------------------------------------------------
+    def _make_toolbar_action(self, text: str, icon_name: str, slot: Callable[[], None]) -> QAction:
+        """Create a toolbar action with a themed icon if available."""
+
+        icon_path = get_asset_path(icon_name)
+        icon = QIcon(str(icon_path)) if icon_path.exists() else QIcon()
+        action = QAction(icon, text, self)
+        action.triggered.connect(slot)
+        return action
+
+    # ------------------------------------------------------------------
+    def new_template(self) -> None:
+        wizard = NewTemplateWizard(self.form_service, self)
+        if wizard.exec() == wizard.DialogCode.Accepted:
+            template_id = wizard.created_template_id
+            if template_id:
+                self.load_template(template_id)
+                self.statusBar().showMessage("Template created", 5000)
+
+    def open_template(self) -> None:
+        templates = self.form_service.list_templates()
+        if not templates:
+            QMessageBox.information(self, "Templates", "No templates available yet.")
+            return
+        items = [f"{t['id']}: {t['name']} v{t['version']}" for t in templates]
+        from PySide6.QtWidgets import QInputDialog
+
+        selected, ok = QInputDialog.getItem(self, "Open Template", "Template", items, 0, False)
+        if ok and selected:
+            template_id = int(selected.split(":", 1)[0])
+            self.load_template(template_id)
+
+    def load_template(self, template_id: int) -> None:
+        template = self.form_service.get_template(template_id)
+        self.current_template = template
+        self.next_field_id = max((f.get("id", 0) for f in template.get("fields", [])), default=0) + 1
+        self.scene.clear()
+        self.background_item = None
+        self.canvas.reset_zoom()
+        self._load_background(template)
+        for field in template.get("fields", []):
+            self._add_field_item(field)
+        self.statusBar().showMessage(f"Loaded template {template['name']} v{template['version']}", 5000)
+
+    def save_template(self) -> None:
+        if not self.current_template:
+            QMessageBox.warning(self, "Save Template", "No template is currently loaded.")
+            return
+        fields = self.current_template.get("fields", [])
+        template_id = self.current_template.get("id")
+        self.form_service.save_template(
+            name=self.current_template.get("name", "Untitled"),
+            category=self.current_template.get("category"),
+            subcategory=self.current_template.get("subcategory"),
+            background_path=self.current_template.get("background_path"),
+            page_count=self.current_template.get("page_count", 1),
+            fields=fields,
+            template_id=template_id,
+        )
+        self.load_template(template_id)
+        self.statusBar().showMessage("Template saved", 3000)
+
+    def preview_template(self) -> None:
+        if not self.current_template:
+            QMessageBox.information(self, "Preview", "Load a template first.")
+            return
+        dialog = PreviewDialog(self.current_template, parent=self)
+        dialog.exec()
+
+    def export_current_instance(self) -> None:
+        if not self.current_template:
+            QMessageBox.warning(self, "Export", "Load a template first.")
+            return
+        path, _ = QFileDialog.getSaveFileName(self, "Export Template PDF", "", "PDF Files (*.pdf)")
+        if not path:
+            return
+        temp_values = {field.get("id"): field.get("default_value") for field in self.current_template.get("fields", [])}
+        export_template = dict(self.current_template)
+        self.form_service.exporter.export_instance(export_template, temp_values, Path(path))
+        self.statusBar().showMessage(f"Exported preview to {path}", 5000)
+
+    # ------------------------------------------------------------------
+    def _handle_palette_double_click(self, item: QListWidgetItem) -> None:
+        field_type = item.data(Qt.ItemDataRole.UserRole)
+        if not self.current_template:
+            QMessageBox.warning(self, "Add Field", "Create or open a template first.")
+            return
+        field = {
+            "id": self.next_field_id,
+            "page": 1,
+            "name": f"field_{self.next_field_id}",
+            "type": field_type,
+            "x": 50.0,
+            "y": 50.0,
+            "width": 150.0,
+            "height": 24.0,
+            "font_family": "",
+            "font_size": 10,
+            "align": "left",
+            "required": False,
+            "placeholder": "",
+            "mask": "",
+            "default_value": "",
+            "config": {"bindings": [], "validations": [], "dropdown": None, "table": None},
+        }
+        self.next_field_id += 1
+        self.current_template.setdefault("fields", []).append(field)
+        self._add_field_item(field)
+
+    def _add_field_item(self, field: dict[str, Any]) -> None:
+        cls = FIELD_CLASSES.get(field.get("type"), FieldItem)
+        item = cls(field)
+        self.scene.addItem(item)
+        item.setZValue(5)
+
+    def _on_selection_changed(self) -> None:
+        items = self.scene.selectedItems()
+        self.current_field_item = items[0] if items else None
+        if self.current_field_item is None:
+            self._clear_properties()
+            return
+        field = self.current_field_item.field
+        self.field_name_edit.setText(field.get("name", ""))
+        self.field_type_edit.setText(field.get("type", ""))
+        self.field_x_spin.blockSignals(True)
+        self.field_y_spin.blockSignals(True)
+        self.field_w_spin.blockSignals(True)
+        self.field_h_spin.blockSignals(True)
+        self.font_size_spin.blockSignals(True)
+        self.field_x_spin.setValue(float(field.get("x", 0)))
+        self.field_y_spin.setValue(float(field.get("y", 0)))
+        self.field_w_spin.setValue(float(field.get("width", 0)))
+        self.field_h_spin.setValue(float(field.get("height", 0)))
+        self.font_size_spin.setValue(int(field.get("font_size", 10)))
+        self.field_x_spin.blockSignals(False)
+        self.field_y_spin.blockSignals(False)
+        self.field_w_spin.blockSignals(False)
+        self.field_h_spin.blockSignals(False)
+        self.font_size_spin.blockSignals(False)
+        self.binding_button.setEnabled(True)
+        self.validation_button.setEnabled(True)
+
+    def _clear_properties(self) -> None:
+        self.field_name_edit.clear()
+        self.field_type_edit.clear()
+        self.field_x_spin.setValue(0)
+        self.field_y_spin.setValue(0)
+        self.field_w_spin.setValue(0)
+        self.field_h_spin.setValue(0)
+        self.font_size_spin.setValue(10)
+        self.binding_button.setEnabled(False)
+        self.validation_button.setEnabled(False)
+
+    def _apply_properties_changes(self) -> None:
+        if not self.current_field_item:
+            return
+        field = self.current_field_item.field
+        field["name"] = self.field_name_edit.text()
+        field["x"] = self.field_x_spin.value()
+        field["y"] = self.field_y_spin.value()
+        field["width"] = self.field_w_spin.value()
+        field["height"] = self.field_h_spin.value()
+        field["font_size"] = self.font_size_spin.value()
+        self.current_field_item.setPos(field["x"], field["y"])
+        self.current_field_item.setRect(0, 0, field["width"], field["height"])
+
+    def _open_binding_dialog(self) -> None:
+        if not self.current_field_item:
+            return
+        field = self.current_field_item.field
+        dialog = BindingDialog(field.get("config", {}), self.form_service.binder, self)
+        if dialog.exec() == dialog.DialogCode.Accepted:
+            field.setdefault("config", {})["bindings"] = dialog.bindings
+
+    def _open_validation_dialog(self) -> None:
+        if not self.current_field_item:
+            return
+        field = self.current_field_item.field
+        dialog = ValidationDialog(field.get("config", {}), self)
+        if dialog.exec() == dialog.DialogCode.Accepted:
+            field.setdefault("config", {})["validations"] = dialog.validations
+
+    def _load_background(self, template: dict[str, Any]) -> None:
+        background_path = Path(template.get("background_path", ""))
+        if not background_path.is_absolute():
+            background_path = self.form_service.data_dir / background_path
+        image_path = background_path / "background_page_001.png"
+        pixmap = QPixmap(str(image_path))
+        if pixmap.isNull():
+            return
+        self.background_item = self.scene.addPixmap(pixmap)
+        self.background_item.setZValue(-10)
+        self.background_item.setEnabled(False)
+        self.scene.setSceneRect(0, 0, pixmap.width(), pixmap.height())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke test helper
+    app = QApplication([])
+    window = MainWindow()
+    window.show()
+    app.exec()

--- a/modules/forms_creator/ui/__init__.py
+++ b/modules/forms_creator/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Qt widget components for the form creator."""

--- a/modules/forms_creator/ui/dialogs/BindingDialog.py
+++ b/modules/forms_creator/ui/dialogs/BindingDialog.py
@@ -1,0 +1,84 @@
+"""Dialog used to configure field bindings."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+    QVBoxLayout,
+)
+
+from ...services.binder import Binder
+
+
+class BindingDialog(QDialog):
+    """Simple binding editor supporting static and system bindings."""
+
+    def __init__(self, config: dict[str, Any], binder: Binder, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Field Bindings")
+        self.binder = binder
+        self.bindings: list[dict[str, Any]] = config.get("bindings", []).copy()
+
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        layout.addLayout(form)
+
+        self.type_combo = QComboBox()
+        self.type_combo.addItem("Static", "static")
+        self.type_combo.addItem("System", "system")
+        form.addRow("Source Type", self.type_combo)
+
+        self.static_edit = QLineEdit()
+        form.addRow("Static Value", self.static_edit)
+
+        self.system_combo = QComboBox()
+        self.system_bindings = binder.available_keys()
+        for binding in self.system_bindings:
+            self.system_combo.addItem(binding.label, binding.key)
+        form.addRow("System Key", self.system_combo)
+
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        layout.addWidget(button_box)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+
+        self.type_combo.currentIndexChanged.connect(self._sync_controls)
+        self._load_initial_state()
+
+    def _load_initial_state(self) -> None:
+        if not self.bindings:
+            self._sync_controls()
+            return
+        binding = self.bindings[0]
+        source_type = binding.get("source_type", "static")
+        index = self.type_combo.findData(source_type)
+        if index >= 0:
+            self.type_combo.setCurrentIndex(index)
+        if source_type == "static":
+            self.static_edit.setText(binding.get("value", ""))
+        elif source_type == "system":
+            key = binding.get("source_ref", "")
+            idx = self.system_combo.findData(key)
+            if idx >= 0:
+                self.system_combo.setCurrentIndex(idx)
+        self._sync_controls()
+
+    def _sync_controls(self) -> None:
+        source_type = self.type_combo.currentData()
+        self.static_edit.setEnabled(source_type == "static")
+        self.system_combo.setEnabled(source_type == "system")
+
+    def accept(self) -> None:  # noqa: D401
+        source_type = self.type_combo.currentData()
+        if source_type == "static":
+            binding = {"source_type": "static", "value": self.static_edit.text()}
+        else:
+            binding = {"source_type": "system", "source_ref": self.system_combo.currentData()}
+        self.bindings = [binding]
+        super().accept()

--- a/modules/forms_creator/ui/dialogs/NewTemplateWizard.py
+++ b/modules/forms_creator/ui/dialogs/NewTemplateWizard.py
@@ -1,0 +1,146 @@
+"""Wizard that helps users import a document and create a template."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+from PySide6.QtGui import QImage
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QGridLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWizard,
+    QWizardPage,
+)
+
+from ...services.rasterizer import Rasterizer, RasterizerError
+from ...services.templates import FormService
+
+
+class _FileSelectionPage(QWizardPage):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setTitle("Select Source Document")
+        layout = QGridLayout(self)
+        layout.addWidget(QLabel("PDF or image"), 0, 0)
+        self.path_edit = QLineEdit()
+        layout.addWidget(self.path_edit, 0, 1)
+        browse_btn = QPushButton("Browse…")
+        layout.addWidget(browse_btn, 0, 2)
+        browse_btn.clicked.connect(self._browse)
+
+    def _browse(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select PDF or image",
+            "",
+            "PDF Files (*.pdf);;Images (*.png *.jpg *.jpeg)",
+        )
+        if path:
+            self.path_edit.setText(path)
+
+    def selected_path(self) -> Path:
+        return Path(self.path_edit.text())
+
+
+class _MetadataPage(QWizardPage):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setTitle("Template Details")
+        layout = QVBoxLayout(self)
+        form_layout = QGridLayout()
+        layout.addLayout(form_layout)
+
+        form_layout.addWidget(QLabel("Name"), 0, 0)
+        self.name_edit = QLineEdit()
+        form_layout.addWidget(self.name_edit, 0, 1)
+
+        form_layout.addWidget(QLabel("Category"), 1, 0)
+        self.category_edit = QLineEdit()
+        form_layout.addWidget(self.category_edit, 1, 1)
+
+        form_layout.addWidget(QLabel("Subcategory"), 2, 0)
+        self.subcategory_edit = QLineEdit()
+        form_layout.addWidget(self.subcategory_edit, 2, 1)
+
+    def metadata(self) -> dict[str, str | None]:
+        return {
+            "name": self.name_edit.text().strip() or "Untitled Template",
+            "category": self.category_edit.text().strip() or None,
+            "subcategory": self.subcategory_edit.text().strip() or None,
+        }
+
+
+class NewTemplateWizard(QWizard):
+    """Walks the user through importing a PDF/image into a template."""
+
+    def __init__(self, form_service: FormService, parent=None, *, rasterizer: Rasterizer | None = None):
+        super().__init__(parent)
+        self.form_service = form_service
+        self.rasterizer = rasterizer or Rasterizer()
+        self.setWindowTitle("New Form Template")
+        self.created_template_id: int | None = None
+
+        self.file_page = _FileSelectionPage()
+        self.meta_page = _MetadataPage()
+        self.addPage(self.file_page)
+        self.addPage(self.meta_page)
+
+    def accept(self) -> None:  # noqa: D401
+        try:
+            self.created_template_id = self._create_template()
+        except RasterizerError as exc:  # pragma: no cover - Qt dialog path
+            QMessageBox.critical(self, "Rasterizer", str(exc))
+            return
+        except Exception as exc:  # pragma: no cover - Qt dialog path
+            QMessageBox.critical(self, "Template", f"Failed to create template: {exc}")
+            return
+        super().accept()
+
+    # ------------------------------------------------------------------
+    def _create_template(self) -> int:
+        source = self.file_page.selected_path()
+        if not source.exists():
+            raise FileNotFoundError("Selected source file does not exist")
+
+        meta = self.meta_page.metadata()
+        template_uuid = uuid.uuid4().hex
+        template_dir = self.form_service.templates_dir / template_uuid
+        template_dir.mkdir(parents=True, exist_ok=True)
+
+        if source.suffix.lower() == ".pdf":
+            images = self.rasterizer.rasterize_pdf(source, template_dir)
+        else:
+            images = self._copy_image(source, template_dir)
+
+        if not images:
+            raise RuntimeError("Rasteriser returned no images")
+
+        background_rel = Path("forms") / "templates" / template_uuid
+        template_id = self.form_service.save_template(
+            name=meta["name"],
+            category=meta["category"],
+            subcategory=meta["subcategory"],
+            background_path=str(background_rel),
+            page_count=len(images),
+            fields=[],
+        )
+
+        # Persist metadata for future reference
+        meta_path = template_dir / "meta.json"
+        meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+        return template_id
+
+    def _copy_image(self, source: Path, target_dir: Path) -> list[Path]:
+        image_path = target_dir / "background_page_001.png"
+        image = QImage(str(source))
+        if image.isNull():
+            raise RuntimeError(f"Unable to load image {source}")
+        image.save(str(image_path))
+        return [image_path]

--- a/modules/forms_creator/ui/dialogs/PreviewDialog.py
+++ b/modules/forms_creator/ui/dialogs/PreviewDialog.py
@@ -1,0 +1,49 @@
+"""Preview dialog for templates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from PySide6.QtGui import QColor, QImage, QPainter, QPixmap
+from PySide6.QtWidgets import QDialog, QDialogButtonBox, QLabel, QVBoxLayout
+
+
+class PreviewDialog(QDialog):
+    """Renders a lightweight preview of the first template page."""
+
+    def __init__(self, template: dict[str, Any], *, data_dir: Path | str = Path("data"), parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Template Preview")
+        layout = QVBoxLayout(self)
+
+        pixmap = self._render_preview(template, Path(data_dir))
+        label = QLabel()
+        label.setPixmap(pixmap)
+        layout.addWidget(label)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        buttons.rejected.connect(self.reject)
+        buttons.accepted.connect(self.accept)
+        layout.addWidget(buttons)
+
+    def _render_preview(self, template: dict[str, Any], data_dir: Path) -> QPixmap:
+        background = Path(template.get("background_path", ""))
+        if not background.is_absolute():
+            background = data_dir / background
+        image_path = background / "background_page_001.png"
+        base = QImage(str(image_path))
+        if base.isNull():
+            base = QImage(800, 600, QImage.Format.Format_ARGB32)
+            base.fill(QColor("white"))
+        painter = QPainter(base)
+        painter.setPen(QColor(0, 0, 0))
+        for field in template.get("fields", []):
+            if int(field.get("page", 1)) != 1:
+                continue
+            rect = (field.get("x", 0), field.get("y", 0), field.get("width", 0), field.get("height", 0))
+            painter.drawRect(*rect)
+            value = field.get("default_value", "")
+            painter.drawText(rect[0] + 2, rect[1] + rect[3] / 2, str(value))
+        painter.end()
+        return QPixmap.fromImage(base)

--- a/modules/forms_creator/ui/dialogs/TableEditorDialog.py
+++ b/modules/forms_creator/ui/dialogs/TableEditorDialog.py
@@ -1,0 +1,24 @@
+"""Stub table configuration dialog."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QDialog, QDialogButtonBox, QLabel, QVBoxLayout
+
+
+class TableEditorDialog(QDialog):
+    """Placeholder dialog that will evolve in future iterations."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Table Field Editor")
+        layout = QVBoxLayout(self)
+        layout.addWidget(
+            QLabel(
+                "Table/repeater configuration is planned for a future release.\n"
+                "You can still place the field on the canvas to reserve space."
+            )
+        )
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Close)
+        buttons.rejected.connect(self.reject)
+        buttons.accepted.connect(self.accept)
+        layout.addWidget(buttons)

--- a/modules/forms_creator/ui/dialogs/ValidationDialog.py
+++ b/modules/forms_creator/ui/dialogs/ValidationDialog.py
@@ -1,0 +1,78 @@
+"""Dialog to configure field validation rules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+    QVBoxLayout,
+)
+
+
+class ValidationDialog(QDialog):
+    """Collects simple validation rules (required + regex)."""
+
+    def __init__(self, config: dict[str, Any], parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Field Validations")
+        self.validations: list[dict[str, Any]] = config.get("validations", []).copy()
+        self._required_message: str | None = None
+
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        layout.addLayout(form)
+
+        self.required_check = QCheckBox("Field is required")
+        form.addRow(self.required_check)
+
+        self.regex_edit = QLineEdit()
+        self.regex_edit.setPlaceholderText("Regular expression pattern")
+        form.addRow("Regex", self.regex_edit)
+
+        self.regex_message_edit = QLineEdit()
+        self.regex_message_edit.setPlaceholderText("Error message when regex fails")
+        form.addRow("Regex Message", self.regex_message_edit)
+
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        layout.addWidget(button_box)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+
+        self._load_initial_state()
+
+    def _load_initial_state(self) -> None:
+        for rule in self.validations:
+            if rule.get("rule_type") == "required":
+                self.required_check.setChecked(True)
+                self._required_message = rule.get("error_message")
+            elif rule.get("rule_type") == "regex":
+                config = rule.get("rule_config", {})
+                self.regex_edit.setText(config.get("pattern", ""))
+                self.regex_message_edit.setText(rule.get("error_message", ""))
+
+    def accept(self) -> None:  # noqa: D401
+        result: list[dict[str, Any]] = []
+        if self.required_check.isChecked():
+            result.append(
+                {
+                    "rule_type": "required",
+                    "rule_config": {},
+                    "error_message": self._required_message or "Required field",
+                }
+            )
+        pattern = self.regex_edit.text().strip()
+        if pattern:
+            result.append(
+                {
+                    "rule_type": "regex",
+                    "rule_config": {"pattern": pattern},
+                    "error_message": self.regex_message_edit.text().strip() or "Invalid format",
+                }
+            )
+        self.validations = result
+        super().accept()

--- a/modules/forms_creator/ui/dialogs/__init__.py
+++ b/modules/forms_creator/ui/dialogs/__init__.py
@@ -1,0 +1,1 @@
+"""Dialog helpers for the form creator UI."""


### PR DESCRIPTION
## Summary
- add an asset helper that resolves module-local icon paths
- ship a starter set of SVG toolbar icons for the form creator workspace
- update the designer toolbar to use the themed icons for key actions

## Testing
- python -m compileall modules/forms_creator

------
https://chatgpt.com/codex/tasks/task_b_68cbe3761780832b856883d2228e67ab