### PR TITLE
Switch vehicle editor dialog to SQLite backend and add inventory panel

### DIFF
--- a/main.py
+++ b/main.py
@@ -862,7 +862,12 @@ class MainWindow(QMainWindow):
         self._open_qml_modal("qml/TeamTypesWindow.qml", title="Team Types")
 
     def open_edit_vehicles(self) -> None:
-        self._open_qml_modal("qml/VehiclesWindow.qml", title="Vehicles")
+        from modules.logistics.vehicle.panels.vehicle_inventory_panel import (
+            VehicleInventoryDialog,
+        )
+
+        dialog = VehicleInventoryDialog(parent=self)
+        dialog.exec()
 
     def open_edit_aircraft(self) -> None:
         self._open_qml_modal("qml/AircraftWindow.qml", title="Aircraft")

--- a/models/qmlwindow.py
+++ b/models/qmlwindow.py
@@ -274,8 +274,9 @@ def open_personnel():
     win.exec()
 
 def open_vehicles():
-    path = os.path.abspath("qml/VehiclesWindow.qml")
-    win = QmlWindow(path, "Vehicles Catalog")
+    from modules.logistics.vehicle.panels.vehicle_inventory_panel import VehicleInventoryDialog
+
+    win = VehicleInventoryDialog()
     win.exec()
 
 def open_aircraft():

--- a/modules/logistics/vehicle/panels/__init__.py
+++ b/modules/logistics/vehicle/panels/__init__.py
@@ -1,0 +1,11 @@
+"""Public exports for vehicle panels."""
+
+from .vehicle_edit_window import VehicleEditDialog, VehicleRepository
+from .vehicle_inventory_panel import VehicleInventoryDialog, VehicleInventoryWidget
+
+__all__ = [
+    "VehicleEditDialog",
+    "VehicleInventoryDialog",
+    "VehicleInventoryWidget",
+    "VehicleRepository",
+]

--- a/modules/logistics/vehicle/panels/vehicle_edit_window.py
+++ b/modules/logistics/vehicle/panels/vehicle_edit_window.py
@@ -1,0 +1,817 @@
+"""Vehicle inventory editing dialog implemented with Qt widgets."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Optional
+
+from utils.db import get_master_conn
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QIntValidator
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STATUS_CHOICES: list[str] = [
+    "Available",
+    "In Service",
+    "Out of Service",
+    "Retired",
+]
+
+DEFAULT_TYPE_CHOICES: list[str] = [
+    "Passenger Vehicle",
+    "Utility",
+    "Support",
+    "Other",
+]
+
+
+class VehicleRepository:
+    """Persistence helper that reads and writes vehicle records in SQLite."""
+
+    def __init__(self, db_path: Optional[str | Path] = None) -> None:
+        self._db_path: Optional[Path] = Path(db_path) if db_path else None
+
+    # ------------------------------------------------------------------
+    # Connection helpers
+    # ------------------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection:
+        if self._db_path is not None:
+            conn = sqlite3.connect(str(self._db_path))
+            conn.row_factory = sqlite3.Row
+            return conn
+        conn = get_master_conn()
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _table_exists(self, conn: sqlite3.Connection, table_name: str) -> bool:
+        query = "SELECT 1 FROM sqlite_master WHERE type='table' AND lower(name)=? LIMIT 1"
+        row = conn.execute(query, (table_name.lower(),)).fetchone()
+        return row is not None
+
+    # ------------------------------------------------------------------
+    # Reference data
+    # ------------------------------------------------------------------
+    def list_vehicles(self, search_text: str | None = None) -> list[dict[str, Any]]:
+        """Return vehicles from the master database, optionally filtered."""
+
+        if search_text is not None:
+            normalized = search_text.strip().lower()
+            search_text = normalized or None
+
+        conn = self._connect()
+        try:
+            base_query = (
+                """
+                SELECT id, vin, license_plate, year, make, model, capacity,
+                       type_id, status_id, tags, organization
+                FROM vehicles
+                """
+            )
+            params: list[Any] = []
+            if search_text:
+                term = f"%{search_text}%"
+                filters = " OR ".join(
+                    [
+                        "lower(COALESCE(vin, '')) LIKE ?",
+                        "lower(COALESCE(license_plate, '')) LIKE ?",
+                        "lower(COALESCE(make, '')) LIKE ?",
+                        "lower(COALESCE(model, '')) LIKE ?",
+                        "lower(COALESCE(tags, '')) LIKE ?",
+                    ]
+                )
+                base_query += f"WHERE {filters}\n"
+                params.extend([term] * 5)
+
+            base_query += (
+                """
+                ORDER BY
+                    CASE WHEN TRIM(COALESCE(make, '')) = '' THEN 1 ELSE 0 END,
+                    lower(COALESCE(make, '')),
+                    lower(COALESCE(model, '')),
+                    CAST(id AS INTEGER)
+                """
+            )
+
+            rows = conn.execute(base_query, tuple(params)).fetchall()
+        finally:
+            conn.close()
+
+        return [self._row_to_dict(row) for row in rows]
+
+    def list_vehicle_types(self) -> list[dict[str, Any]]:
+        """Return available vehicle type options."""
+
+        conn = self._connect()
+        try:
+            for table_name in ("vehicle_types", "vehicle_type"):
+                if self._table_exists(conn, table_name):
+                    rows = conn.execute(
+                        f"SELECT id, name FROM {table_name} ORDER BY name"
+                    ).fetchall()
+                    return [
+                        {"id": row["id"], "name": row["name"] or str(row["id"])}
+                        for row in rows
+                    ]
+
+            rows = conn.execute(
+                """
+                SELECT DISTINCT type_id
+                FROM vehicles
+                WHERE TRIM(COALESCE(type_id, '')) != ''
+                ORDER BY type_id
+                """
+            ).fetchall()
+            entries = []
+            for row in rows:
+                value = row["type_id"]
+                if value in (None, ""):
+                    continue
+                label = str(value).strip()
+                entries.append({"id": value, "name": label or str(value)})
+        finally:
+            conn.close()
+
+        if not entries:
+            entries = [{"id": choice, "name": choice} for choice in DEFAULT_TYPE_CHOICES]
+        return entries
+
+    def list_statuses(self) -> list[dict[str, Any]]:
+        """Return available vehicle status options."""
+
+        conn = self._connect()
+        try:
+            for table_name in ("vehicle_statuses", "statuses"):
+                if self._table_exists(conn, table_name):
+                    rows = conn.execute(
+                        f"SELECT id, name FROM {table_name} ORDER BY name"
+                    ).fetchall()
+                    return [
+                        {"id": row["id"], "name": row["name"] or str(row["id"])}
+                        for row in rows
+                    ]
+
+            rows = conn.execute(
+                """
+                SELECT DISTINCT status_id
+                FROM vehicles
+                WHERE TRIM(COALESCE(status_id, '')) != ''
+                ORDER BY status_id
+                """
+            ).fetchall()
+            options = OrderedDict()
+            for row in rows:
+                value = row["status_id"]
+                if value in (None, ""):
+                    continue
+                label = str(value).strip() or str(value)
+                options.setdefault(value, label)
+        finally:
+            conn.close()
+
+        for default in DEFAULT_STATUS_CHOICES:
+            options.setdefault(default, default)
+        return [{"id": key, "name": label} for key, label in options.items()]
+
+    # ------------------------------------------------------------------
+    # CRUD helpers
+    # ------------------------------------------------------------------
+    def delete_vehicle(self, vehicle_id: int | str) -> None:
+        """Remove a vehicle from the catalog."""
+
+        conn = self._connect()
+        try:
+            cur = conn.execute(
+                "DELETE FROM vehicles WHERE id = ?",
+                (str(vehicle_id),),
+            )
+            if cur.rowcount == 0:
+                raise LookupError(f"Vehicle {vehicle_id} does not exist")
+            conn.commit()
+        finally:
+            conn.close()
+
+    def fetch_vehicle(self, vehicle_id: int | str) -> Optional[dict[str, Any]]:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                """
+                SELECT id, vin, license_plate, year, make, model, capacity,
+                       type_id, status_id, tags, organization
+                FROM vehicles
+                WHERE id = ?
+                """,
+                (str(vehicle_id),),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        if row is None:
+            return None
+        return self._row_to_dict(row)
+
+    def create_vehicle(self, payload: dict[str, Any]) -> dict[str, Any]:
+        conn = self._connect()
+        try:
+            new_id = self._generate_new_id(conn)
+            params = self._build_params(payload)
+            params.insert(0, new_id)
+            conn.execute(
+                """
+                INSERT INTO vehicles (
+                    id, vin, license_plate, year, make, model,
+                    capacity, type_id, status_id, tags, organization
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                tuple(params),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        record = self.fetch_vehicle(new_id)
+        if record is None:  # pragma: no cover - defensive
+            raise RuntimeError("Vehicle creation failed")
+        return record
+
+    def update_vehicle(self, vehicle_id: int | str, payload: dict[str, Any]) -> dict[str, Any]:
+        conn = self._connect()
+        try:
+            params = self._build_params(payload)
+            params.append(str(vehicle_id))
+            cur = conn.execute(
+                """
+                UPDATE vehicles
+                SET vin = ?,
+                    license_plate = ?,
+                    year = ?,
+                    make = ?,
+                    model = ?,
+                    capacity = ?,
+                    type_id = ?,
+                    status_id = ?,
+                    tags = ?,
+                    organization = ?
+                WHERE id = ?
+                """,
+                tuple(params),
+            )
+            if cur.rowcount == 0:
+                raise LookupError(f"Vehicle {vehicle_id} does not exist")
+            conn.commit()
+        finally:
+            conn.close()
+
+        record = self.fetch_vehicle(vehicle_id)
+        if record is None:  # pragma: no cover - defensive
+            raise RuntimeError("Vehicle update failed")
+        return record
+
+    # ------------------------------------------------------------------
+    # Internal utilities
+    # ------------------------------------------------------------------
+    def _generate_new_id(self, conn: sqlite3.Connection) -> str:
+        row = conn.execute(
+            "SELECT MAX(CAST(id AS INTEGER)) FROM vehicles WHERE CAST(id AS INTEGER) IS NOT NULL"
+        ).fetchone()
+        next_id = (row[0] or 0) + 1
+        # Ensure uniqueness in case of non-numeric identifiers.
+        while conn.execute("SELECT 1 FROM vehicles WHERE id = ?", (str(next_id),)).fetchone():
+            next_id += 1
+        return str(next_id)
+
+    def _build_params(self, payload: dict[str, Any]) -> list[Any]:
+        tags = payload.get("tags") or []
+        if isinstance(tags, str):
+            tags_list = [part.strip() for part in tags.split(",") if part.strip()]
+        else:
+            tags_list = list(tags)
+        tags_value = ", ".join(tags_list) if tags_list else None
+
+        make_value = payload.get("make") or None
+        model_value = payload.get("model") or None
+        organization_value = payload.get("organization")
+
+        params: list[Any] = [
+            payload.get("vin") or None,
+            payload.get("license_plate") or None,
+            payload.get("year"),
+            make_value,
+            model_value,
+            payload.get("capacity", 0),
+            self._normalize_reference(payload.get("type_id")),
+            self._normalize_reference(payload.get("status_id")),
+            tags_value,
+            organization_value,
+        ]
+        return params
+
+    def _normalize_reference(self, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+    def _row_to_dict(self, row: sqlite3.Row) -> dict[str, Any]:
+        record = dict(row)
+        identifier = record.get("id")
+        if isinstance(identifier, str):
+            try:
+                record["id"] = int(identifier)
+            except ValueError:
+                pass
+
+        tags_value = record.get("tags")
+        if isinstance(tags_value, str):
+            record["tags"] = [
+                part.strip() for part in tags_value.split(",") if part.strip()
+            ]
+        elif tags_value is None:
+            record["tags"] = []
+
+        return record
+
+
+class VehicleEditDialog(QDialog):
+    """Modal dialog used to add or edit a single vehicle record."""
+
+    vehicleSaved = Signal(dict)
+
+    def __init__(
+        self,
+        vehicle_id: int | None = None,
+        repository: Optional[VehicleRepository] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._repository = repository or VehicleRepository()
+        self._vehicle_id: int | None = None
+        self._current_record: dict[str, Any] | None = None
+        self._vehicle_types: list[dict[str, Any]] = []
+        self._statuses: list[dict[str, Any]] = []
+        self._references_loaded = False
+        self._pending_vehicle_load = False
+
+        self.id_value_label: QLabel
+        self.license_plate_edit: QLineEdit
+        self.vin_edit: QLineEdit
+        self.year_edit: QLineEdit
+        self.make_edit: QLineEdit
+        self.model_edit: QLineEdit
+        self.capacity_spin: QSpinBox
+        self.type_combo: QComboBox
+        self.status_combo: QComboBox
+        self.tags_edit: QLineEdit
+        self.save_button: QPushButton
+        self.cancel_button: QPushButton
+
+        self.setup_ui()
+        self.set_vehicle_id(vehicle_id)
+        self.load_reference_lists()
+
+    # ------------------------------------------------------------------
+    # UI construction helpers
+    # ------------------------------------------------------------------
+    def setup_ui(self) -> None:
+        """Build widgets, configure layout, and establish defaults."""
+
+        self.setWindowTitle("Vehicle Editor")
+        self.setModal(True)
+        self.setMinimumWidth(520)
+
+        main_layout = QVBoxLayout(self)
+        form_layout = QFormLayout()
+        form_layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        main_layout.addLayout(form_layout)
+
+        id_caption = QLabel("ID:")
+        self.id_value_label = QLabel("New")
+        self.id_value_label.setAccessibleName("Vehicle identifier")
+        form_layout.addRow(id_caption, self.id_value_label)
+
+        self.license_plate_edit = QLineEdit()
+        self.license_plate_edit.setAccessibleName("License plate")
+        self.license_plate_edit.setPlaceholderText("Required")
+        license_label = QLabel("License Plate:")
+        license_label.setBuddy(self.license_plate_edit)
+        form_layout.addRow(license_label, self.license_plate_edit)
+
+        self.vin_edit = QLineEdit()
+        self.vin_edit.setAccessibleName("Vehicle identification number")
+        self.vin_edit.setPlaceholderText("Required")
+        vin_label = QLabel("VIN:")
+        vin_label.setBuddy(self.vin_edit)
+        form_layout.addRow(vin_label, self.vin_edit)
+
+        vehicle_fields = QWidget()
+        vehicle_row = QHBoxLayout(vehicle_fields)
+        vehicle_row.setContentsMargins(0, 0, 0, 0)
+        vehicle_row.setSpacing(8)
+
+        self.year_edit = QLineEdit()
+        self.year_edit.setAccessibleName("Vehicle year")
+        self.year_edit.setPlaceholderText("Year")
+        self.year_edit.setValidator(QIntValidator(1900, 2100, self.year_edit))
+        vehicle_row.addWidget(self.year_edit)
+
+        self.make_edit = QLineEdit()
+        self.make_edit.setAccessibleName("Vehicle make")
+        self.make_edit.setPlaceholderText("Make")
+        vehicle_row.addWidget(self.make_edit)
+
+        self.model_edit = QLineEdit()
+        self.model_edit.setAccessibleName("Vehicle model")
+        self.model_edit.setPlaceholderText("Model")
+        vehicle_row.addWidget(self.model_edit)
+
+        vehicle_label = QLabel("Vehicle:")
+        vehicle_label.setBuddy(self.year_edit)
+        form_layout.addRow(vehicle_label, vehicle_fields)
+
+        self.capacity_spin = QSpinBox()
+        self.capacity_spin.setRange(0, 100)
+        self.capacity_spin.setAccessibleName("Passenger capacity")
+        capacity_label = QLabel("Capacity:")
+        capacity_label.setBuddy(self.capacity_spin)
+        form_layout.addRow(capacity_label, self.capacity_spin)
+
+        self.type_combo = QComboBox()
+        self.type_combo.setAccessibleName("Vehicle type")
+        self._configure_combo(self.type_combo)
+        type_label = QLabel("Type:")
+        type_label.setBuddy(self.type_combo)
+        form_layout.addRow(type_label, self.type_combo)
+
+        self.status_combo = QComboBox()
+        self.status_combo.setAccessibleName("Vehicle status")
+        self._configure_combo(self.status_combo)
+        status_label = QLabel("Status:")
+        status_label.setBuddy(self.status_combo)
+        form_layout.addRow(status_label, self.status_combo)
+
+        self.tags_edit = QLineEdit()
+        self.tags_edit.setAccessibleName("Vehicle tags")
+        self.tags_edit.setPlaceholderText("tag1, tag2")
+        tags_label = QLabel("Tags:")
+        tags_label.setBuddy(self.tags_edit)
+        form_layout.addRow(tags_label, self.tags_edit)
+
+        button_row = QHBoxLayout()
+        button_row.addStretch(1)
+        self.save_button = QPushButton("Save")
+        self.save_button.setDefault(True)
+        self.save_button.setAutoDefault(True)
+        self.save_button.setEnabled(False)
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.setAutoDefault(False)
+        button_row.addWidget(self.save_button)
+        button_row.addWidget(self.cancel_button)
+        main_layout.addLayout(button_row)
+
+        self.save_button.clicked.connect(self.on_save_clicked)
+        self.cancel_button.clicked.connect(self.reject)
+
+        self.setTabOrder(self.license_plate_edit, self.vin_edit)
+        self.setTabOrder(self.vin_edit, self.year_edit)
+        self.setTabOrder(self.year_edit, self.make_edit)
+        self.setTabOrder(self.make_edit, self.model_edit)
+        self.setTabOrder(self.model_edit, self.capacity_spin)
+        self.setTabOrder(self.capacity_spin, self.type_combo)
+        self.setTabOrder(self.type_combo, self.status_combo)
+        self.setTabOrder(self.status_combo, self.tags_edit)
+        self.setTabOrder(self.tags_edit, self.save_button)
+        self.setTabOrder(self.save_button, self.cancel_button)
+
+        self.adjustSize()
+
+    def _configure_combo(self, combo: QComboBox) -> None:
+        """Apply a disabled placeholder entry to a combo box."""
+
+        combo.clear()
+        combo.addItem("(Select…)", None)
+        model = combo.model()
+        index = model.index(0, 0)
+        model.setData(index, 0, Qt.UserRole - 1)
+        combo.setCurrentIndex(0)
+        combo.setEnabled(False)
+
+    # ------------------------------------------------------------------
+    # Data loading and population
+    # ------------------------------------------------------------------
+    def load_reference_lists(self) -> None:
+        """Load vehicle types and statuses from the master database."""
+
+        self._references_loaded = False
+        self._update_save_button_state()
+
+        while True:
+            try:
+                types_payload = self._repository.list_vehicle_types()
+                statuses_payload = self._repository.list_statuses()
+                if not types_payload or not statuses_payload:
+                    raise ValueError("Reference lists are empty")
+            except Exception as exc:  # pragma: no cover - UI branch
+                logger.error("Failed to load vehicle reference data: %s", exc)
+                choice = QMessageBox.warning(
+                    self,
+                    "Reference Data Unavailable",
+                    "Unable to load vehicle reference data.\n\n" + str(exc),
+                    QMessageBox.Retry | QMessageBox.Cancel,
+                )
+                if choice == QMessageBox.Retry:
+                    continue
+                self._vehicle_types = []
+                self._statuses = []
+                self.type_combo.setEnabled(False)
+                self.status_combo.setEnabled(False)
+                return
+            else:
+                break
+
+        self._vehicle_types = types_payload
+        self._statuses = statuses_payload
+        self._populate_combo(self.type_combo, self._vehicle_types)
+        self._populate_combo(self.status_combo, self._statuses)
+        self.type_combo.setEnabled(True)
+        self.status_combo.setEnabled(True)
+        self._references_loaded = True
+        self._update_save_button_state()
+
+        if self._pending_vehicle_load and self._vehicle_id is not None:
+            self._pending_vehicle_load = False
+            self._load_vehicle(self._vehicle_id)
+
+    def _populate_combo(self, combo: QComboBox, entries: list[dict[str, Any]]) -> None:
+        """Populate a combo box with name/id pairs."""
+
+        combo.clear()
+        combo.addItem("(Select…)", None)
+        model = combo.model()
+        index = model.index(0, 0)
+        model.setData(index, 0, Qt.UserRole - 1)
+        for entry in entries:
+            entry_id = entry.get("id")
+            label = entry.get("name") or str(entry_id)
+            combo.addItem(label, entry_id)
+        combo.setCurrentIndex(0)
+
+    def _load_vehicle(self, vehicle_id: int) -> None:
+        """Fetch a vehicle record and populate the form."""
+
+        try:
+            record = self._repository.fetch_vehicle(vehicle_id)
+            if record is None:
+                raise LookupError(f"Vehicle {vehicle_id} was not found")
+        except Exception as exc:  # pragma: no cover - UI branch
+            logger.error("Failed to load vehicle %s: %s", vehicle_id, exc)
+            QMessageBox.critical(
+                self,
+                "Unable to Load Vehicle",
+                f"Failed to load vehicle #{vehicle_id}.\n\n{exc}",
+            )
+            return
+
+        self.populate_from_record(record)
+
+    def populate_from_record(self, record: dict[str, Any]) -> None:
+        """Fill the widgets using values from a stored vehicle record."""
+
+        self._current_record = record
+        self._vehicle_id = record.get("id", self._vehicle_id)
+        self.id_value_label.setText(
+            "New" if self._vehicle_id is None else str(self._vehicle_id)
+        )
+        self._update_window_title()
+
+        self.license_plate_edit.setText(record.get("license_plate", "") or "")
+        self.vin_edit.setText(record.get("vin", "") or "")
+
+        year_value = record.get("year")
+        self.year_edit.setText(str(year_value) if year_value is not None else "")
+
+        self.make_edit.setText(record.get("make", "") or "")
+        self.model_edit.setText(record.get("model", "") or "")
+
+        capacity_value = record.get("capacity")
+        if isinstance(capacity_value, int) and 0 <= capacity_value <= 100:
+            self.capacity_spin.setValue(capacity_value)
+        else:
+            self.capacity_spin.setValue(0)
+
+        self._select_combo_value(self.type_combo, record.get("type_id"))
+        self._select_combo_value(self.status_combo, record.get("status_id"))
+
+        tags = record.get("tags")
+        if isinstance(tags, list):
+            tags_text = ", ".join(str(tag) for tag in tags)
+        else:
+            tags_text = tags or ""
+        self.tags_edit.setText(tags_text)
+
+    def _select_combo_value(self, combo: QComboBox, value: Any) -> None:
+        if value is None:
+            combo.setCurrentIndex(0)
+            return
+        index = combo.findData(value)
+        if index < 0 and isinstance(value, str):
+            try:
+                numeric_value = int(value)
+            except ValueError:
+                numeric_value = None
+            if numeric_value is not None:
+                index = combo.findData(numeric_value)
+        if index < 0 and isinstance(value, int):
+            index = combo.findData(str(value))
+        combo.setCurrentIndex(index if index >= 0 else 0)
+
+    # ------------------------------------------------------------------
+    # Form state helpers
+    # ------------------------------------------------------------------
+    def clear_form(self) -> None:
+        """Reset all user-editable fields to their defaults."""
+
+        self.license_plate_edit.clear()
+        self.vin_edit.clear()
+        self.year_edit.clear()
+        self.make_edit.clear()
+        self.model_edit.clear()
+        self.capacity_spin.setValue(0)
+        if self.type_combo.count():
+            self.type_combo.setCurrentIndex(0)
+        if self.status_combo.count():
+            self.status_combo.setCurrentIndex(0)
+        self.tags_edit.clear()
+        self._current_record = None
+
+    def set_vehicle_id(self, vehicle_id: int | None) -> None:
+        """Change the active vehicle being edited."""
+
+        self._vehicle_id = vehicle_id
+        self._pending_vehicle_load = vehicle_id is not None
+
+        if vehicle_id is None:
+            self.id_value_label.setText("New")
+            self.clear_form()
+        else:
+            self.id_value_label.setText(str(vehicle_id))
+            if self._references_loaded:
+                self._pending_vehicle_load = False
+                self._load_vehicle(vehicle_id)
+
+        self._update_window_title()
+
+    def _update_window_title(self) -> None:
+        if self._vehicle_id is None:
+            self.setWindowTitle("Add Vehicle")
+        else:
+            self.setWindowTitle(f"Edit Vehicle #{self._vehicle_id}")
+
+    def _update_save_button_state(self) -> None:
+        self.save_button.setEnabled(self._references_loaded)
+
+    # ------------------------------------------------------------------
+    # Payload collection and validation
+    # ------------------------------------------------------------------
+    def collect_payload(self) -> dict[str, Any]:
+        """Collect the current form values into a database payload."""
+
+        license_plate = self.license_plate_edit.text().strip()
+        vin = self.vin_edit.text().strip()
+
+        year_text = self.year_edit.text().strip()
+        year_value: int | None = None
+        if year_text:
+            try:
+                year_value = int(year_text)
+            except ValueError as exc:
+                raise ValueError("Year must be a number.") from exc
+
+        make_text = self.make_edit.text().strip()
+        model_text = self.model_edit.text().strip()
+
+        tags = [
+            tag.strip()
+            for tag in self.tags_edit.text().split(",")
+            if tag.strip()
+        ]
+
+        payload = {
+            "license_plate": license_plate,
+            "vin": vin,
+            "year": year_value,
+            "make": make_text or None,
+            "model": model_text or None,
+            "capacity": self.capacity_spin.value(),
+            "type_id": self.type_combo.currentData(),
+            "status_id": self.status_combo.currentData(),
+            "tags": tags,
+            "organization": (
+                self._current_record.get("organization")
+                if self._current_record
+                else None
+            ),
+        }
+        return payload
+
+    def validate_payload(self, payload: dict[str, Any]) -> tuple[bool, Optional[str]]:
+        """Validate required fields and data ranges before saving."""
+
+        if not payload.get("license_plate"):
+            return False, "License plate is required."
+        if not payload.get("vin"):
+            return False, "VIN is required."
+
+        year_value = payload.get("year")
+        if year_value is not None and not (1900 <= year_value <= 2100):
+            return False, "Year must be between 1900 and 2100."
+
+        type_id = payload.get("type_id")
+        if type_id is None or (isinstance(type_id, str) and not type_id.strip()):
+            return False, "Please select a vehicle type."
+        status_id = payload.get("status_id")
+        if status_id is None or (isinstance(status_id, str) and not status_id.strip()):
+            return False, "Please select a vehicle status."
+
+        return True, None
+
+    # ------------------------------------------------------------------
+    # Save handling
+    # ------------------------------------------------------------------
+    def on_save_clicked(self) -> None:
+        """Validate and submit the current vehicle record."""
+
+        if not self._references_loaded:
+            QMessageBox.warning(
+                self,
+                "Reference Data Missing",
+                "Reference lists have not loaded yet. Please retry after they finish loading.",
+            )
+            return
+
+        try:
+            payload = self.collect_payload()
+        except ValueError as exc:
+            QMessageBox.warning(self, "Invalid Input", str(exc))
+            return
+
+        valid, message = self.validate_payload(payload)
+        if not valid:
+            QMessageBox.warning(self, "Validation Error", message or "Invalid vehicle data.")
+            return
+
+        try:
+            if self._vehicle_id is None:
+                response = self._repository.create_vehicle(payload)
+                new_id = response.get("id")
+                if isinstance(new_id, int):
+                    self._vehicle_id = new_id
+            else:
+                response = self._repository.update_vehicle(self._vehicle_id, payload)
+        except LookupError as exc:  # pragma: no cover - UI branch
+            logger.error("Failed to save vehicle %s: %s", self._vehicle_id, exc)
+            QMessageBox.critical(
+                self,
+                "Save Failed",
+                f"The vehicle could not be found.\n\n{exc}",
+            )
+            return
+        except Exception as exc:  # pragma: no cover - UI branch
+            logger.error("Failed to save vehicle %s: %s", self._vehicle_id, exc)
+            QMessageBox.critical(
+                self,
+                "Save Failed",
+                self._format_error_message(exc),
+            )
+            return
+
+        self._current_record = response
+        self.vehicleSaved.emit(response)
+        self.accept()
+
+    def _format_error_message(self, exc: Exception) -> str:
+        """Generate a user-friendly description of a persistence error."""
+
+        if isinstance(exc, sqlite3.Error):
+            parts = [str(part) for part in exc.args if part]
+            message = " ".join(parts)
+            if message:
+                return f"Unable to save the vehicle.\n\n{message}"
+        return f"Unable to save the vehicle.\n\n{exc}"

--- a/modules/logistics/vehicle/panels/vehicle_inventory_panel.py
+++ b/modules/logistics/vehicle/panels/vehicle_inventory_panel.py
@@ -1,0 +1,373 @@
+"""Qt widgets panel presenting the vehicle inventory list."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from PySide6.QtCore import QSortFilterProxyModel, Qt, QTimer, QModelIndex
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTableView,
+    QVBoxLayout,
+    QWidget,
+)
+from PySide6.QtGui import QKeySequence, QAction
+from PySide6.QtCore import QAbstractTableModel
+
+from .vehicle_edit_window import VehicleEditDialog, VehicleRepository
+
+logger = logging.getLogger(__name__)
+
+
+class VehicleTableModel(QAbstractTableModel):
+    """Simple table model to display vehicles in a QTableView."""
+
+    _COLUMNS: list[tuple[str, str]] = [
+        ("id", "ID"),
+        ("vin", "VIN"),
+        ("license_plate", "Plate"),
+        ("year", "Year"),
+        ("make", "Make"),
+        ("model", "Model"),
+        ("capacity", "Capacity"),
+        ("type_id", "Type"),
+        ("status_id", "Status"),
+        ("tags", "Tags"),
+        ("organization", "Organization"),
+    ]
+
+    def __init__(self, vehicles: Optional[list[dict[str, Any]]] = None, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._vehicles: list[dict[str, Any]] = vehicles or []
+
+    # ------------------------------------------------------------------
+    # Qt model interface
+    # ------------------------------------------------------------------
+    def rowCount(self, parent: QModelIndex | None = None) -> int:  # type: ignore[override]
+        if parent and parent.isValid():
+            return 0
+        return len(self._vehicles)
+
+    def columnCount(self, parent: QModelIndex | None = None) -> int:  # type: ignore[override]
+        if parent and parent.isValid():
+            return 0
+        return len(self._COLUMNS)
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole) -> Any:  # type: ignore[override]
+        if not index.isValid():
+            return None
+        record = self._vehicles[index.row()]
+        key, _ = self._COLUMNS[index.column()]
+        value = record.get(key)
+
+        if role in (Qt.DisplayRole, Qt.EditRole):
+            if value is None:
+                return ""
+            if isinstance(value, list):
+                return ", ".join(str(item) for item in value)
+            return str(value)
+
+        if role == Qt.TextAlignmentRole:
+            if key in {"id", "year", "capacity"}:
+                return Qt.AlignRight | Qt.AlignVCenter
+            return Qt.AlignLeft | Qt.AlignVCenter
+
+        return None
+
+    def headerData(self, section: int, orientation: Qt.Orientation, role: int = Qt.DisplayRole) -> Any:  # type: ignore[override]
+        if role != Qt.DisplayRole:
+            return None
+        if orientation == Qt.Horizontal:
+            try:
+                return self._COLUMNS[section][1]
+            except IndexError:  # pragma: no cover - defensive
+                return None
+        return str(section + 1)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def set_vehicles(self, vehicles: list[dict[str, Any]]) -> None:
+        self.beginResetModel()
+        self._vehicles = vehicles
+        self.endResetModel()
+
+    def vehicle_at(self, row: int) -> Optional[dict[str, Any]]:
+        if 0 <= row < len(self._vehicles):
+            return self._vehicles[row]
+        return None
+
+    def find_row_by_id(self, vehicle_id: Any) -> int:
+        target = str(vehicle_id)
+        for idx, record in enumerate(self._vehicles):
+            if str(record.get("id")) == target:
+                return idx
+        return -1
+
+
+class VehicleInventoryWidget(QWidget):
+    """Widget exposing search and CRUD controls for vehicles."""
+
+    def __init__(
+        self,
+        repository: Optional[VehicleRepository] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._repository = repository or VehicleRepository()
+        self._search_timer = QTimer(self)
+        self._search_timer.setSingleShot(True)
+        self._search_timer.setInterval(350)
+        self._search_timer.timeout.connect(self._apply_search)
+
+        self._model = VehicleTableModel(parent=self)
+        self._proxy_model = QSortFilterProxyModel(self)
+        self._proxy_model.setSourceModel(self._model)
+        self._proxy_model.setDynamicSortFilter(True)
+        self._proxy_model.setSortCaseSensitivity(Qt.CaseInsensitive)
+
+        self.search_edit: QLineEdit
+        self.table_view: QTableView
+        self.add_button: QPushButton
+        self.edit_button: QPushButton
+        self.delete_button: QPushButton
+        self.refresh_button: QPushButton
+
+        self._setup_ui()
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    # UI setup
+    # ------------------------------------------------------------------
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        search_row = QHBoxLayout()
+        search_label = QLabel("Search:")
+        self.search_edit = QLineEdit()
+        self.search_edit.setPlaceholderText("Search vehicles")
+        self.search_edit.setAccessibleName("Search vehicles")
+        self.search_edit.setClearButtonEnabled(True)
+        self.search_edit.textChanged.connect(self._on_search_text_changed)
+        self.search_edit.returnPressed.connect(self._apply_search)
+
+        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button.setAccessibleName("Refresh vehicle list")
+        self.refresh_button.clicked.connect(self.refresh)
+
+        search_row.addWidget(search_label)
+        search_row.addWidget(self.search_edit, 1)
+        search_row.addWidget(self.refresh_button)
+        layout.addLayout(search_row)
+
+        self.table_view = QTableView()
+        self.table_view.setModel(self._proxy_model)
+        self.table_view.setSortingEnabled(True)
+        self.table_view.sortByColumn(4, Qt.AscendingOrder)
+        self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table_view.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.table_view.setAlternatingRowColors(True)
+        self.table_view.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.table_view.doubleClicked.connect(self._open_selected_vehicle)
+        header = self.table_view.horizontalHeader()
+        header.setStretchLastSection(True)
+        header.setSectionsMovable(True)
+        header.setSortIndicatorShown(True)
+
+        # Context actions for keyboard shortcuts
+        delete_action = QAction("Delete Vehicle", self)
+        delete_action.setShortcut(QKeySequence.Delete)
+        delete_action.setShortcutContext(Qt.WidgetWithChildrenShortcut)
+        delete_action.triggered.connect(self._delete_selected_vehicle)
+        self.addAction(delete_action)
+
+        layout.addWidget(self.table_view, 1)
+
+        button_row = QHBoxLayout()
+        button_row.addStretch(1)
+
+        self.add_button = QPushButton("Add")
+        self.add_button.setAccessibleName("Add vehicle")
+        self.add_button.clicked.connect(self._open_add_vehicle)
+        button_row.addWidget(self.add_button)
+
+        self.edit_button = QPushButton("Edit")
+        self.edit_button.setAccessibleName("Edit selected vehicle")
+        self.edit_button.clicked.connect(self._open_selected_vehicle)
+        button_row.addWidget(self.edit_button)
+
+        self.delete_button = QPushButton("Delete")
+        self.delete_button.setAccessibleName("Delete selected vehicle")
+        self.delete_button.clicked.connect(self._delete_selected_vehicle)
+        button_row.addWidget(self.delete_button)
+
+        layout.addLayout(button_row)
+
+        selection_model = self.table_view.selectionModel()
+        selection_model.selectionChanged.connect(lambda *_: self._update_actions_state())
+        self._update_actions_state()
+
+    # ------------------------------------------------------------------
+    # Data loading helpers
+    # ------------------------------------------------------------------
+    def refresh(self) -> None:
+        self.load_data()
+
+    def load_data(self, *, select_id: Any | None = None) -> None:
+        current_selection = self.selected_vehicle_id()
+        target_id = select_id if select_id is not None else current_selection
+
+        search_text = self.search_edit.text().strip()
+
+        try:
+            vehicles = self._repository.list_vehicles(search_text or None)
+        except Exception as exc:  # pragma: no cover - UI branch
+            logger.error("Failed to load vehicles: %s", exc)
+            QMessageBox.critical(
+                self,
+                "Unable to Load Vehicles",
+                f"The vehicle list could not be loaded.\n\n{exc}",
+            )
+            return
+
+        self._model.set_vehicles(vehicles)
+        self.table_view.resizeColumnsToContents()
+        self._update_actions_state()
+
+        if target_id is not None:
+            self.select_vehicle(target_id)
+
+    # ------------------------------------------------------------------
+    # Selection helpers
+    # ------------------------------------------------------------------
+    def selected_vehicle(self) -> Optional[dict[str, Any]]:
+        selection_model = self.table_view.selectionModel()
+        if selection_model is None:
+            return None
+        indexes = selection_model.selectedRows()
+        if not indexes:
+            return None
+        proxy_index = indexes[0]
+        source_index = self._proxy_model.mapToSource(proxy_index)
+        return self._model.vehicle_at(source_index.row())
+
+    def selected_vehicle_id(self) -> Any | None:
+        record = self.selected_vehicle()
+        if record is None:
+            return None
+        return record.get("id")
+
+    def select_vehicle(self, vehicle_id: Any) -> None:
+        row = self._model.find_row_by_id(vehicle_id)
+        if row < 0:
+            self.table_view.clearSelection()
+            return
+        source_index = self._model.index(row, 0)
+        proxy_index = self._proxy_model.mapFromSource(source_index)
+        if proxy_index.isValid():
+            self.table_view.selectRow(proxy_index.row())
+            self.table_view.scrollTo(proxy_index, QTableView.PositionAtCenter)
+
+    # ------------------------------------------------------------------
+    # Action handlers
+    # ------------------------------------------------------------------
+    def _on_search_text_changed(self, _text: str) -> None:
+        self._search_timer.start()
+
+    def _apply_search(self) -> None:
+        self.load_data()
+
+    def _update_actions_state(self) -> None:
+        has_selection = self.selected_vehicle() is not None
+        self.edit_button.setEnabled(has_selection)
+        self.delete_button.setEnabled(has_selection)
+
+    def _open_add_vehicle(self) -> None:
+        dialog = VehicleEditDialog(repository=self._repository, parent=self)
+        dialog.vehicleSaved.connect(self._handle_vehicle_saved)
+        dialog.exec()
+
+    def _open_selected_vehicle(self, _index: QModelIndex | None = None) -> None:
+        vehicle_id = self.selected_vehicle_id()
+        if vehicle_id is None:
+            return
+        dialog = VehicleEditDialog(vehicle_id=vehicle_id, repository=self._repository, parent=self)
+        dialog.vehicleSaved.connect(self._handle_vehicle_saved)
+        dialog.exec()
+
+    def _handle_vehicle_saved(self, record: dict[str, Any]) -> None:
+        self.load_data(select_id=record.get("id"))
+
+    def _delete_selected_vehicle(self) -> None:
+        record = self.selected_vehicle()
+        if record is None:
+            return
+
+        vehicle_id = record.get("id")
+        if vehicle_id is None:
+            return
+
+        confirmation = QMessageBox.question(
+            self,
+            "Delete Vehicle",
+            f"Are you sure you want to delete vehicle #{vehicle_id}?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if confirmation != QMessageBox.Yes:
+            return
+
+        try:
+            self._repository.delete_vehicle(vehicle_id)
+        except LookupError as exc:  # pragma: no cover - UI branch
+            QMessageBox.warning(
+                self,
+                "Vehicle Not Found",
+                f"The selected vehicle could not be deleted.\n\n{exc}",
+            )
+        except Exception as exc:  # pragma: no cover - UI branch
+            logger.error("Failed to delete vehicle %s: %s", vehicle_id, exc)
+            QMessageBox.critical(
+                self,
+                "Delete Failed",
+                f"The vehicle could not be deleted.\n\n{exc}",
+            )
+        else:
+            self.load_data()
+
+
+class VehicleInventoryDialog(QDialog):
+    """Modal window wrapping :class:`VehicleInventoryWidget`."""
+
+    def __init__(
+        self,
+        repository: Optional[VehicleRepository] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Edit Vehicles")
+        self.setModal(True)
+        self.setMinimumSize(960, 560)
+
+        layout = QVBoxLayout(self)
+        self.inventory_widget = VehicleInventoryWidget(repository=repository, parent=self)
+        layout.addWidget(self.inventory_widget)
+
+        button_row = QHBoxLayout()
+        button_row.addStretch(1)
+        close_button = QPushButton("Close")
+        close_button.setDefault(True)
+        close_button.setAutoDefault(True)
+        close_button.clicked.connect(self.reject)
+        button_row.addWidget(close_button)
+        layout.addLayout(button_row)
+
+        self.inventory_widget.setFocus()
+

--- a/modules/logistics/windows.py
+++ b/modules/logistics/windows.py
@@ -75,9 +75,11 @@ def get_personnel_panel(incident_id: object | None = None) -> QWidget:
 
 
 def get_vehicles_panel(incident_id: object | None = None) -> QWidget:
-    """Return placeholder QWidget for Vehicle Roster."""
-    return _make_panel(
-        "Vehicle Roster",
-        f"Manage vehicles — incident: {incident_id}",
+    """Return the vehicle inventory management panel."""
+
+    from modules.logistics.vehicle.panels.vehicle_inventory_panel import (
+        VehicleInventoryWidget,
     )
+
+    return VehicleInventoryWidget()
 


### PR DESCRIPTION
## Summary
- replace the dialog's HTTP API client with a VehicleRepository that talks to data/master.db
- populate reference combos from the database (with sensible defaults) and preserve existing records when saving
- submit add/update actions through SQLite, improving validation and user-friendly error reporting
- add a VehicleInventoryWidget/Dialog with a searchable roster, CRUD actions, and integration with the vehicles menu/panel
- extend VehicleRepository with list/delete helpers to support roster management

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68ca3f2aac28832ba9c504be069d6a57