### PR TITLE
Add binding library service and UI

### DIFF
--- a/modules/devtools/dev_menu.py
+++ b/modules/devtools/dev_menu.py
@@ -8,6 +8,7 @@ from .panels.template_debug_panel import TemplateDebugPanel
 from .panels.profile_manager_panel import ProfileManagerPanel
 from .panels.form_catalog_manager import FormCatalogManager
 from .panels.form_template_builder import FormTemplateBuilder
+from .panels.binding_library_panel import BindingLibraryPanel
 from .panels.fema_forms_importer import FEMAFormsImporter
 
 
@@ -101,6 +102,24 @@ def attach_dev_menu(main_window):
 
     act_ftb.triggered.connect(_open_ftb)
     dev_menu.addAction(act_ftb)
+
+    # Binding Library Browser
+    act_binding = QAction("Binding Library", main_window)
+
+    def _open_binding():
+        panel = BindingLibraryPanel(parent=main_window)
+        dlg = QDialog(main_window)
+        dlg.setWindowTitle("Binding Library")
+        dlg.setWindowModality(Qt.ApplicationModal)
+        dlg.setAttribute(Qt.WA_DeleteOnClose, True)
+        v = QVBoxLayout(dlg)
+        v.setContentsMargins(0, 0, 0, 0)
+        v.addWidget(panel)
+        dlg.resize(700, 500)
+        dlg.exec()
+
+    act_binding.triggered.connect(_open_binding)
+    dev_menu.addAction(act_binding)
 
     # FEMA Forms Importer
     act_fema = QAction("Fetch FEMA ICS Forms", main_window)

--- a/modules/devtools/panels/binding_library_panel.py
+++ b/modules/devtools/panels/binding_library_panel.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import List
+
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QLineEdit,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
+    QAbstractItemView,
+    QMessageBox,
+)
+
+from ..services.binding_library import load_binding_library, BindingOption
+from utils.profile_manager import profile_manager
+
+
+class BindingLibraryPanel(QWidget):
+    """Display the centralized catalog of bindings for quick reference."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Binding Library")
+
+        self._bindings: List[BindingOption] = []
+
+        layout = QVBoxLayout(self)
+
+        header = QHBoxLayout()
+        self.lbl_profile = QLabel("")
+        header.addWidget(self.lbl_profile)
+        header.addStretch(1)
+        self.btn_refresh = QPushButton("Refresh")
+        self.btn_refresh.clicked.connect(self.refresh)
+        header.addWidget(self.btn_refresh)
+        layout.addLayout(header)
+
+        self.txt_filter = QLineEdit()
+        self.txt_filter.setPlaceholderText("Filter bindings…")
+        self.txt_filter.textChanged.connect(self._apply_filter)
+        layout.addWidget(self.txt_filter)
+
+        self.tbl = QTableWidget(0, 3, self)
+        self.tbl.setHorizontalHeaderLabels(["Key", "Source", "Description"])
+        self.tbl.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeToContents)
+        self.tbl.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        self.tbl.horizontalHeader().setSectionResizeMode(2, QHeaderView.Stretch)
+        self.tbl.verticalHeader().setVisible(False)
+        self.tbl.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.tbl.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.tbl.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.tbl.itemSelectionChanged.connect(self._update_copy_enabled)
+        self.tbl.itemDoubleClicked.connect(lambda *_: self._copy_selected_key())
+        layout.addWidget(self.tbl, 1)
+
+        footer = QHBoxLayout()
+        self.lbl_count = QLabel("")
+        footer.addWidget(self.lbl_count)
+        footer.addStretch(1)
+        self.btn_copy = QPushButton("Copy Key")
+        self.btn_copy.clicked.connect(self._copy_selected_key)
+        footer.addWidget(self.btn_copy)
+        layout.addLayout(footer)
+
+        self.btn_copy.setEnabled(False)
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    def refresh(self) -> None:
+        """Reload bindings from the active profile catalog."""
+
+        active = profile_manager.get_active_profile_id() or "(no active profile)"
+        self.lbl_profile.setText(f"Active profile: {active}")
+        try:
+            bindings = load_binding_library()
+        except Exception as exc:  # pragma: no cover - defensive UI path
+            QMessageBox.warning(self, "Binding Library", f"Failed to load bindings: {exc}")
+            bindings = []
+        self._bindings = bindings
+        self._rebuild_table()
+
+    def _rebuild_table(self) -> None:
+        self.tbl.setRowCount(0)
+        for binding in self._bindings:
+            row = self.tbl.rowCount()
+            self.tbl.insertRow(row)
+            self.tbl.setItem(row, 0, QTableWidgetItem(binding.key))
+            self.tbl.setItem(row, 1, QTableWidgetItem(binding.source))
+            self.tbl.setItem(row, 2, QTableWidgetItem(binding.description))
+        self.lbl_count.setText(f"{len(self._bindings)} bindings")
+        self._apply_filter(self.txt_filter.text())
+        first_visible = None
+        for idx in range(self.tbl.rowCount()):
+            if not self.tbl.isRowHidden(idx):
+                first_visible = idx
+                break
+        if first_visible is not None:
+            self.tbl.selectRow(first_visible)
+        else:
+            self.tbl.clearSelection()
+        self._update_copy_enabled()
+
+    def _apply_filter(self, text: str) -> None:
+        query = (text or "").strip().lower()
+        for row in range(self.tbl.rowCount()):
+            if not query:
+                self.tbl.setRowHidden(row, False)
+                continue
+            content = " ".join(
+                self.tbl.item(row, col).text() if self.tbl.item(row, col) else ""
+                for col in range(self.tbl.columnCount())
+            )
+            self.tbl.setRowHidden(row, query not in content.lower())
+        self._update_copy_enabled()
+
+    def _copy_selected_key(self) -> None:
+        row = self.tbl.currentRow()
+        if row < 0 or row >= len(self._bindings):
+            QMessageBox.information(self, "Copy Key", "Select a binding to copy.")
+            return
+        key = self._bindings[row].key
+        QGuiApplication.clipboard().setText(key)
+        QMessageBox.information(self, "Copy Key", f"Copied {key} to clipboard.")
+
+    def _update_copy_enabled(self) -> None:
+        has_selection = False
+        row = self.tbl.currentRow()
+        if row >= 0 and not self.tbl.isRowHidden(row):
+            has_selection = True
+        self.btn_copy.setEnabled(has_selection)
+
+
+__all__ = ["BindingLibraryPanel"]

--- a/modules/devtools/panels/form_template_builder.py
+++ b/modules/devtools/panels/form_template_builder.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QStandardItemModel, QStandardItem
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -16,11 +17,14 @@ from PySide6.QtWidgets import (
     QTableWidgetItem,
     QHeaderView,
     QMessageBox,
+    QComboBox,
+    QCompleter,
 )
 
 from ..services.form_catalog import FormCatalog, TemplateEntry
 from ..services.form_identify import guess_form_id_and_version
 from ..services.pdf_mapgen import extract_acroform_fields, generate_map, extract_schema_paths
+from ..services.binding_library import load_binding_library, BindingOption
 
 
 PDF_DIR = Path("data/forms/pdfs")
@@ -115,14 +119,35 @@ class FormTemplateBuilder(QWidget):
             mapping = generate_map(self.pdf_path, fid or "form", ver or "x", tmp_map, schema_path if schema_path and schema_path.exists() else None, None)
         except Exception:
             mapping = {"fields": {f.name: "" for f in fields}}
-        # Prepare candidate list for a simple searchable combo
-        candidates: List[str] = []
+        # Prepare candidate list for a searchable combo fed by binding library
+        schema_candidates: List[str] = []
         try:
             if schema_path and schema_path.exists():
-                candidates = extract_schema_paths(schema_path, None) or []
+                schema_candidates = extract_schema_paths(schema_path, None) or []
         except Exception:
-            candidates = []
-        from PySide6.QtWidgets import QComboBox
+            schema_candidates = []
+
+        catalog_options = load_binding_library()
+        catalog_lookup: Dict[str, BindingOption] = {opt.key: opt for opt in catalog_options}
+        for candidate in schema_candidates:
+            if candidate not in catalog_lookup:
+                catalog_lookup[candidate] = BindingOption(
+                    key=candidate,
+                    source="schema",
+                    description="Schema suggestion",
+                )
+
+        option_list = sorted(catalog_lookup.values(), key=lambda opt: opt.key.lower())
+
+        model = QStandardItemModel(self.tbl_fields)
+        for opt in option_list:
+            item = QStandardItem(opt.display_label)
+            item.setEditable(False)
+            item.setData(opt.key, Qt.UserRole)
+            item.setData(opt.source, Qt.UserRole + 1)
+            item.setData(opt.description, Qt.UserRole + 2)
+            model.appendRow(item)
+
         self.tbl_fields.setRowCount(0)
         for f in fields:
             r = self.tbl_fields.rowCount()
@@ -130,11 +155,33 @@ class FormTemplateBuilder(QWidget):
             self.tbl_fields.setItem(r, 0, QTableWidgetItem(f.name))
             cbo = QComboBox()
             cbo.setEditable(True)
-            for c in candidates:
-                cbo.addItem(c)
+            cbo.setInsertPolicy(QComboBox.NoInsert)
+            if cbo.lineEdit() is not None:
+                cbo.lineEdit().setClearButtonEnabled(True)
+            cbo.setModel(model)
+            cbo.setModelColumn(0)
+            completer = QCompleter(model, cbo)
+            completer.setCaseSensitivity(Qt.CaseInsensitive)
+            try:
+                completer.setFilterMode(Qt.MatchFlag.MatchContains)
+            except AttributeError:
+                completer.setFilterMode(Qt.MatchContains)
+            completer.setCompletionRole(Qt.DisplayRole)
+            cbo.setCompleter(completer)
+            if cbo.lineEdit() is not None:
+                cbo.lineEdit().setPlaceholderText("Search bindings…")
             pre = str(mapping.get("fields", {}).get(f.name, ""))
             if pre:
-                cbo.setCurrentText(pre)
+                matched_index = -1
+                for idx in range(model.rowCount()):
+                    item = model.item(idx)
+                    if item and item.data(Qt.UserRole) == pre:
+                        matched_index = idx
+                        break
+                if matched_index >= 0:
+                    cbo.setCurrentIndex(matched_index)
+                else:
+                    cbo.setEditText(pre)
             self.tbl_fields.setCellWidget(r, 1, cbo)
 
     def _save(self):
@@ -165,7 +212,11 @@ class FormTemplateBuilder(QWidget):
             editor = self.tbl_fields.cellWidget(r, 1)
             val = ""
             if editor is not None and hasattr(editor, 'currentText'):
-                val = editor.currentText().strip()
+                if hasattr(editor, "currentData"):
+                    data = editor.currentData(Qt.UserRole)
+                else:
+                    data = None
+                val = str(data).strip() if data else editor.currentText().strip()
             if k:
                 mapping["fields"][k] = val
         # save YAML

--- a/modules/devtools/services/__init__.py
+++ b/modules/devtools/services/__init__.py
@@ -1,2 +1,9 @@
 # Services for DevTools
 
+from .binding_library import BindingOption, load_binding_library
+
+__all__ = [
+    "BindingOption",
+    "load_binding_library",
+]
+

--- a/modules/devtools/services/binding_library.py
+++ b/modules/devtools/services/binding_library.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from utils.profile_manager import profile_manager
+
+
+@dataclass(frozen=True)
+class BindingOption:
+    """A single binding entry exposed to authoring tools."""
+
+    key: str
+    source: str
+    description: str
+
+    @property
+    def display_label(self) -> str:
+        source = (self.source or "").strip() or "?"
+        label = f"{source} · {self.key}"
+        desc = (self.description or "").strip()
+        if desc:
+            label = f"{label} — {desc}"
+        return label
+
+
+def _iter_catalog_keys(catalog: Dict[str, object]) -> List[BindingOption]:
+    keys = catalog.get("keys") if isinstance(catalog, dict) else None
+    if not isinstance(keys, dict):
+        return []
+    options: List[BindingOption] = []
+    for raw_key, raw_meta in keys.items():
+        if not isinstance(raw_key, str):
+            continue
+        meta = raw_meta if isinstance(raw_meta, dict) else {}
+        source = str(meta.get("source") or "constants")
+        desc = str(meta.get("desc") or meta.get("description") or "")
+        options.append(BindingOption(key=raw_key, source=source, description=desc))
+    return options
+
+
+def load_binding_library(profile_id: Optional[str] = None) -> List[BindingOption]:
+    """Return binding entries from the active (or specified) profile catalog."""
+
+    try:
+        if profile_id:
+            catalog = profile_manager.get_catalog_for_profile(profile_id)
+        else:
+            catalog = profile_manager.get_catalog()
+    except Exception:
+        catalog = {}
+
+    options = list(_iter_catalog_keys(catalog))
+    deduped: Dict[str, BindingOption] = {}
+    for option in options:
+        deduped.setdefault(option.key, option)
+    return sorted(deduped.values(), key=lambda opt: opt.key.lower())
+
+
+__all__ = ["BindingOption", "load_binding_library"]

--- a/tests/test_binding_library.py
+++ b/tests/test_binding_library.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from modules.devtools.services.binding_library import load_binding_library
+from utils.profile_manager import profile_manager
+
+
+@pytest.fixture()
+def temp_profile_catalog(tmp_path: Path):
+    repo_root = Path(__file__).resolve().parents[1]
+
+    base_dir = tmp_path / "base_profile"
+    child_dir = tmp_path / "child_profile"
+    for p in (base_dir, child_dir):
+        (p / "templates").mkdir(parents=True, exist_ok=True)
+        (p / "assets").mkdir(parents=True, exist_ok=True)
+        (p / "computed.py").write_text("# test stub\n", encoding="utf-8")
+
+    base_manifest: Dict[str, object] = {
+        "id": "base",
+        "name": "Base",
+        "version": "1.0.0",
+        "inherits": [],
+        "locale": {"date_format": "YYYY-MM-DD"},
+        "units": {"distance": "km"},
+        "templates_dir": "templates",
+        "catalog": "catalog.json",
+        "computed_module": "computed.py",
+        "assets": {},
+    }
+    child_manifest: Dict[str, object] = {
+        "id": "child",
+        "name": "Child",
+        "version": "1.0.0",
+        "inherits": ["base"],
+        "locale": {"date_format": "YYYY-MM-DD"},
+        "units": {"distance": "km"},
+        "templates_dir": "templates",
+        "catalog": "catalog.json",
+        "computed_module": "computed.py",
+        "assets": {},
+    }
+
+    base_catalog = {
+        "version": 1,
+        "keys": {
+            "incident.name": {"source": "constants", "desc": "Base incident name"},
+            "mission.id": {"source": "mission", "desc": "Mission identifier"},
+        },
+    }
+    child_catalog = {
+        "version": 1,
+        "keys": {
+            "incident.name": {"desc": "Child incident name"},
+            "planning.chief": {"source": "personnel", "desc": "Planning Section Chief"},
+        },
+    }
+
+    (base_dir / "manifest.json").write_text(json.dumps(base_manifest, indent=2), encoding="utf-8")
+    (base_dir / "catalog.json").write_text(json.dumps(base_catalog, indent=2), encoding="utf-8")
+    (child_dir / "manifest.json").write_text(json.dumps(child_manifest, indent=2), encoding="utf-8")
+    (child_dir / "catalog.json").write_text(json.dumps(child_catalog, indent=2), encoding="utf-8")
+
+    try:
+        profile_manager.load_all_profiles(tmp_path)
+        yield "child"
+    finally:
+        profile_manager.load_all_profiles(repo_root / "profiles")
+
+
+def test_binding_library_merges_catalogs(temp_profile_catalog: str):
+    child_id = temp_profile_catalog
+    # ensure default active profile resolves to child for this test
+    profile_manager._active_id = child_id  # type: ignore[attr-defined]
+
+    options = load_binding_library()
+    direct_options = load_binding_library(child_id)
+
+    assert [opt.key for opt in options] == [opt.key for opt in direct_options]
+
+    opt_map = {opt.key: opt for opt in options}
+    assert opt_map["incident.name"].source == "constants"
+    assert opt_map["incident.name"].description == "Child incident name"
+    assert opt_map["mission.id"].source == "mission"
+    assert opt_map["planning.chief"].source == "personnel"
+    assert len(opt_map) == 3


### PR DESCRIPTION
## Summary
- add a binding library service that flattens the active profile catalog into reusable options
- update the Form Template Builder to populate binding combos from the shared catalog with searchable completers
- surface a Binding Library browser panel on the Developer menu for quick inspection

## Testing
- pytest --import-mode=importlib *(fails: ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_b_68cd0624fd38832ba9c2544da0ceaf92