### PR TITLE
Replace team detail window QML with widgets

### DIFF
--- a/modules/operations/teams/panels/team_detail_window.py
+++ b/modules/operations/teams/panels/team_detail_window.py
@@ -1,11 +1,32 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 from datetime import datetime
-import os
-import sqlite3
 
-from PySide6.QtCore import QObject, Property, Signal, Slot
+from PySide6.QtCore import QObject, Property, Signal, Slot, Qt, QTimer, QPoint
+from PySide6.QtGui import QColor, QPalette, QTextOption
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QComboBox,
+    QFormLayout,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMenu,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+    QHeaderView,
+)
 
 from utils.styles import team_status_colors, TEAM_TYPE_COLORS, subscribe_theme
 from models.database import get_incident_by_number
@@ -796,6 +817,882 @@ class TeamDetailBridge(QObject):
         # Placeholder for PDF/HTML export
         pass
 
+
+
+class TeamDetailWindow(QMainWindow):
+    """Widget-based implementation of the Team Detail window."""
+
+    def __init__(
+        self,
+        team_id: Optional[int] = None,
+        bridge: Optional[TeamDetailBridge] = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._bridge = bridge or TeamDetailBridge(self)
+        self._team_id: Optional[int] = team_id
+        self._is_air: bool = False
+        self._updating: bool = False
+        self._members_cache: List[Dict[str, Any]] = []
+        self._asset_cache: List[Dict[str, Any]] = []
+        self._equipment_cache: List[Dict[str, Any]] = []
+        self._personnel_medic_column: Optional[int] = None
+        self._assist_anim_state: bool = False
+
+        self._notes_timer = QTimer(self)
+        self._notes_timer.setSingleShot(True)
+        self._notes_timer.setInterval(500)
+        self._notes_timer.timeout.connect(self._commit_notes)
+
+        self._assist_timer = QTimer(self)
+        self._assist_timer.setInterval(700)
+        self._assist_timer.timeout.connect(self._toggle_assist_strip)
+
+        self.setWindowTitle("Team Detail")
+        self.resize(980, 700)
+
+        self._build_ui()
+        self._populate_team_type_options()
+        self._populate_status_options()
+
+        self._bridge.teamChanged.connect(self._on_team_changed)
+        self._bridge.statusChanged.connect(self._on_status_changed)
+        self._bridge.error.connect(self._show_error)
+
+        if self._team_id is not None:
+            try:
+                self._bridge.loadTeam(int(self._team_id))
+            except Exception:
+                self._on_team_changed()
+        else:
+            self._on_team_changed()
+
+    # ---- UI construction ----
+    def _build_ui(self) -> None:
+        self._central = QWidget(self)
+        self._central.setObjectName("teamDetailCentral")
+        self._central.setAutoFillBackground(True)
+        self.setCentralWidget(self._central)
+
+        main_layout = QVBoxLayout(self._central)
+        main_layout.setContentsMargins(12, 12, 12, 12)
+        main_layout.setSpacing(10)
+
+        self._title_label = QLabel("Team Detail")
+        title_font = self._title_label.font()
+        title_font.setBold(True)
+        title_font.setPointSize(20)
+        self._title_label.setFont(title_font)
+        main_layout.addWidget(self._title_label)
+
+        self._assist_banner = QFrame()
+        self._assist_banner.setObjectName("assistBanner")
+        self._assist_banner.setVisible(False)
+        self._assist_banner.setStyleSheet(
+            "#assistBanner {"
+            " background-color: #7a001a;"
+            " border: 1px solid #ffb3c1;"
+            " border-radius: 6px;"
+            "}"
+        )
+        banner_layout = QVBoxLayout(self._assist_banner)
+        banner_layout.setContentsMargins(0, 0, 0, 0)
+        banner_layout.setSpacing(0)
+
+        self._assist_strip = QFrame()
+        self._assist_strip.setFixedHeight(3)
+        self._assist_strip.setStyleSheet("background-color: #ff4d6d; border-radius: 2px;")
+        banner_layout.addWidget(self._assist_strip)
+
+        banner_row = QHBoxLayout()
+        banner_row.setContentsMargins(10, 6, 10, 6)
+        banner_row.setSpacing(8)
+        banner_label = QLabel("⚠️  NEEDS ASSISTANCE")
+        banner_label.setStyleSheet("color: white; font-weight: bold;")
+        banner_row.addWidget(banner_label)
+        banner_row.addStretch()
+        banner_layout.addLayout(banner_row)
+        main_layout.addWidget(self._assist_banner)
+
+        overview_frame = QFrame()
+        overview_frame.setObjectName("overviewFrame")
+        overview_frame.setStyleSheet(
+            "#overviewFrame {"
+            " background-color: rgba(255, 255, 255, 0.92);"
+            " border: 1px solid #d0d0d0;"
+            " border-radius: 6px;"
+            "}"
+        )
+        overview_layout = QVBoxLayout(overview_frame)
+        overview_layout.setContentsMargins(10, 10, 10, 10)
+        overview_layout.setSpacing(8)
+
+        grid = QGridLayout()
+        grid.setHorizontalSpacing(24)
+        grid.setVerticalSpacing(8)
+        overview_layout.addLayout(grid)
+
+        left_widget = QWidget()
+        left_form = QFormLayout(left_widget)
+        left_form.setContentsMargins(0, 0, 0, 0)
+        left_form.setSpacing(8)
+        left_form.setLabelAlignment(Qt.AlignRight)
+
+        self._team_type_label = QLabel("Team Type")
+        self._team_type_combo = QComboBox()
+        left_form.addRow(self._team_type_label, self._team_type_combo)
+
+        self._name_label = QLabel("Team Name")
+        self._name_field = QLineEdit()
+        left_form.addRow(self._name_label, self._name_field)
+
+        self._leader_label = QLabel("Team Leader")
+        self._leader_field = QLineEdit()
+        self._leader_field.setReadOnly(True)
+        left_form.addRow(self._leader_label, self._leader_field)
+
+        self._phone_label = QLabel("Phone")
+        self._phone_field = QLineEdit()
+        self._phone_field.setReadOnly(True)
+        left_form.addRow(self._phone_label, self._phone_field)
+
+        self._status_label = QLabel("Status")
+        self._status_combo = QComboBox()
+        left_form.addRow(self._status_label, self._status_combo)
+
+        grid.addWidget(left_widget, 0, 0)
+
+        right_widget = QWidget()
+        right_form = QFormLayout(right_widget)
+        right_form.setContentsMargins(0, 0, 0, 0)
+        right_form.setSpacing(8)
+        right_form.setLabelAlignment(Qt.AlignRight)
+
+        last_contact_label = QLabel("Last Contact")
+        self._last_contact_value = QLabel("–")
+        right_form.addRow(last_contact_label, self._last_contact_value)
+
+        task_row_widget = QWidget()
+        task_row_layout = QHBoxLayout(task_row_widget)
+        task_row_layout.setContentsMargins(0, 0, 0, 0)
+        task_row_layout.setSpacing(6)
+        self._task_field = QLineEdit()
+        self._task_field.setReadOnly(True)
+        task_row_layout.addWidget(self._task_field)
+        self._task_button = QPushButton("Link…")
+        task_row_layout.addWidget(self._task_button)
+        self._unlink_task_button = QPushButton("Unlink")
+        self._unlink_task_button.setVisible(False)
+        task_row_layout.addWidget(self._unlink_task_button)
+        right_form.addRow(QLabel("Primary Task"), task_row_widget)
+
+        self._assignment_field = QLineEdit()
+        right_form.addRow(QLabel("Assignment"), self._assignment_field)
+
+        grid.addWidget(right_widget, 0, 1)
+
+        notes_label = QLabel("Notes")
+        self._notes_edit = QTextEdit()
+        self._notes_edit.setWordWrapMode(QTextOption.WordWrap)
+        self._notes_edit.setFixedHeight(90)
+        overview_layout.addWidget(notes_label)
+        overview_layout.addWidget(self._notes_edit)
+
+        main_layout.addWidget(overview_frame)
+
+        actions_layout = QHBoxLayout()
+        actions_layout.setSpacing(8)
+        self._edit_team_button = QPushButton("Edit Team")
+        actions_layout.addWidget(self._edit_team_button)
+        self._needs_assist_button = QPushButton("Flag Needs Assistance")
+        actions_layout.addWidget(self._needs_assist_button)
+        self._status_button = QPushButton("Update Status")
+        actions_layout.addWidget(self._status_button)
+        self._view_task_button = QPushButton("View Task")
+        actions_layout.addWidget(self._view_task_button)
+        actions_layout.addStretch()
+        main_layout.addLayout(actions_layout)
+
+        self._tabs = QTabWidget()
+        self._tabs.setDocumentMode(True)
+        self._tabs.setTabPosition(QTabWidget.North)
+        main_layout.addWidget(self._tabs, 1)
+
+        self._personnel_tab = QWidget()
+        self._assets_tab = QWidget()
+        self._equipment_tab = QWidget()
+        self._logs_tab = QWidget()
+        self._tabs.addTab(self._personnel_tab, "Personnel (Ground)")
+        self._tabs.addTab(self._assets_tab, "Vehicles")
+        self._tabs.addTab(self._equipment_tab, "Equipment")
+        self._tabs.addTab(self._logs_tab, "Logs")
+
+        personnel_layout = QVBoxLayout(self._personnel_tab)
+        personnel_layout.setContentsMargins(0, 0, 0, 0)
+        personnel_layout.setSpacing(8)
+        member_buttons = QHBoxLayout()
+        member_buttons.setSpacing(6)
+        self._add_member_button = QPushButton("Add Personnel")
+        member_buttons.addWidget(self._add_member_button)
+        member_buttons.addStretch()
+        self._member_detail_button = QPushButton("Detail")
+        self._member_detail_button.setEnabled(False)
+        member_buttons.addWidget(self._member_detail_button)
+        personnel_layout.addLayout(member_buttons)
+
+        self._personnel_table = QTableWidget()
+        self._personnel_table.setAlternatingRowColors(True)
+        self._personnel_table.verticalHeader().setVisible(False)
+        self._personnel_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._personnel_table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._personnel_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._personnel_table.setContextMenuPolicy(Qt.CustomContextMenu)
+        self._personnel_table.customContextMenuRequested.connect(self._show_personnel_menu)
+        self._personnel_table.itemSelectionChanged.connect(self._on_member_selection_changed)
+        personnel_layout.addWidget(self._personnel_table)
+
+        assets_layout = QVBoxLayout(self._assets_tab)
+        assets_layout.setContentsMargins(0, 0, 0, 0)
+        assets_layout.setSpacing(8)
+        asset_buttons = QHBoxLayout()
+        asset_buttons.setSpacing(6)
+        self._asset_add_button = QPushButton("Add Vehicle")
+        asset_buttons.addWidget(self._asset_add_button)
+        asset_buttons.addStretch()
+        assets_layout.addLayout(asset_buttons)
+
+        self._asset_table = QTableWidget()
+        self._asset_table.setAlternatingRowColors(True)
+        self._asset_table.verticalHeader().setVisible(False)
+        self._asset_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._asset_table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._asset_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        assets_layout.addWidget(self._asset_table)
+
+        equipment_layout = QVBoxLayout(self._equipment_tab)
+        equipment_layout.setContentsMargins(0, 0, 0, 0)
+        equipment_layout.setSpacing(8)
+        equipment_buttons = QHBoxLayout()
+        equipment_buttons.setSpacing(6)
+        self._equipment_add_button = QPushButton("Add Equipment")
+        equipment_buttons.addWidget(self._equipment_add_button)
+        equipment_buttons.addStretch()
+        equipment_layout.addLayout(equipment_buttons)
+
+        self._equipment_table = QTableWidget()
+        self._equipment_table.setAlternatingRowColors(True)
+        self._equipment_table.verticalHeader().setVisible(False)
+        self._equipment_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._equipment_table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._equipment_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        equipment_layout.addWidget(self._equipment_table)
+
+        logs_layout = QVBoxLayout(self._logs_tab)
+        logs_layout.setContentsMargins(0, 0, 0, 0)
+        logs_layout.setSpacing(8)
+        placeholder = QLabel("Logs will appear here when implemented.")
+        placeholder.setAlignment(Qt.AlignCenter)
+        placeholder.setStyleSheet("color: #555555;")
+        logs_layout.addWidget(placeholder)
+        self._tabs.setTabEnabled(3, False)
+
+        # Connections for form controls
+        self._team_type_combo.currentIndexChanged.connect(self._handle_team_type_changed)
+        self._status_combo.currentIndexChanged.connect(self._handle_status_changed)
+        self._name_field.editingFinished.connect(self._handle_name_edited)
+        self._assignment_field.editingFinished.connect(self._handle_assignment_edited)
+        self._notes_edit.textChanged.connect(self._on_notes_changed)
+        self._task_button.clicked.connect(self._handle_task_button)
+        self._unlink_task_button.clicked.connect(self._handle_unlink_task)
+        self._edit_team_button.clicked.connect(self._handle_edit_team)
+        self._needs_assist_button.clicked.connect(self._bridge.raiseNeedsAssist)
+        self._status_button.clicked.connect(self._status_combo.showPopup)
+        self._view_task_button.clicked.connect(self._handle_view_task)
+        self._add_member_button.clicked.connect(self._handle_add_member)
+        self._member_detail_button.clicked.connect(self._handle_member_detail)
+        self._asset_add_button.clicked.connect(self._handle_add_asset)
+        self._equipment_add_button.clicked.connect(self._handle_add_equipment)
+
+    # ---- Data refresh helpers ----
+    def _populate_team_type_options(self) -> None:
+        options = getattr(self._bridge, "teamTypeList", []) or []
+        self._team_type_combo.blockSignals(True)
+        self._team_type_combo.clear()
+        for opt in options:
+            label = str(opt.get("label", ""))
+            code = str(opt.get("code", ""))
+            self._team_type_combo.addItem(label, code)
+        self._team_type_combo.blockSignals(False)
+
+    def _populate_status_options(self) -> None:
+        options = getattr(self._bridge, "statusList", []) or []
+        self._status_combo.blockSignals(True)
+        self._status_combo.clear()
+        for opt in options:
+            label = str(opt.get("label", ""))
+            key = str(opt.get("key", label)).strip().lower()
+            self._status_combo.addItem(label, key)
+        self._status_combo.blockSignals(False)
+
+    def _on_team_changed(self) -> None:
+        self._updating = True
+        team = self._bridge.team if hasattr(self._bridge, "team") else {}
+        team = team or {}
+        self._is_air = bool(getattr(self._bridge, "isAircraftTeam", False))
+        try:
+            self._members_cache = (
+                self._bridge.aircrewMembers() if self._is_air else self._bridge.groundMembers()
+            )
+        except Exception:
+            self._members_cache = []
+        try:
+            self._asset_cache = (
+                self._bridge.aircraft() if self._is_air else self._bridge.vehicles()
+            )
+        except Exception:
+            self._asset_cache = []
+        try:
+            self._equipment_cache = self._bridge.equipment()
+        except Exception:
+            self._equipment_cache = []
+
+        self._apply_team_type_ui()
+        self._update_background()
+        self._update_title(team)
+        self._populate_team_type_selection(team)
+        self._populate_status_selection(team)
+        self._update_leader_fields(team)
+        self._update_name_assignment_fields(team)
+        self._update_last_contact(team)
+        self._update_task_widgets(team)
+        self._update_notes_field(team)
+        self._populate_personnel_table(self._members_cache)
+        self._populate_assets_table(self._asset_cache)
+        self._populate_equipment_table(self._equipment_cache)
+        self._update_assistance_ui()
+        self._update_member_detail_button()
+        self._apply_status_palette()
+
+        self._updating = False
+
+    def _on_status_changed(self, status_key: str) -> None:
+        if self._updating:
+            return
+        self._populate_status_selection({"status": status_key})
+        self._apply_status_palette()
+
+    def _apply_team_type_ui(self) -> None:
+        if self._is_air:
+            self._name_label.setText("Callsign")
+            self._leader_label.setText("Pilot")
+            self._tabs.setTabText(0, "Aircrew")
+            self._tabs.setTabText(1, "Aircraft")
+            self._add_member_button.setText("Add Aircrew")
+            self._asset_add_button.setText("Add Aircraft")
+        else:
+            self._name_label.setText("Team Name")
+            self._leader_label.setText("Team Leader")
+            self._tabs.setTabText(0, "Personnel (Ground)")
+            self._tabs.setTabText(1, "Vehicles")
+            self._add_member_button.setText("Add Personnel")
+            self._asset_add_button.setText("Add Vehicle")
+
+    def _update_title(self, team: Dict[str, Any]) -> None:
+        parts: List[str] = []
+        team_type = str(team.get("team_type", "")).upper()
+        if team_type:
+            parts.append(team_type)
+        name = ""
+        if self._is_air:
+            name = team.get("callsign") or team.get("name") or ""
+        else:
+            name = team.get("name") or ""
+        if name:
+            parts.append(str(name))
+        leader_id = team.get("team_leader_id")
+        leader_last = ""
+        if leader_id is not None:
+            try:
+                leader_name = self._bridge.leaderName(int(leader_id))  # type: ignore[arg-type]
+            except Exception:
+                leader_name = ""
+            if leader_name:
+                bits = str(leader_name).strip().split()
+                if bits:
+                    leader_last = bits[-1]
+        if leader_last:
+            parts.append(leader_last)
+        title = " - ".join(p for p in parts if p)
+        self._title_label.setText(title or "Team Detail")
+        if name:
+            self.setWindowTitle(f"Team Detail - {name}")
+        else:
+            self.setWindowTitle("Team Detail")
+
+    def _populate_team_type_selection(self, team: Dict[str, Any]) -> None:
+        current = str(team.get("team_type", ""))
+        self._team_type_combo.blockSignals(True)
+        index = self._team_type_combo.findData(current)
+        if index == -1:
+            index = self._team_type_combo.findData(current.upper())
+        if index >= 0:
+            self._team_type_combo.setCurrentIndex(index)
+        self._team_type_combo.blockSignals(False)
+
+    def _populate_status_selection(self, team: Dict[str, Any]) -> None:
+        status = str(team.get("status", "")).strip().lower()
+        self._status_combo.blockSignals(True)
+        index = self._status_combo.findData(status)
+        if index >= 0:
+            self._status_combo.setCurrentIndex(index)
+        self._status_combo.blockSignals(False)
+
+    def _update_leader_fields(self, team: Dict[str, Any]) -> None:
+        leader_id = team.get("team_leader_id")
+        leader_name = ""
+        leader_phone = team.get("team_leader_phone") or team.get("phone") or ""
+        if leader_id is not None:
+            try:
+                leader_name = self._bridge.leaderName(int(leader_id))
+            except Exception:
+                leader_name = ""
+            for member in self._members_cache:
+                if str(member.get("id")) == str(leader_id):
+                    leader_phone = member.get("phone") or leader_phone or ""
+                    break
+        self._leader_field.setText(leader_name or "")
+        self._phone_field.setText(str(leader_phone or ""))
+
+    def _update_name_assignment_fields(self, team: Dict[str, Any]) -> None:
+        name_value = team.get("name") or ""
+        callsign_value = team.get("callsign") or ""
+        display_name = callsign_value if self._is_air else name_value
+        if self._is_air and not display_name:
+            display_name = name_value
+        self._name_field.blockSignals(True)
+        self._name_field.setText(str(display_name or ""))
+        self._name_field.blockSignals(False)
+
+        assignment = team.get("assignment") or ""
+        self._assignment_field.blockSignals(True)
+        self._assignment_field.setText(str(assignment or ""))
+        self._assignment_field.blockSignals(False)
+
+    def _update_last_contact(self, team: Dict[str, Any]) -> None:
+        ts = team.get("last_comm_ts") or team.get("last_contact_ts") or team.get("last_update_ts")
+        label = "–"
+        if ts:
+            try:
+                dt = datetime.fromisoformat(str(ts))
+                label = dt.strftime("%Y-%m-%d %H:%M")
+            except Exception:
+                label = str(ts)
+        self._last_contact_value.setText(label)
+
+    def _update_task_widgets(self, team: Dict[str, Any]) -> None:
+        task_id = team.get("current_task_id") or team.get("primary_task_id")
+        task_display = str(task_id) if task_id else ""
+        self._task_field.setText(task_display)
+        if task_id:
+            self._task_button.setText("Open")
+            self._unlink_task_button.setVisible(True)
+        else:
+            self._task_button.setText("Link…")
+            self._unlink_task_button.setVisible(False)
+        self._view_task_button.setEnabled(bool(task_id))
+
+    def _update_notes_field(self, team: Dict[str, Any]) -> None:
+        notes = team.get("notes") or ""
+        self._notes_timer.stop()
+        self._notes_edit.blockSignals(True)
+        self._notes_edit.setPlainText(str(notes))
+        self._notes_edit.blockSignals(False)
+
+    def _populate_personnel_table(self, members: List[Dict[str, Any]]) -> None:
+        headers = []
+        if self._is_air:
+            headers = ["ID", "Name", "Role", "Phone", "Certifications", "PIC", "Actions"]
+        else:
+            headers = ["ID", "Name", "Role", "Phone", "Leader", "Medic", "Actions"]
+        self._personnel_table.clear()
+        self._personnel_table.setRowCount(len(members))
+        self._personnel_table.setColumnCount(len(headers))
+        self._personnel_table.setHorizontalHeaderLabels(headers)
+
+        roles = []
+        try:
+            roles = self._bridge.teamRoleOptions() or []
+        except Exception:
+            roles = []
+
+        role_col = 2
+        phone_col = 3
+        leader_col = 5 if self._is_air else 4
+        actions_col = len(headers) - 1
+        self._personnel_medic_column = None
+        if not self._is_air:
+            self._personnel_medic_column = 5
+
+        for row, member in enumerate(members):
+            member_id = member.get("id")
+            id_item = QTableWidgetItem(str(member_id) if member_id is not None else "")
+            id_item.setData(Qt.UserRole, member_id)
+            id_item.setTextAlignment(Qt.AlignCenter)
+            self._personnel_table.setItem(row, 0, id_item)
+
+            name_item = QTableWidgetItem(str(member.get("name") or ""))
+            self._personnel_table.setItem(row, 1, name_item)
+
+            role_combo = QComboBox()
+            role_combo.addItem("", "")
+            for role in roles:
+                role_combo.addItem(str(role), role)
+            current_role = member.get("role") or ""
+            role_combo.blockSignals(True)
+            if current_role:
+                idx = role_combo.findData(current_role)
+                if idx == -1:
+                    idx = role_combo.findText(str(current_role))
+                if idx >= 0:
+                    role_combo.setCurrentIndex(idx)
+            role_combo.blockSignals(False)
+            role_combo.currentIndexChanged.connect(
+                lambda idx, pid=member_id, combo=role_combo: self._on_role_changed(pid, combo.itemData(idx))
+            )
+            self._personnel_table.setCellWidget(row, role_col, role_combo)
+
+            phone_item = QTableWidgetItem(str(member.get("phone") or ""))
+            self._personnel_table.setItem(row, phone_col, phone_item)
+
+            if self._is_air:
+                certs_item = QTableWidgetItem(str(member.get("certs") or ""))
+                self._personnel_table.setItem(row, 4, certs_item)
+                pic_item = QTableWidgetItem("Yes" if member.get("isPIC") else "")
+                pic_item.setTextAlignment(Qt.AlignCenter)
+                self._personnel_table.setItem(row, leader_col, pic_item)
+            else:
+                leader_item = QTableWidgetItem("Yes" if member.get("isLeader") else "")
+                leader_item.setTextAlignment(Qt.AlignCenter)
+                self._personnel_table.setItem(row, leader_col, leader_item)
+                medic_col = self._personnel_medic_column
+                if medic_col is not None:
+                    medic_box = QCheckBox()
+                    medic_box.setChecked(bool(member.get("isMedic")))
+                    medic_box.stateChanged.connect(
+                        lambda state, pid=member_id: self._on_medic_toggled(pid, state)
+                    )
+                    self._personnel_table.setCellWidget(row, medic_col, medic_box)
+
+            remove_btn = QPushButton("Remove")
+            remove_btn.clicked.connect(
+                lambda _=False, pid=member_id: self._bridge.removeMember(pid) if pid is not None else None
+            )
+            self._personnel_table.setCellWidget(row, actions_col, remove_btn)
+
+        header = self._personnel_table.horizontalHeader()
+        for col in range(len(headers)):
+            mode = QHeaderView.ResizeToContents
+            if col == 1:
+                mode = QHeaderView.Stretch
+            header.setSectionResizeMode(col, mode)
+
+    def _populate_assets_table(self, assets: List[Dict[str, Any]]) -> None:
+        if self._is_air:
+            headers = ["ID", "Tail/Callsign", "Type", "Base", "Comms", "Actions"]
+        else:
+            headers = ["ID", "Callsign/Name", "Type", "Driver", "Phone", "Actions"]
+        self._asset_table.clear()
+        self._asset_table.setRowCount(len(assets))
+        self._asset_table.setColumnCount(len(headers))
+        self._asset_table.setHorizontalHeaderLabels(headers)
+
+        for row, asset in enumerate(assets):
+            asset_id = asset.get("id")
+            id_item = QTableWidgetItem(str(asset_id) if asset_id is not None else "")
+            id_item.setData(Qt.UserRole, asset_id)
+            id_item.setTextAlignment(Qt.AlignCenter)
+            self._asset_table.setItem(row, 0, id_item)
+
+            label_value = ""
+            if self._is_air:
+                label_value = asset.get("tail") or asset.get("callsign") or ""
+            else:
+                label_value = asset.get("callsign") or asset.get("name") or ""
+            label_item = QTableWidgetItem(str(label_value))
+            self._asset_table.setItem(row, 1, label_item)
+
+            type_item = QTableWidgetItem(str(asset.get("type") or ""))
+            self._asset_table.setItem(row, 2, type_item)
+
+            driver_value = asset.get("base") if self._is_air else asset.get("driver")
+            driver_item = QTableWidgetItem(str(driver_value or ""))
+            self._asset_table.setItem(row, 3, driver_item)
+
+            comm_value = asset.get("comms") or asset.get("phone") or ""
+            comm_item = QTableWidgetItem(str(comm_value))
+            self._asset_table.setItem(row, 4, comm_item)
+
+            remove_btn = QPushButton("Remove")
+            remove_btn.clicked.connect(
+                lambda _=False, aid=asset_id: self._bridge.removeAsset(aid) if aid is not None else None
+            )
+            self._asset_table.setCellWidget(row, len(headers) - 1, remove_btn)
+
+        header = self._asset_table.horizontalHeader()
+        for col in range(len(headers)):
+            mode = QHeaderView.ResizeToContents
+            if col == 1:
+                mode = QHeaderView.Stretch
+            header.setSectionResizeMode(col, mode)
+
+    def _populate_equipment_table(self, equipment: List[Dict[str, Any]]) -> None:
+        headers = ["ID", "Name", "Qty", "Notes", "Actions"]
+        self._equipment_table.clear()
+        self._equipment_table.setRowCount(len(equipment))
+        self._equipment_table.setColumnCount(len(headers))
+        self._equipment_table.setHorizontalHeaderLabels(headers)
+
+        for row, item in enumerate(equipment):
+            eq_id = item.get("id")
+            id_item = QTableWidgetItem(str(eq_id) if eq_id is not None else "")
+            id_item.setData(Qt.UserRole, eq_id)
+            id_item.setTextAlignment(Qt.AlignCenter)
+            self._equipment_table.setItem(row, 0, id_item)
+
+            name_item = QTableWidgetItem(str(item.get("name") or ""))
+            self._equipment_table.setItem(row, 1, name_item)
+
+            qty_item = QTableWidgetItem(str(item.get("qty") or ""))
+            qty_item.setTextAlignment(Qt.AlignCenter)
+            self._equipment_table.setItem(row, 2, qty_item)
+
+            notes_item = QTableWidgetItem(str(item.get("notes") or ""))
+            self._equipment_table.setItem(row, 3, notes_item)
+
+            remove_btn = QPushButton("Remove")
+            remove_btn.clicked.connect(
+                lambda _=False, eid=eq_id: self._bridge.removeEquipment(eid) if eid is not None else None
+            )
+            self._equipment_table.setCellWidget(row, len(headers) - 1, remove_btn)
+
+        header = self._equipment_table.horizontalHeader()
+        for col in range(len(headers)):
+            mode = QHeaderView.ResizeToContents
+            if col == 3:
+                mode = QHeaderView.Stretch
+            header.setSectionResizeMode(col, mode)
+
+    def _update_assistance_ui(self) -> None:
+        needs_assist = bool(getattr(self._bridge, "needsAssistActive", False))
+        self._assist_banner.setVisible(needs_assist)
+        if needs_assist:
+            if not self._assist_timer.isActive():
+                self._assist_anim_state = False
+                self._assist_timer.start()
+            self._needs_assist_button.setText("NEEDS ASSISTANCE")
+            self._needs_assist_button.setStyleSheet(
+                "QPushButton { background-color: #c1121f; color: white; font-weight: bold; }"
+            )
+        else:
+            self._assist_timer.stop()
+            self._assist_strip.setStyleSheet("background-color: #ff4d6d; border-radius: 2px;")
+            self._needs_assist_button.setText("Flag Needs Assistance")
+            self._needs_assist_button.setStyleSheet("")
+
+    def _apply_status_palette(self) -> None:
+        try:
+            colors = self._bridge.teamStatusColor
+        except Exception:
+            colors = {"bg": "#888888", "fg": "#000000"}
+        bg = colors.get("bg", "#888888")
+        fg = colors.get("fg", "#000000")
+        self._status_combo.setStyleSheet(
+            f"QComboBox {{ background-color: {bg}; color: {fg}; font-weight: bold; }}"
+        )
+
+    def _update_background(self) -> None:
+        try:
+            color_str = getattr(self._bridge, "teamTypeColor", "#f0f0f0")
+        except Exception:
+            color_str = "#f0f0f0"
+        color = QColor(str(color_str))
+        if not color.isValid():
+            color = QColor("#f0f0f0")
+        base = color.lighter(130)
+        palette = self._central.palette()
+        palette.setColor(QPalette.Window, base)
+        self._central.setPalette(palette)
+
+    def _show_error(self, message: str) -> None:
+        QMessageBox.warning(self, "Team Detail", message)
+
+    def _handle_team_type_changed(self, index: int) -> None:
+        if self._updating:
+            return
+        code = self._team_type_combo.itemData(index)
+        if code is None:
+            return
+        try:
+            self._bridge.setTeamType(code)
+        except Exception:
+            pass
+
+    def _handle_status_changed(self, index: int) -> None:
+        if self._updating:
+            return
+        key = self._status_combo.itemData(index)
+        if key is None:
+            return
+        try:
+            self._bridge.setStatus(str(key))
+        except Exception:
+            pass
+
+    def _handle_name_edited(self) -> None:
+        if self._updating:
+            return
+        value = self._name_field.text().strip()
+        payload = {"callsign": value} if self._is_air else {"name": value}
+        try:
+            self._bridge.updateFromQml(payload)
+        except Exception:
+            pass
+
+    def _handle_assignment_edited(self) -> None:
+        if self._updating:
+            return
+        value = self._assignment_field.text().strip()
+        try:
+            self._bridge.updateFromQml({"assignment": value})
+        except Exception:
+            pass
+
+    def _on_notes_changed(self) -> None:
+        if self._updating:
+            return
+        self._notes_timer.start()
+
+    def _commit_notes(self) -> None:
+        if self._updating:
+            return
+        text = self._notes_edit.toPlainText()
+        try:
+            self._bridge.updateFromQml({"notes": text})
+        except Exception:
+            pass
+
+    def _handle_task_button(self) -> None:
+        team = self._bridge.team if hasattr(self._bridge, "team") else {}
+        task_id = team.get("current_task_id") or team.get("primary_task_id")
+        if task_id:
+            self._handle_view_task()
+            return
+        dialog = getattr(self._bridge, "linkTaskDialog", None)
+        if dialog and hasattr(dialog, "open"):
+            dialog.open()
+            return
+        QMessageBox.information(
+            self,
+            "Link Task",
+            "Linking a task requires the task linking dialog, which is not available.",
+        )
+
+    def _handle_unlink_task(self) -> None:
+        team = self._bridge.team if hasattr(self._bridge, "team") else {}
+        task_id = team.get("current_task_id") or team.get("primary_task_id")
+        if task_id and hasattr(self._bridge, "unlinkTask"):
+            try:
+                self._bridge.unlinkTask(int(task_id))
+            except Exception:
+                pass
+
+    def _handle_view_task(self) -> None:
+        handler = getattr(self._bridge, "openTaskDetail", None)
+        if callable(handler):
+            handler()
+
+    def _handle_edit_team(self) -> None:
+        handler = getattr(self._bridge, "openEditTeam", None)
+        if callable(handler):
+            handler()
+
+    def _handle_add_member(self) -> None:
+        handler = getattr(self._bridge, "addMember", None)
+        if callable(handler):
+            handler()
+
+    def _handle_member_detail(self) -> None:
+        handler = getattr(self._bridge, "openSelectedMember", None)
+        if callable(handler):
+            handler()
+
+    def _handle_add_asset(self) -> None:
+        handler = getattr(self._bridge, "addAsset", None)
+        if callable(handler):
+            handler()
+
+    def _handle_add_equipment(self) -> None:
+        handler = getattr(self._bridge, "addEquipment", None)
+        if callable(handler):
+            handler()
+
+    def _on_member_selection_changed(self) -> None:
+        has_selection = bool(self._personnel_table.selectionModel().selectedRows())
+        handler = getattr(self._bridge, "openSelectedMember", None)
+        self._member_detail_button.setEnabled(bool(has_selection and callable(handler)))
+
+    def _show_personnel_menu(self, pos: QPoint) -> None:
+        row = self._personnel_table.rowAt(pos.y())
+        if row < 0:
+            return
+        item = self._personnel_table.item(row, 0)
+        if item is None:
+            return
+        person_id = item.data(Qt.UserRole)
+        if person_id is None:
+            return
+        menu = QMenu(self)
+        label = "Set as PIC" if self._is_air else "Set as Leader"
+        menu.addAction(label, lambda: self._bridge.setLeader(person_id))
+        if not self._is_air and self._personnel_medic_column is not None:
+            widget = self._personnel_table.cellWidget(row, self._personnel_medic_column)
+            is_medic = bool(widget.isChecked()) if isinstance(widget, QCheckBox) else False
+            toggle_text = "Unset Medic" if is_medic else "Mark as Medic"
+            menu.addAction(
+                toggle_text,
+                lambda: self._bridge.setMedic(person_id, not is_medic),
+            )
+        menu.addAction("Remove", lambda: self._bridge.removeMember(person_id))
+        menu.exec(self._personnel_table.viewport().mapToGlobal(pos))
+
+    def _on_role_changed(self, person_id: Any, value: Any) -> None:
+        if self._updating or person_id is None:
+            return
+        role_value = value if value not in (None, "") else None
+        try:
+            self._bridge.setPersonRole(int(person_id), role_value)
+        except Exception:
+            pass
+
+    def _on_medic_toggled(self, person_id: Any, state: int) -> None:
+        if self._updating or person_id is None:
+            return
+        handler = getattr(self._bridge, "setMedic", None)
+        if callable(handler):
+            try:
+                handler(int(person_id), state == Qt.Checked)
+            except Exception:
+                pass
+
+    def _toggle_assist_strip(self) -> None:
+        self._assist_anim_state = not self._assist_anim_state
+        color = "#ff4d6d" if self._assist_anim_state else "#ffb3c1"
+        self._assist_strip.setStyleSheet(f"background-color: {color}; border-radius: 2px;")
+
+    def _update_member_detail_button(self) -> None:
+        handler = getattr(self._bridge, "openSelectedMember", None)
+        enabled = bool(callable(handler) and self._personnel_table.selectionModel().hasSelection())
+        self._member_detail_button.setEnabled(enabled)
 
 
 

--- a/modules/operations/teams/windows.py
+++ b/modules/operations/teams/windows.py
@@ -1,49 +1,25 @@
 from __future__ import annotations
 
-import os
 from typing import Optional
 
-from PySide6.QtQml import QQmlApplicationEngine
-from PySide6.QtCore import QUrl
-
-from .panels.team_detail_window import TeamDetailBridge
+from .panels.team_detail_window import TeamDetailWindow
 
 
-_open_engines: list[QQmlApplicationEngine] = []
+_open_windows: list[TeamDetailWindow] = []
 
 
-def open_team_detail_window(team_id: Optional[int] = None):
-    """Open the Team Detail window.
+def open_team_detail_window(team_id: Optional[int] = None) -> TeamDetailWindow:
+    """Open the Team Detail window using the widget-based implementation."""
 
-    Loads modules/operations/teams/qml/TeamDetailWindow.qml, injects a
-    TeamDetailBridge as `teamBridge`, and passes the optional teamId.
-    """
-    qml_path = os.path.abspath(os.path.join(
-        "modules", "operations", "teams", "qml", "TeamDetailWindow.qml"
-    ))
-    engine = QQmlApplicationEngine()
-    # Inject bridge first so QML can call it on startup
-    bridge = TeamDetailBridge()
-    engine.rootContext().setContextProperty("teamBridge", bridge)
-    engine.load(QUrl.fromLocalFile(qml_path))
-    # If a team id was provided, load it immediately so the bridge
-    # has data even if QML hasn't yet reacted to the property change.
-    if team_id is not None:
+    window = TeamDetailWindow(team_id=team_id)
+    window.show()
+    _open_windows.append(window)
+
+    def _cleanup() -> None:
         try:
-            bridge.loadTeam(int(team_id))
-        except Exception:
+            _open_windows.remove(window)
+        except ValueError:
             pass
-    roots = engine.rootObjects()
-    if roots:
-        root = roots[0]
-        try:
-            if team_id is not None:
-                root.setProperty("teamId", int(team_id))
-        except Exception:
-            pass
-        try:
-            root.setProperty("visible", True)
-        except Exception:
-            pass
-    _open_engines.append(engine)
-    return engine
+
+    window.destroyed.connect(lambda *_: _cleanup())
+    return window


### PR DESCRIPTION
## Summary
- add a TeamDetailWindow QMainWindow that mirrors the previous QML layout while reusing TeamDetailBridge for data and actions
- implement form bindings, assistance banner animation, tabular personnel/asset/equipment views, and debounced notes updates in widgets
- update the launcher to open the new widget-based window and track live instances

## Testing
- pytest --import-mode=importlib *(fails: missing libGL runtime dependency in container)*

------
https://chatgpt.com/codex/tasks/task_b_68cce96773fc832b8cb3347564d735a8