### PR TITLE
Fix PySide6 QShortcut usage

### DIFF
--- a/modules/logistics/resource_requests/panels/request_list_panel.py
+++ b/modules/logistics/resource_requests/panels/request_list_panel.py
@@ -66,8 +66,8 @@ class ResourceRequestListPanel(QtWidgets.QWidget):
         button_bar.addStretch(1)
         layout.addLayout(button_bar)
 
-        QtWidgets.QShortcut(QtGui.QKeySequence.New, self, self._new_request)
-        QtWidgets.QShortcut(QtGui.QKeySequence(QtCore.Qt.CTRL | QtCore.Qt.Key_Return), self, self._submit_selected)
+        QtGui.QShortcut(QtGui.QKeySequence.New, self, self._new_request)
+        QtGui.QShortcut(QtGui.QKeySequence(QtCore.Qt.CTRL | QtCore.Qt.Key_Return), self, self._submit_selected)
 
         self.refresh()
 


### PR DESCRIPTION
## Summary
- instantiate resource request list keyboard shortcuts using QtGui.QShortcut now that PySide6 no longer exposes it from QtWidgets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cd173a7be4832b87df1625cca6684f