### PR TITLE
Add communications traffic log module with repository and UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -411,6 +411,12 @@ class MainWindow(QMainWindow):
         m_comms = mb.addMenu("Communications")
         self._add_action(m_comms, "Communications Unit Log ICS-214", None, "comms.unit_log")
         m_comms.addSeparator()
+        self._add_action(
+            m_comms,
+            "Communications Traffic Log ICS-309",
+            None,
+            "comms.traffic_log",
+        )
         self._add_action(m_comms, "Messaging", None, "comms.chat")
         self._add_action(m_comms, "ICS 213 Messages", None, "comms.213")
         self._add_action(m_comms, "Communications Plan ICS-205", None, "comms.205")
@@ -655,6 +661,7 @@ class MainWindow(QMainWindow):
 
             # ----- Communications -----
             "comms.unit_log": self.open_comms_unit_log,
+            "comms.traffic_log": self.open_comms_traffic_log,
             "comms.chat": self.open_comms_chat,
             "comms.213": self.open_comms_213,
             "comms.205": self.open_comms_205,
@@ -1085,12 +1092,19 @@ class MainWindow(QMainWindow):
         panel = ics214.get_ics214_panel(incident_id)
         self._open_dock_widget(panel, title="ICS-214 Activity Log")
 
+    def open_comms_traffic_log(self) -> None:
+        from modules.communications.panels import MessageLogPanel
+
+        incident_id = getattr(self, "current_incident_id", None)
+        panel = MessageLogPanel(self, incident_id=incident_id)
+        self._open_dock_widget(panel, title="Communications Traffic Log")
+
     def open_comms_chat(self) -> None:
         from modules.communications.panels import MessageLogPanel
 
         # TODO: incident-specific scoping for communications panels
         _incident_id = getattr(self, "current_incident_id", None)
-        panel = MessageLogPanel()
+        panel = MessageLogPanel(self, incident_id=_incident_id)
         self._open_dock_widget(panel, title="Messaging")
 
     def open_comms_213(self) -> None:
@@ -1098,7 +1112,7 @@ class MainWindow(QMainWindow):
 
         # TODO: incident-specific scoping for communications panels
         _incident_id = getattr(self, "current_incident_id", None)
-        panel = MessageLogPanel()
+        panel = MessageLogPanel(self, incident_id=_incident_id)
         self._open_dock_widget(panel, title="ICS 213 Messages")
 
     def open_comms_205(self) -> None:

--- a/modules/communications/__init__.py
+++ b/modules/communications/__init__.py
@@ -1,14 +1,26 @@
-"""ICS‑205 Communications module (Widgets only).
-
-Provides a factory to create the standalone ICS‑205 window.
-"""
-
-from .panels.ics205_window import ICS205Window
+"""Communications module exports."""
 
 
 def create_ics205_window(parent=None):
+    from .panels.ics205_window import ICS205Window
+
     return ICS205Window(parent)
 
 
-__all__ = ["create_ics205_window", "ICS205Window"]
+def create_traffic_log_window(parent=None, *, incident_id=None):
+    from .traffic_log import create_log_window
 
+    return create_log_window(parent=parent, incident_id=incident_id)
+
+
+def get_communications_log_service(*, incident_id=None):
+    from .traffic_log import CommsLogService
+
+    return CommsLogService(incident_id=incident_id)
+
+
+__all__ = [
+    "create_ics205_window",
+    "create_traffic_log_window",
+    "get_communications_log_service",
+]

--- a/modules/communications/models/db.py
+++ b/modules/communications/models/db.py
@@ -12,10 +12,11 @@ Master DB schema is never altered here.
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
+import os
 import sqlite3
 from typing import Iterator
 
-from utils import mission_db
+from utils import incident_context
 
 
 MASTER_DB_PATH = Path("data") / "master.db"
@@ -35,12 +36,20 @@ def get_master_conn() -> sqlite3.Connection:
     return _conn(MASTER_DB_PATH)
 
 
-def get_incident_conn(incident_number: str | int) -> sqlite3.Connection:
-    """Return a connection to the current incident database.
+def get_incident_conn(incident_number: str | int | None = None) -> sqlite3.Connection:
+    """Return a connection to the incident database.
 
-    The path is resolved via utils.mission_db.
+    Falls back to the active incident configured via ``incident_context`` when
+    no explicit identifier is provided.
     """
-    path = mission_db.get_incident_db_path(incident_number)
+    if incident_number is None:
+        incident = incident_context.get_active_incident_id()
+        if incident is None:
+            raise RuntimeError("Active incident not set")
+        incident_number = incident
+    base = Path(os.environ.get("CHECKIN_DATA_DIR", "data")) / "incidents"
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / f"{incident_number}.db"
     return _conn(path)
 
 

--- a/modules/communications/panels/__init__.py
+++ b/modules/communications/panels/__init__.py
@@ -1,0 +1,50 @@
+"""Panel factories for the communications module."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLabel, QMessageBox, QVBoxLayout, QWidget
+
+from ..traffic_log import create_log_window
+from .ics205_window import ICS205Window
+
+__all__ = ["MessageLogPanel", "ICS205Window"]
+
+logger = logging.getLogger(__name__)
+
+
+def MessageLogPanel(parent=None, *, incident_id: Optional[str] = None):
+    """Return the communications traffic log panel.
+
+    Falls back to a placeholder widget if no incident database is available.
+    """
+
+    try:
+        return create_log_window(parent=parent, incident_id=incident_id)
+    except RuntimeError as exc:
+        logger.warning("Communications log unavailable: %s", exc)
+        if parent is not None:
+            try:
+                QMessageBox.warning(
+                    parent,
+                    "Communications Log",
+                    "Select or create an incident to use the communications log.",
+                )
+            except Exception:
+                # QMessageBox may be unavailable in headless contexts
+                logger.debug("Unable to display QMessageBox for comms log warning.")
+        placeholder = QWidget(parent)
+        placeholder.setObjectName("communicationsLogUnavailable")
+        layout = QVBoxLayout(placeholder)
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(12)
+        label = QLabel(
+            "Select or create an incident to use the communications log."
+        )
+        label.setWordWrap(True)
+        layout.addWidget(label, alignment=Qt.AlignCenter)
+        placeholder.setEnabled(False)
+        return placeholder

--- a/modules/communications/traffic_log/__init__.py
+++ b/modules/communications/traffic_log/__init__.py
@@ -1,0 +1,24 @@
+"""Communications Traffic Log module."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .services import CommsLogService
+
+__all__ = ["create_log_window", "CommsLogService", "get_log_window_class"]
+
+
+def create_log_window(parent=None, *, incident_id: Optional[str] = None):
+    """Factory for the communications traffic log window."""
+    from .ui.log_window import CommunicationsLogWindow
+
+    service = CommsLogService(incident_id=incident_id)
+    window = CommunicationsLogWindow(service, parent=parent)
+    return window
+
+
+def get_log_window_class():
+    from .ui.log_window import CommunicationsLogWindow
+
+    return CommunicationsLogWindow

--- a/modules/communications/traffic_log/exporters/csv_exporter.py
+++ b/modules/communications/traffic_log/exporters/csv_exporter.py
@@ -12,7 +12,6 @@ from ..models import CommsLogEntry
 COLUMNS: Sequence[str] = (
     "Timestamp UTC",
     "Timestamp Local",
-    "Direction",
     "Priority",
     "Channel",
     "Frequency",
@@ -42,7 +41,6 @@ def _entry_row(entry: CommsLogEntry) -> List[str]:
     return [
         entry.ts_utc,
         entry.ts_local,
-        entry.direction,
         entry.priority,
         entry.resource_label,
         entry.frequency,

--- a/modules/communications/traffic_log/exporters/csv_exporter.py
+++ b/modules/communications/traffic_log/exporters/csv_exporter.py
@@ -1,0 +1,90 @@
+"""CSV exporter for communications log entries."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+from ..models import CommsLogEntry
+
+
+COLUMNS: Sequence[str] = (
+    "Timestamp UTC",
+    "Timestamp Local",
+    "Direction",
+    "Priority",
+    "Channel",
+    "Frequency",
+    "Band",
+    "Mode",
+    "From",
+    "To",
+    "Message",
+    "Action Taken",
+    "Follow Up",
+    "Disposition",
+    "Operator",
+    "Team",
+    "Task",
+    "Vehicle",
+    "Personnel",
+    "Attachments",
+    "Geotag Lat",
+    "Geotag Lon",
+    "Notification",
+    "Status Update",
+)
+
+
+def _entry_row(entry: CommsLogEntry) -> List[str]:
+    attachments = "; ".join(entry.attachments)
+    return [
+        entry.ts_utc,
+        entry.ts_local,
+        entry.direction,
+        entry.priority,
+        entry.resource_label,
+        entry.frequency,
+        entry.band,
+        entry.mode,
+        entry.from_unit,
+        entry.to_unit,
+        entry.message,
+        entry.action_taken,
+        "Yes" if entry.follow_up_required else "No",
+        entry.disposition,
+        entry.operator_user_id or "",
+        str(entry.team_id or ""),
+        str(entry.task_id or ""),
+        str(entry.vehicle_id or ""),
+        str(entry.personnel_id or ""),
+        attachments,
+        "" if entry.geotag_lat is None else f"{entry.geotag_lat:.6f}",
+        "" if entry.geotag_lon is None else f"{entry.geotag_lon:.6f}",
+        entry.notification_level or "",
+        "Yes" if entry.is_status_update else "No",
+    ]
+
+
+def export_entries(entries: Iterable[CommsLogEntry], path: Path, metadata: Dict[str, object]) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["Communications Traffic Log Export"])
+        writer.writerow([f"Incident: {metadata.get('incident', '')}"])
+        if metadata.get("operational_period"):
+            writer.writerow([f"Operational Period: {metadata['operational_period']}"])
+        if metadata.get("time_zone"):
+            writer.writerow([f"Time Zone: {metadata['time_zone']}"])
+        if metadata.get("generated_at"):
+            writer.writerow([f"Generated: {metadata['generated_at']}"])
+        writer.writerow([])
+        writer.writerow(list(COLUMNS))
+        for entry in entries:
+            writer.writerow(_entry_row(entry))
+    return path
+
+
+__all__ = ["export_entries", "COLUMNS"]

--- a/modules/communications/traffic_log/exporters/pdf_exporter.py
+++ b/modules/communications/traffic_log/exporters/pdf_exporter.py
@@ -1,0 +1,116 @@
+"""Minimal PDF exporter for communications log entries."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from textwrap import wrap
+from typing import Dict, Iterable, List
+
+from ..models import CommsLogEntry
+
+
+def _escape_pdf_text(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def _wrap_entry_lines(entry: CommsLogEntry) -> List[str]:
+    base = f"{entry.ts_local} | {entry.direction[:3]} | {entry.priority[:3]} | {entry.resource_label} | {entry.from_unit} -> {entry.to_unit}"
+    lines = [base]
+    for field_label, field_value in (
+        ("Message", entry.message),
+        ("Action", entry.action_taken),
+    ):
+        if field_value:
+            wrapped = wrap(field_value, 88) or [field_value]
+            for idx, segment in enumerate(wrapped):
+                prefix = f"  {field_label}: " if idx == 0 else " " * 11
+                lines.append(prefix + segment)
+    if entry.follow_up_required:
+        lines.append("  Follow Up Required")
+    if entry.is_status_update:
+        lines.append("  Status Update Flagged")
+    if entry.notification_level:
+        lines.append(f"  Notification Level: {entry.notification_level}")
+    if entry.attachments:
+        lines.append("  Attachments: " + ", ".join(entry.attachments))
+    return lines
+
+
+def _compose_text(entries: Iterable[CommsLogEntry], metadata: Dict[str, object]) -> List[str]:
+    lines: List[str] = []
+    lines.append("Communications Traffic Log Export")
+    incident_label = metadata.get("incident") or ""
+    lines.append(f"Incident: {incident_label}")
+    if metadata.get("operational_period"):
+        lines.append(f"Operational Period: {metadata['operational_period']}")
+    if metadata.get("time_zone"):
+        lines.append(f"Time Zone: {metadata['time_zone']}")
+    generated = metadata.get("generated_at") or datetime.utcnow().isoformat(timespec="seconds")
+    lines.append(f"Generated: {generated}")
+    lines.append("")
+    for entry in entries:
+        lines.extend(_wrap_entry_lines(entry))
+        lines.append("")
+    return lines
+
+
+def _build_pdf_bytes(lines: List[str]) -> bytes:
+    content_lines = ["BT", "/F1 10 Tf", "50 770 Td"]
+    first_line = True
+    for line in lines:
+        safe = _escape_pdf_text(line)
+        if first_line:
+            content_lines.append(f"({safe}) Tj")
+            first_line = False
+        else:
+            content_lines.append("T*")
+            content_lines.append(f"({safe}) Tj")
+    content_lines.append("ET")
+    content_stream = "\n".join(content_lines).encode("latin-1", "ignore")
+
+    objects: List[bytes] = []
+    objects.append(b"1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n")
+    objects.append(b"2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n")
+    objects.append(
+        b"3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj\n"
+    )
+    content_obj = (
+        f"4 0 obj << /Length {len(content_stream)} >> stream\n".encode("ascii")
+        + content_stream
+        + b"\nendstream\nendobj\n"
+    )
+    objects.append(content_obj)
+    objects.append(b"5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\n")
+
+    header = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
+    offsets = [0]
+    body = bytearray()
+    offset = len(header)
+    for obj in objects:
+        offsets.append(offset)
+        body.extend(obj)
+        offset += len(obj)
+
+    xref_entries = [b"0000000000 65535 f \n"]
+    for off in offsets[1:]:
+        xref_entries.append(f"{off:010d} 00000 n \n".encode("ascii"))
+    xref = b"xref\n0 %d\n" % (len(offsets)) + b"".join(xref_entries)
+    trailer = (
+        b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n"
+        % (len(offsets), len(header) + len(body))
+    )
+    return header + body + xref + trailer
+
+
+def export_entries(entries: Iterable[CommsLogEntry], path: Path, metadata: Dict[str, object]) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = _compose_text(entries, metadata)
+    pdf_bytes = _build_pdf_bytes(lines)
+    path.write_bytes(pdf_bytes)
+    return path
+
+
+__all__ = ["export_entries"]

--- a/modules/communications/traffic_log/exporters/pdf_exporter.py
+++ b/modules/communications/traffic_log/exporters/pdf_exporter.py
@@ -15,7 +15,7 @@ def _escape_pdf_text(text: str) -> str:
 
 
 def _wrap_entry_lines(entry: CommsLogEntry) -> List[str]:
-    base = f"{entry.ts_local} | {entry.direction[:3]} | {entry.priority[:3]} | {entry.resource_label} | {entry.from_unit} -> {entry.to_unit}"
+    base = f"{entry.ts_local} | {entry.priority[:3]} | {entry.resource_label} | {entry.from_unit} -> {entry.to_unit}"
     lines = [base]
     for field_label, field_value in (
         ("Message", entry.message),

--- a/modules/communications/traffic_log/models.py
+++ b/modules/communications/traffic_log/models.py
@@ -1,0 +1,194 @@
+"""Domain models for the communications traffic log."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+import json
+
+
+DIRECTION_INCOMING = "Incoming"
+DIRECTION_OUTGOING = "Outgoing"
+DIRECTION_INTERNAL = "Internal"
+
+PRIORITY_ROUTINE = "Routine"
+PRIORITY_PRIORITY = "Priority"
+PRIORITY_EMERGENCY = "Emergency"
+
+DISPOSITION_OPEN = "Open"
+DISPOSITION_CLOSED = "Closed"
+
+
+def utcnow_iso() -> str:
+    """Return the current UTC timestamp as ISO 8601 string."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def localnow_iso() -> str:
+    """Return the current local timestamp as ISO 8601 string."""
+    return datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+@dataclass(slots=True)
+class CommsLogEntry:
+    """Representation of a communications traffic log entry."""
+
+    ts_utc: str = field(default_factory=utcnow_iso)
+    ts_local: str = field(default_factory=localnow_iso)
+    direction: str = DIRECTION_INCOMING
+    priority: str = PRIORITY_ROUTINE
+    resource_id: Optional[int] = None
+    resource_label: str = ""
+    frequency: str = ""
+    band: str = ""
+    mode: str = ""
+    from_unit: str = ""
+    to_unit: str = ""
+    message: str = ""
+    action_taken: str = ""
+    follow_up_required: bool = False
+    disposition: str = DISPOSITION_OPEN
+    operator_user_id: Optional[str] = None
+    team_id: Optional[int] = None
+    task_id: Optional[int] = None
+    vehicle_id: Optional[int] = None
+    personnel_id: Optional[int] = None
+    attachments: List[str] = field(default_factory=list)
+    geotag_lat: Optional[float] = None
+    geotag_lon: Optional[float] = None
+    notification_level: Optional[str] = None
+    is_status_update: bool = False
+    created_at: str = field(default_factory=utcnow_iso)
+    updated_at: str = field(default_factory=utcnow_iso)
+    operator_display_name: Optional[str] = None
+    id: Optional[int] = None
+
+    def to_record(self) -> Dict[str, Any]:
+        """Return a mapping ready for SQLite insertion/update."""
+        payload = asdict(self)
+        payload["follow_up_required"] = 1 if self.follow_up_required else 0
+        payload["is_status_update"] = 1 if self.is_status_update else 0
+        payload["attachments"] = json.dumps(self.attachments, ensure_ascii=False)
+        # ``id`` is handled separately to avoid duplicates in INSERT payloads
+        payload.pop("id", None)
+        payload.pop("operator_display_name", None)
+        return payload
+
+    @classmethod
+    def from_row(cls, row: Dict[str, Any]) -> "CommsLogEntry":
+        attachments_raw = row.get("attachments")
+        if attachments_raw in (None, ""):
+            attachments = []
+        else:
+            try:
+                parsed = json.loads(attachments_raw)
+            except Exception:
+                parsed = []
+            if isinstance(parsed, list):
+                attachments = [str(p) for p in parsed]
+            elif isinstance(parsed, str):
+                attachments = [parsed]
+            else:
+                attachments = []
+        return cls(
+            id=row.get("id"),
+            ts_utc=row.get("ts_utc") or utcnow_iso(),
+            ts_local=row.get("ts_local") or localnow_iso(),
+            direction=row.get("direction") or DIRECTION_INCOMING,
+            priority=row.get("priority") or PRIORITY_ROUTINE,
+            resource_id=row.get("resource_id"),
+            resource_label=row.get("resource_label") or "",
+            frequency=row.get("frequency") or "",
+            band=row.get("band") or "",
+            mode=row.get("mode") or "",
+            from_unit=row.get("from_unit") or "",
+            to_unit=row.get("to_unit") or "",
+            message=row.get("message") or "",
+            action_taken=row.get("action_taken") or "",
+            follow_up_required=bool(row.get("follow_up_required")),
+            disposition=row.get("disposition") or DISPOSITION_OPEN,
+            operator_user_id=str(row.get("operator_user_id")) if row.get("operator_user_id") is not None else None,
+            team_id=row.get("team_id"),
+            task_id=row.get("task_id"),
+            vehicle_id=row.get("vehicle_id"),
+            personnel_id=row.get("personnel_id"),
+            attachments=attachments,
+            geotag_lat=row.get("geotag_lat"),
+            geotag_lon=row.get("geotag_lon"),
+            notification_level=row.get("notification_level"),
+            is_status_update=bool(row.get("is_status_update")),
+            created_at=row.get("created_at") or utcnow_iso(),
+            updated_at=row.get("updated_at") or utcnow_iso(),
+            operator_display_name=row.get("operator_display_name"),
+        )
+
+
+@dataclass(slots=True)
+class CommsLogAuditEntry:
+    """Audit entry for a communications record."""
+
+    comms_log_id: int
+    action: str
+    changed_by: Optional[str]
+    change_json: Dict[str, Any]
+    changed_at: str = field(default_factory=utcnow_iso)
+    id: Optional[int] = None
+
+
+@dataclass(slots=True)
+class CommsLogFilterPreset:
+    """Persisted user filter preset."""
+
+    name: str
+    filters: Dict[str, Any]
+    user_id: str
+    created_at: str = field(default_factory=utcnow_iso)
+    updated_at: str = field(default_factory=utcnow_iso)
+    id: Optional[int] = None
+
+
+@dataclass(slots=True)
+class CommsLogQuery:
+    """Filter definition used for querying the log table."""
+
+    start_ts_utc: Optional[str] = None
+    end_ts_utc: Optional[str] = None
+    priorities: Optional[List[str]] = None
+    directions: Optional[List[str]] = None
+    resource_ids: Optional[List[int]] = None
+    resource_labels: Optional[List[str]] = None
+    unit_like: Optional[str] = None
+    operator_ids: Optional[List[str]] = None
+    dispositions: Optional[List[str]] = None
+    has_attachments: Optional[bool] = None
+    text_search: Optional[str] = None
+    notification_levels: Optional[List[str]] = None
+    is_status_update: Optional[bool] = None
+    follow_up_required: Optional[bool] = None
+    task_ids: Optional[List[int]] = None
+    team_ids: Optional[List[int]] = None
+    vehicle_ids: Optional[List[int]] = None
+    personnel_ids: Optional[List[int]] = None
+    limit: Optional[int] = None
+    offset: Optional[int] = None
+    order_by: str = "ts_utc"
+    order_desc: bool = True
+
+
+__all__ = [
+    "CommsLogEntry",
+    "CommsLogAuditEntry",
+    "CommsLogFilterPreset",
+    "CommsLogQuery",
+    "utcnow_iso",
+    "localnow_iso",
+    "DIRECTION_INCOMING",
+    "DIRECTION_OUTGOING",
+    "DIRECTION_INTERNAL",
+    "PRIORITY_ROUTINE",
+    "PRIORITY_PRIORITY",
+    "PRIORITY_EMERGENCY",
+    "DISPOSITION_OPEN",
+    "DISPOSITION_CLOSED",
+]

--- a/modules/communications/traffic_log/models.py
+++ b/modules/communications/traffic_log/models.py
@@ -2,15 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 import json
-
-
-DIRECTION_INCOMING = "Incoming"
-DIRECTION_OUTGOING = "Outgoing"
-DIRECTION_INTERNAL = "Internal"
 
 PRIORITY_ROUTINE = "Routine"
 PRIORITY_PRIORITY = "Priority"
@@ -36,7 +31,6 @@ class CommsLogEntry:
 
     ts_utc: str = field(default_factory=utcnow_iso)
     ts_local: str = field(default_factory=localnow_iso)
-    direction: str = DIRECTION_INCOMING
     priority: str = PRIORITY_ROUTINE
     resource_id: Optional[int] = None
     resource_label: str = ""
@@ -95,7 +89,6 @@ class CommsLogEntry:
             id=row.get("id"),
             ts_utc=row.get("ts_utc") or utcnow_iso(),
             ts_local=row.get("ts_local") or localnow_iso(),
-            direction=row.get("direction") or DIRECTION_INCOMING,
             priority=row.get("priority") or PRIORITY_ROUTINE,
             resource_id=row.get("resource_id"),
             resource_label=row.get("resource_label") or "",
@@ -155,7 +148,6 @@ class CommsLogQuery:
     start_ts_utc: Optional[str] = None
     end_ts_utc: Optional[str] = None
     priorities: Optional[List[str]] = None
-    directions: Optional[List[str]] = None
     resource_ids: Optional[List[int]] = None
     resource_labels: Optional[List[str]] = None
     unit_like: Optional[str] = None
@@ -183,9 +175,6 @@ __all__ = [
     "CommsLogQuery",
     "utcnow_iso",
     "localnow_iso",
-    "DIRECTION_INCOMING",
-    "DIRECTION_OUTGOING",
-    "DIRECTION_INTERNAL",
     "PRIORITY_ROUTINE",
     "PRIORITY_PRIORITY",
     "PRIORITY_EMERGENCY",

--- a/modules/communications/traffic_log/repository.py
+++ b/modules/communications/traffic_log/repository.py
@@ -1,0 +1,524 @@
+"""Persistence layer for the communications traffic log."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from modules.communications.models.master_repo import MasterRepository
+from utils.state import AppState
+
+from .models import (
+    CommsLogAuditEntry,
+    CommsLogEntry,
+    CommsLogFilterPreset,
+    CommsLogQuery,
+    DISPOSITION_OPEN,
+    localnow_iso,
+    utcnow_iso,
+)
+
+logger = logging.getLogger(__name__)
+
+_DATA_DIR = Path(os.environ.get("CHECKIN_DATA_DIR", "data"))
+
+
+def _incident_db_path(incident_id: str) -> Path:
+    base = _DATA_DIR / "incidents"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{incident_id}.db"
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA busy_timeout = 4000")
+    except sqlite3.DatabaseError:
+        pass
+    return conn
+
+
+def _ensure_columns(conn: sqlite3.Connection, table: str, columns: Dict[str, str]) -> None:
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    existing = {row[1] for row in cur.fetchall()}
+    for name, ddl in columns.items():
+        if name not in existing:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {ddl}")
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS comms_log (
+            id INTEGER PRIMARY KEY,
+            ts_utc TEXT,
+            ts_local TEXT,
+            direction TEXT,
+            priority TEXT,
+            resource_id INTEGER,
+            resource_label TEXT,
+            frequency TEXT,
+            band TEXT,
+            mode TEXT,
+            from_unit TEXT,
+            to_unit TEXT,
+            message TEXT,
+            action_taken TEXT,
+            follow_up_required INTEGER DEFAULT 0,
+            disposition TEXT DEFAULT 'Open',
+            operator_user_id TEXT,
+            operator_display_name TEXT,
+            team_id INTEGER,
+            task_id INTEGER,
+            vehicle_id INTEGER,
+            personnel_id INTEGER,
+            attachments TEXT,
+            geotag_lat REAL,
+            geotag_lon REAL,
+            notification_level TEXT,
+            is_status_update INTEGER DEFAULT 0,
+            created_at TEXT,
+            updated_at TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS comms_log_audit (
+            id INTEGER PRIMARY KEY,
+            comms_log_id INTEGER NOT NULL,
+            action TEXT,
+            changed_by TEXT,
+            changed_at TEXT,
+            change_json TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS comms_log_filters (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            filters_json TEXT NOT NULL,
+            created_at TEXT,
+            updated_at TEXT
+        )
+        """
+    )
+    _ensure_columns(
+        conn,
+        "comms_log",
+        {
+            "operator_display_name": "TEXT",
+            "notification_level": "TEXT",
+            "geotag_lat": "REAL",
+            "geotag_lon": "REAL",
+        },
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_comms_log_ts ON comms_log(ts_utc DESC)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_comms_log_priority ON comms_log(priority)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_comms_log_direction ON comms_log(direction)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_comms_log_resource ON comms_log(resource_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_comms_log_task ON comms_log(task_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_comms_log_status ON comms_log(is_status_update)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_comms_log_follow_up ON comms_log(follow_up_required)"
+    )
+    conn.commit()
+
+
+class CommsLogRepository:
+    """Repository managing communications log persistence."""
+
+    def __init__(self, incident_id: Optional[str] = None, master_repo: Optional[MasterRepository] = None):
+        incident = incident_id or AppState.get_active_incident()
+        if not incident:
+            raise RuntimeError("No active incident configured")
+        self.incident_id = str(incident)
+        self._path = _incident_db_path(self.incident_id)
+        self._master_repo = master_repo or MasterRepository()
+        with _connect(self._path) as conn:
+            _ensure_schema(conn)
+
+    def _apply_resource_metadata(self, entry: CommsLogEntry) -> None:
+        if entry.resource_id and not entry.resource_label:
+            try:
+                channel = self._master_repo.get_channel(int(entry.resource_id))
+            except Exception as exc:
+                logger.debug("Failed to load comms resource %s: %s", entry.resource_id, exc)
+                channel = None
+            if channel:
+                entry.resource_label = channel.get("display_name") or channel.get("name") or ""
+                if not entry.frequency:
+                    rx = channel.get("rx_freq")
+                    tx = channel.get("tx_freq")
+                    if rx and tx and rx != tx:
+                        entry.frequency = f"{rx}/{tx}"
+                    elif rx:
+                        entry.frequency = str(rx)
+                    elif tx:
+                        entry.frequency = str(tx)
+                entry.band = entry.band or str(channel.get("band") or "")
+                entry.mode = entry.mode or str(channel.get("mode") or "")
+        if not entry.resource_label:
+            entry.resource_label = ""
+
+    def _apply_operator(self, entry: CommsLogEntry) -> None:
+        if entry.operator_user_id is None:
+            user = AppState.get_active_user_id()
+            if user is not None:
+                entry.operator_user_id = str(user)
+        if entry.operator_display_name is None:
+            user = AppState.get_active_user_id()
+            if user is not None:
+                entry.operator_display_name = str(user)
+
+    def add_entry(self, entry: CommsLogEntry) -> CommsLogEntry:
+        if not entry.message:
+            raise ValueError("Message is required")
+        self._apply_resource_metadata(entry)
+        self._apply_operator(entry)
+        entry.created_at = entry.created_at or utcnow_iso()
+        entry.updated_at = entry.updated_at or entry.created_at
+        entry.ts_utc = entry.ts_utc or utcnow_iso()
+        entry.ts_local = entry.ts_local or localnow_iso()
+        payload = entry.to_record()
+        columns = ",".join(payload.keys())
+        placeholders = ",".join(["?"] * len(payload))
+        values = [payload[k] for k in payload.keys()]
+        with _connect(self._path) as conn:
+            cur = conn.execute(
+                f"INSERT INTO comms_log ({columns}) VALUES ({placeholders})",
+                values,
+            )
+            entry_id = cur.lastrowid
+            conn.commit()
+        entry.id = int(entry_id)
+        self._write_audit(entry.id, "create", asdict(entry))
+        return self.get_entry(entry.id)
+
+    def get_entry(self, entry_id: int) -> CommsLogEntry:
+        with _connect(self._path) as conn:
+            row = conn.execute(
+                "SELECT * FROM comms_log WHERE id=?",
+                (int(entry_id),),
+            ).fetchone()
+            if not row:
+                raise ValueError(f"comms_log entry {entry_id} not found")
+            return CommsLogEntry.from_row(dict(row))
+
+    def list_entries(self, query: Optional[CommsLogQuery] = None) -> List[CommsLogEntry]:
+        query = query or CommsLogQuery()
+        clauses: List[str] = []
+        params: List[Any] = []
+        if query.start_ts_utc:
+            clauses.append("ts_utc >= ?")
+            params.append(query.start_ts_utc)
+        if query.end_ts_utc:
+            clauses.append("ts_utc <= ?")
+            params.append(query.end_ts_utc)
+        if query.priorities:
+            placeholders = ",".join(["?"] * len(query.priorities))
+            clauses.append(f"priority IN ({placeholders})")
+            params.extend(query.priorities)
+        if query.directions:
+            placeholders = ",".join(["?"] * len(query.directions))
+            clauses.append(f"direction IN ({placeholders})")
+            params.extend(query.directions)
+        if query.resource_ids:
+            placeholders = ",".join(["?"] * len(query.resource_ids))
+            clauses.append(f"resource_id IN ({placeholders})")
+            params.extend(query.resource_ids)
+        if query.resource_labels:
+            clauses.append(
+                "(" + " OR ".join(["resource_label LIKE ?" for _ in query.resource_labels]) + ")"
+            )
+            params.extend([f"%{label}%" for label in query.resource_labels])
+        if query.unit_like:
+            clauses.append("(from_unit LIKE ? OR to_unit LIKE ?)")
+            pattern = f"%{query.unit_like}%"
+            params.extend([pattern, pattern])
+        if query.operator_ids:
+            placeholders = ",".join(["?"] * len(query.operator_ids))
+            clauses.append(f"operator_user_id IN ({placeholders})")
+            params.extend(query.operator_ids)
+        if query.dispositions:
+            placeholders = ",".join(["?"] * len(query.dispositions))
+            clauses.append(f"disposition IN ({placeholders})")
+            params.extend(query.dispositions)
+        if query.notification_levels:
+            placeholders = ",".join(["?"] * len(query.notification_levels))
+            clauses.append(f"notification_level IN ({placeholders})")
+            params.extend(query.notification_levels)
+        if query.has_attachments is True:
+            clauses.append("attachments NOT NULL AND attachments NOT LIKE '[]' AND attachments <> ''")
+        elif query.has_attachments is False:
+            clauses.append("(attachments IS NULL OR attachments = '' OR attachments = '[]')")
+        if query.is_status_update is True:
+            clauses.append("is_status_update = 1")
+        elif query.is_status_update is False:
+            clauses.append("is_status_update = 0")
+        if query.follow_up_required is True:
+            clauses.append("follow_up_required = 1")
+        elif query.follow_up_required is False:
+            clauses.append("follow_up_required = 0")
+        if query.task_ids:
+            placeholders = ",".join(["?"] * len(query.task_ids))
+            clauses.append(f"task_id IN ({placeholders})")
+            params.extend(query.task_ids)
+        if query.team_ids:
+            placeholders = ",".join(["?"] * len(query.team_ids))
+            clauses.append(f"team_id IN ({placeholders})")
+            params.extend(query.team_ids)
+        if query.vehicle_ids:
+            placeholders = ",".join(["?"] * len(query.vehicle_ids))
+            clauses.append(f"vehicle_id IN ({placeholders})")
+            params.extend(query.vehicle_ids)
+        if query.personnel_ids:
+            placeholders = ",".join(["?"] * len(query.personnel_ids))
+            clauses.append(f"personnel_id IN ({placeholders})")
+            params.extend(query.personnel_ids)
+        if query.text_search:
+            pattern = f"%{query.text_search.lower()}%"
+            clauses.append(
+                "(" +
+                " OR ".join([
+                    "LOWER(message) LIKE ?",
+                    "LOWER(action_taken) LIKE ?",
+                    "LOWER(from_unit) LIKE ?",
+                    "LOWER(to_unit) LIKE ?",
+                ]) +
+                ")"
+            )
+            params.extend([pattern, pattern, pattern, pattern])
+
+        where_clause = ""
+        if clauses:
+            where_clause = " WHERE " + " AND ".join(clauses)
+        order_column = query.order_by if query.order_by in {
+            "ts_utc",
+            "ts_local",
+            "priority",
+            "direction",
+            "resource_label",
+            "created_at",
+        } else "ts_utc"
+        direction = "DESC" if query.order_desc else "ASC"
+        limit_clause = ""
+        if query.limit is not None:
+            limit_clause = " LIMIT ?"
+            params.append(int(query.limit))
+            if query.offset:
+                limit_clause += " OFFSET ?"
+                params.append(int(query.offset))
+        elif query.offset:
+            # Offset without limit defaults to 1000 rows
+            limit_clause = " LIMIT 1000 OFFSET ?"
+            params.append(int(query.offset))
+        sql = f"SELECT * FROM comms_log{where_clause} ORDER BY {order_column} {direction}{limit_clause}"
+        with _connect(self._path) as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [CommsLogEntry.from_row(dict(row)) for row in rows]
+
+    def _normalize_patch(self, patch: Dict[str, Any]) -> Dict[str, Any]:
+        normalized: Dict[str, Any] = {}
+        for key, value in patch.items():
+            if key == "attachments":
+                normalized[key] = json.dumps(value or [], ensure_ascii=False)
+            elif key in {"follow_up_required", "is_status_update"}:
+                normalized[key] = 1 if bool(value) else 0
+            else:
+                normalized[key] = value
+        normalized["updated_at"] = utcnow_iso()
+        return normalized
+
+    def update_entry(self, entry_id: int, patch: Dict[str, Any]) -> CommsLogEntry:
+        current = self.get_entry(entry_id)
+        normalized = self._normalize_patch(patch)
+        if not normalized:
+            return current
+        assignments = ",".join([f"{k}=?" for k in normalized.keys()])
+        values = list(normalized.values()) + [int(entry_id)]
+        with _connect(self._path) as conn:
+            conn.execute(
+                f"UPDATE comms_log SET {assignments} WHERE id=?",
+                values,
+            )
+            conn.commit()
+        updated = self.get_entry(entry_id)
+        diff = self._diff_entries(current, updated)
+        if diff:
+            self._write_audit(entry_id, "update", diff)
+        return updated
+
+    def delete_entry(self, entry_id: int) -> None:
+        current = self.get_entry(entry_id)
+        with _connect(self._path) as conn:
+            conn.execute("DELETE FROM comms_log WHERE id=?", (int(entry_id),))
+            conn.commit()
+        self._write_audit(entry_id, "delete", {"previous": asdict(current)})
+
+    def _diff_entries(self, before: CommsLogEntry, after: CommsLogEntry) -> Dict[str, Any]:
+        before_map = asdict(before)
+        after_map = asdict(after)
+        diff: Dict[str, Any] = {}
+        for key in after_map.keys():
+            if key in {"created_at", "updated_at"}:
+                continue
+            if before_map.get(key) != after_map.get(key):
+                diff[key] = {"old": before_map.get(key), "new": after_map.get(key)}
+        return diff
+
+    def _write_audit(self, entry_id: int, action: str, payload: Dict[str, Any]) -> None:
+        user = AppState.get_active_user_id()
+        changed_by = str(user) if user is not None else None
+        record = CommsLogAuditEntry(
+            comms_log_id=entry_id,
+            action=action,
+            changed_by=changed_by,
+            change_json=payload,
+        )
+        data = asdict(record)
+        data["change_json"] = json.dumps(payload, ensure_ascii=False)
+        columns = ",".join(k for k in data.keys() if k != "id")
+        placeholders = ",".join(["?"] * (len(data) - 1))
+        values = [data[k] for k in data.keys() if k != "id"]
+        with _connect(self._path) as conn:
+            conn.execute(
+                f"INSERT INTO comms_log_audit ({columns}) VALUES ({placeholders})",
+                values,
+            )
+            conn.commit()
+
+    def list_audit_entries(self, entry_id: int) -> List[CommsLogAuditEntry]:
+        with _connect(self._path) as conn:
+            rows = conn.execute(
+                "SELECT * FROM comms_log_audit WHERE comms_log_id=? ORDER BY changed_at DESC",
+                (int(entry_id),),
+            ).fetchall()
+        result: List[CommsLogAuditEntry] = []
+        for row in rows:
+            try:
+                payload = json.loads(row["change_json"])
+            except Exception:
+                payload = {}
+            result.append(
+                CommsLogAuditEntry(
+                    id=row["id"],
+                    comms_log_id=row["comms_log_id"],
+                    action=row["action"],
+                    changed_by=row["changed_by"],
+                    changed_at=row["changed_at"],
+                    change_json=payload,
+                )
+            )
+        return result
+
+    def list_filter_presets(self, user_id: Optional[str] = None) -> List[CommsLogFilterPreset]:
+        user = user_id or AppState.get_active_user_id()
+        if user is None:
+            return []
+        with _connect(self._path) as conn:
+            rows = conn.execute(
+                "SELECT * FROM comms_log_filters WHERE user_id=? ORDER BY name",
+                (str(user),),
+            ).fetchall()
+        presets: List[CommsLogFilterPreset] = []
+        for row in rows:
+            try:
+                filters = json.loads(row["filters_json"])
+            except Exception:
+                filters = {}
+            presets.append(
+                CommsLogFilterPreset(
+                    id=row["id"],
+                    name=row["name"],
+                    user_id=row["user_id"],
+                    filters=filters,
+                    created_at=row["created_at"],
+                    updated_at=row["updated_at"],
+                )
+            )
+        return presets
+
+    def save_filter_preset(
+        self,
+        name: str,
+        filters: Dict[str, Any],
+        *,
+        preset_id: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> CommsLogFilterPreset:
+        user = user_id or AppState.get_active_user_id()
+        if user is None:
+            raise RuntimeError("Active user is required to save presets")
+        timestamp = utcnow_iso()
+        payload = json.dumps(filters, ensure_ascii=False)
+        if preset_id is None:
+            with _connect(self._path) as conn:
+                cur = conn.execute(
+                    "INSERT INTO comms_log_filters (name, user_id, filters_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+                    (name, str(user), payload, timestamp, timestamp),
+                )
+                preset_id = cur.lastrowid
+                conn.commit()
+        else:
+            with _connect(self._path) as conn:
+                conn.execute(
+                    "UPDATE comms_log_filters SET name=?, filters_json=?, updated_at=? WHERE id=? AND user_id=?",
+                    (name, payload, timestamp, int(preset_id), str(user)),
+                )
+                conn.commit()
+        return CommsLogFilterPreset(
+            id=int(preset_id),
+            name=name,
+            user_id=str(user),
+            filters=filters,
+            created_at=timestamp,
+            updated_at=timestamp,
+        )
+
+    def delete_filter_preset(self, preset_id: int, *, user_id: Optional[str] = None) -> None:
+        user = user_id or AppState.get_active_user_id()
+        if user is None:
+            raise RuntimeError("Active user is required")
+        with _connect(self._path) as conn:
+            conn.execute(
+                "DELETE FROM comms_log_filters WHERE id=? AND user_id=?",
+                (int(preset_id), str(user)),
+            )
+            conn.commit()
+
+    def mark_disposition(self, entry_id: int, disposition: str) -> CommsLogEntry:
+        if not disposition:
+            disposition = DISPOSITION_OPEN
+        return self.update_entry(entry_id, {"disposition": disposition})
+
+    def mark_follow_up(self, entry_id: int, required: bool) -> CommsLogEntry:
+        return self.update_entry(entry_id, {"follow_up_required": required})
+
+    def mark_status_update(self, entry_id: int, value: bool) -> CommsLogEntry:
+        return self.update_entry(entry_id, {"is_status_update": value})
+
+
+__all__ = ["CommsLogRepository"]

--- a/modules/communications/traffic_log/services.py
+++ b/modules/communications/traffic_log/services.py
@@ -1,0 +1,202 @@
+"""Service layer providing business logic for the communications log."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from modules.communications.models.master_repo import MasterRepository
+from utils.state import AppState
+
+from .exporters import csv_exporter, pdf_exporter
+from .models import (
+    CommsLogEntry,
+    CommsLogFilterPreset,
+    CommsLogQuery,
+    PRIORITY_EMERGENCY,
+    PRIORITY_PRIORITY,
+    PRIORITY_ROUTINE,
+)
+from .repository import CommsLogRepository
+
+logger = logging.getLogger(__name__)
+
+
+class CommsLogService:
+    """High-level API consumed by widgets and bridges."""
+
+    def __init__(
+        self,
+        incident_id: Optional[str] = None,
+        *,
+        repository: Optional[CommsLogRepository] = None,
+        master_repo: Optional[MasterRepository] = None,
+    ) -> None:
+        self.repository = repository or CommsLogRepository(incident_id, master_repo=master_repo)
+        self.master_repo = master_repo or MasterRepository()
+        self._last_resource_id: Optional[int] = None
+
+    # ------------------------------------------------------------------
+    # Entry CRUD
+    # ------------------------------------------------------------------
+    def create_entry(self, payload: Dict[str, Any]) -> CommsLogEntry:
+        entry = self._entry_from_payload(payload)
+        created = self.repository.add_entry(entry)
+        if created.resource_id:
+            try:
+                self._last_resource_id = int(created.resource_id)
+            except Exception:
+                pass
+        return created
+
+    def quick_log(self, message: str, *, direction: Optional[str] = None, priority: Optional[str] = None, **extra: Any) -> CommsLogEntry:
+        payload = dict(extra)
+        payload.setdefault("message", message)
+        if direction:
+            payload.setdefault("direction", direction)
+        if priority:
+            payload.setdefault("priority", priority)
+        if "resource_id" not in payload and self._last_resource_id is not None:
+            payload["resource_id"] = self._last_resource_id
+        created = self.create_entry(payload)
+        return created
+
+    def update_entry(self, entry_id: int, patch: Dict[str, Any]) -> CommsLogEntry:
+        if not patch:
+            return self.repository.get_entry(entry_id)
+        if "attachments" in patch and isinstance(patch["attachments"], Iterable):
+            patch["attachments"] = list(patch["attachments"])
+        return self.repository.update_entry(entry_id, patch)
+
+    def delete_entry(self, entry_id: int) -> None:
+        self.repository.delete_entry(entry_id)
+
+    def list_entries(self, query: Optional[CommsLogQuery] = None) -> List[CommsLogEntry]:
+        return self.repository.list_entries(query)
+
+    def get_entry(self, entry_id: int) -> CommsLogEntry:
+        return self.repository.get_entry(entry_id)
+
+    def list_audit(self, entry_id: int):
+        return self.repository.list_audit_entries(entry_id)
+
+    # ------------------------------------------------------------------
+    # Filter presets
+    # ------------------------------------------------------------------
+    def list_filter_presets(self, user_id: Optional[str] = None) -> List[CommsLogFilterPreset]:
+        return self.repository.list_filter_presets(user_id)
+
+    def save_filter_preset(
+        self,
+        name: str,
+        filters: Dict[str, Any],
+        *,
+        preset_id: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> CommsLogFilterPreset:
+        return self.repository.save_filter_preset(name, filters, preset_id=preset_id, user_id=user_id)
+
+    def delete_filter_preset(self, preset_id: int, *, user_id: Optional[str] = None) -> None:
+        self.repository.delete_filter_preset(preset_id, user_id=user_id)
+
+    # ------------------------------------------------------------------
+    # Shortcut helpers
+    # ------------------------------------------------------------------
+    def list_channels(self) -> List[Dict[str, Any]]:
+        try:
+            return self.master_repo.list_channels()
+        except Exception as exc:
+            logger.warning("Unable to list channels: %s", exc)
+            return []
+
+    def last_used_resource(self) -> Optional[int]:
+        return self._last_resource_id
+
+    def mark_disposition(self, entry_id: int, disposition: str) -> CommsLogEntry:
+        return self.repository.mark_disposition(entry_id, disposition)
+
+    def mark_follow_up(self, entry_id: int, required: bool) -> CommsLogEntry:
+        return self.repository.mark_follow_up(entry_id, required)
+
+    def mark_status_update(self, entry_id: int, flag: bool) -> CommsLogEntry:
+        return self.repository.mark_status_update(entry_id, flag)
+
+    def attach_files(self, entry_id: int, paths: Iterable[str]) -> CommsLogEntry:
+        entry = self.repository.get_entry(entry_id)
+        existing = list(entry.attachments)
+        for path in paths:
+            if path and path not in existing:
+                existing.append(path)
+        return self.repository.update_entry(entry_id, {"attachments": existing})
+
+    # ------------------------------------------------------------------
+    # Integration helpers
+    # ------------------------------------------------------------------
+    def create_follow_up_task(self, entry_id: int, *, title: Optional[str] = None) -> Optional[int]:
+        try:
+            from modules.operations.taskings import repository as task_repo
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.warning("Task module unavailable: %s", exc)
+            return None
+
+        entry = self.repository.get_entry(entry_id)
+        base_title = title or entry.message.splitlines()[0][:60] or "Comms Follow-up"
+        priority_map = {
+            PRIORITY_ROUTINE: 2,
+            PRIORITY_PRIORITY: 3,
+            PRIORITY_EMERGENCY: 4,
+        }
+        priority = priority_map.get(entry.priority, 2)
+        task_id = task_repo.create_task(title=base_title, priority=priority)
+        self.repository.update_entry(entry_id, {"task_id": task_id, "follow_up_required": False})
+        return task_id
+
+    # ------------------------------------------------------------------
+    # Export helpers
+    # ------------------------------------------------------------------
+    def export_to_csv(self, path: Path | str, query: Optional[CommsLogQuery] = None, *, metadata: Optional[Dict[str, Any]] = None) -> Path:
+        entries = self.list_entries(query)
+        target = Path(path)
+        csv_exporter.export_entries(entries, target, metadata or self._default_export_metadata())
+        return target
+
+    def export_to_pdf(self, path: Path | str, query: Optional[CommsLogQuery] = None, *, metadata: Optional[Dict[str, Any]] = None) -> Path:
+        entries = self.list_entries(query)
+        target = Path(path)
+        pdf_exporter.export_entries(entries, target, metadata or self._default_export_metadata())
+        return target
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _entry_from_payload(self, payload: Dict[str, Any]) -> CommsLogEntry:
+        data = dict(payload)
+        attachments = data.get("attachments")
+        if attachments is not None and not isinstance(attachments, list):
+            data["attachments"] = list(attachments)
+        entry = CommsLogEntry()
+        for key, value in data.items():
+            if hasattr(entry, key):
+                setattr(entry, key, value)
+        if not entry.operator_user_id:
+            user = AppState.get_active_user_id()
+            if user is not None:
+                entry.operator_user_id = str(user)
+        if entry.resource_id:
+            try:
+                self._last_resource_id = int(entry.resource_id)
+            except Exception:
+                pass
+        return entry
+
+    def _default_export_metadata(self) -> Dict[str, Any]:
+        incident = AppState.get_active_incident()
+        metadata = {
+            "incident": incident or self.repository.incident_id,
+            "generated_by": AppState.get_active_user_id(),
+        }
+        return metadata
+
+
+__all__ = ["CommsLogService"]

--- a/modules/communications/traffic_log/services.py
+++ b/modules/communications/traffic_log/services.py
@@ -50,11 +50,9 @@ class CommsLogService:
                 pass
         return created
 
-    def quick_log(self, message: str, *, direction: Optional[str] = None, priority: Optional[str] = None, **extra: Any) -> CommsLogEntry:
+    def quick_log(self, message: str, *, priority: Optional[str] = None, **extra: Any) -> CommsLogEntry:
         payload = dict(extra)
         payload.setdefault("message", message)
-        if direction:
-            payload.setdefault("direction", direction)
         if priority:
             payload.setdefault("priority", priority)
         if "resource_id" not in payload and self._last_resource_id is not None:
@@ -129,6 +127,13 @@ class CommsLogService:
             if path and path not in existing:
                 existing.append(path)
         return self.repository.update_entry(entry_id, {"attachments": existing})
+
+    def list_contact_entities(self) -> List[Dict[str, Any]]:
+        try:
+            return self.repository.list_contact_entities()
+        except Exception as exc:
+            logger.warning("Unable to list communications contacts: %s", exc)
+            return []
 
     # ------------------------------------------------------------------
     # Integration helpers

--- a/modules/communications/traffic_log/tests/test_repository.py
+++ b/modules/communications/traffic_log/tests/test_repository.py
@@ -76,7 +76,6 @@ def test_repository_creates_entry_and_audit(setup_env):
     repo = CommsLogRepository(incident_id="test-incident")
     entry = CommsLogEntry(
         message="Rescue team checking in",
-        direction="Incoming",
         priority="Routine",
         resource_id=1,
         from_unit="Team 1",
@@ -107,7 +106,6 @@ def test_service_exports_csv(tmp_path, setup_env):
     service.create_entry(
         {
             "message": "Perimeter established",
-            "direction": "Outgoing",
             "priority": "Priority",
             "resource_id": 1,
             "from_unit": "Base",

--- a/modules/communications/traffic_log/tests/test_repository.py
+++ b/modules/communications/traffic_log/tests/test_repository.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from utils import incident_context
+from utils.state import AppState
+
+from modules.communications.models.master_repo import MasterRepository
+from modules.communications.traffic_log.models import CommsLogEntry, CommsLogQuery
+from modules.communications.traffic_log.repository import CommsLogRepository
+from modules.communications.traffic_log.services import CommsLogService
+
+
+@pytest.fixture()
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHECKIN_DATA_DIR", str(tmp_path))
+    incident_context.set_active_incident("test-incident")
+    AppState.set_active_incident("test-incident")
+    AppState.set_active_user_id("comm_op")
+    master_db = tmp_path / "master.db"
+    with sqlite3.connect(master_db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE comms_resources (
+                id INTEGER PRIMARY KEY,
+                alpha_tag TEXT,
+                function TEXT,
+                freq_rx REAL,
+                freq_tx REAL,
+                mode TEXT,
+                notes TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO comms_resources (id, alpha_tag, function, freq_rx, freq_tx, mode, notes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (1, "VHF-1", "Tactical", 155.55, 155.55, "FM", "Primary tactical"),
+        )
+        conn.commit()
+
+    # Reload modules that cache database paths
+    import modules.communications.models.db as comms_db
+    import modules.communications.models.master_repo as master_repo_module
+    import modules.communications.traffic_log.models as log_models
+    import modules.communications.traffic_log.repository as repo_module
+    import modules.communications.traffic_log.services as services_module
+
+    comms_db.MASTER_DB_PATH = master_db
+    importlib.reload(comms_db)
+    comms_db.MASTER_DB_PATH = master_db
+    importlib.reload(master_repo_module)
+    importlib.reload(log_models)
+    importlib.reload(repo_module)
+    importlib.reload(services_module)
+
+    global MasterRepository, CommsLogEntry, CommsLogQuery, CommsLogRepository, CommsLogService
+    from modules.communications.models.master_repo import MasterRepository as MasterRepository
+    from modules.communications.traffic_log.models import CommsLogEntry as CommsLogEntry
+    from modules.communications.traffic_log.models import CommsLogQuery as CommsLogQuery
+    from modules.communications.traffic_log.repository import CommsLogRepository as CommsLogRepository
+    from modules.communications.traffic_log.services import CommsLogService as CommsLogService
+
+    return tmp_path
+
+
+def test_repository_creates_entry_and_audit(setup_env):
+    repo = CommsLogRepository(incident_id="test-incident")
+    entry = CommsLogEntry(
+        message="Rescue team checking in",
+        direction="Incoming",
+        priority="Routine",
+        resource_id=1,
+        from_unit="Team 1",
+        to_unit="Base",
+    )
+    created = repo.add_entry(entry)
+    assert created.id is not None
+    master = MasterRepository()
+    channel = master.get_channel(1)
+    assert created.resource_label == channel["display_name"]
+    assert created.frequency.startswith("155")
+
+    updated = repo.update_entry(created.id, {"message": "Updated message", "follow_up_required": True})
+    assert updated.message == "Updated message"
+    assert updated.follow_up_required is True
+
+    audits = repo.list_audit_entries(created.id)
+    assert len(audits) >= 2
+    assert audits[0].action in {"update", "create"}
+
+    results = repo.list_entries(CommsLogQuery(priorities=["Routine"]))
+    assert results and results[0].message == "Updated message"
+
+
+def test_service_exports_csv(tmp_path, setup_env):
+    repo = CommsLogRepository(incident_id="test-incident")
+    service = CommsLogService(repository=repo)
+    service.create_entry(
+        {
+            "message": "Perimeter established",
+            "direction": "Outgoing",
+            "priority": "Priority",
+            "resource_id": 1,
+            "from_unit": "Base",
+            "to_unit": "Ops",
+            "follow_up_required": False,
+        }
+    )
+    export_path = tmp_path / "log.csv"
+    service.export_to_csv(export_path, CommsLogQuery())
+    assert export_path.exists()
+    text = export_path.read_text(encoding="utf-8")
+    assert "Perimeter established" in text

--- a/modules/communications/traffic_log/ui/log_detail.py
+++ b/modules/communications/traffic_log/ui/log_detail.py
@@ -24,9 +24,6 @@ from ..models import (
     CommsLogEntry,
     DISPOSITION_CLOSED,
     DISPOSITION_OPEN,
-    DIRECTION_INCOMING,
-    DIRECTION_INTERNAL,
-    DIRECTION_OUTGOING,
     PRIORITY_EMERGENCY,
     PRIORITY_PRIORITY,
     PRIORITY_ROUTINE,
@@ -59,10 +56,6 @@ class LogDetailDrawer(QWidget):
 
         self.ts_label = QLabel("—")
         form.addRow("Timestamp", self.ts_label)
-
-        self.direction_combo = QComboBox()
-        self.direction_combo.addItems([DIRECTION_INCOMING, DIRECTION_OUTGOING, DIRECTION_INTERNAL])
-        form.addRow("Direction", self.direction_combo)
 
         self.priority_combo = QComboBox()
         self.priority_combo.addItems([PRIORITY_ROUTINE, PRIORITY_PRIORITY, PRIORITY_EMERGENCY])
@@ -132,7 +125,6 @@ class LogDetailDrawer(QWidget):
         self.notification_field.textChanged.connect(self._update_diff)
         self.follow_checkbox.toggled.connect(self._update_diff)
         self.status_checkbox.toggled.connect(self._update_diff)
-        self.direction_combo.currentIndexChanged.connect(self._update_diff)
         self.priority_combo.currentIndexChanged.connect(self._update_diff)
         self.disposition_combo.currentIndexChanged.connect(self._update_diff)
 
@@ -160,7 +152,6 @@ class LogDetailDrawer(QWidget):
         self.setEnabled(True)
         self.header_label.setText(f"Entry #{entry.id} — {entry.ts_local}")
         self.ts_label.setText(f"Local: {entry.ts_local}\nUTC: {entry.ts_utc}")
-        self.direction_combo.setCurrentText(entry.direction)
         self.priority_combo.setCurrentText(entry.priority)
         self.channel_field.setText(entry.resource_label)
         self.from_field.setText(entry.from_unit)
@@ -191,8 +182,6 @@ class LogDetailDrawer(QWidget):
             return {}
         entry = self._entry
         patch = {}
-        if entry.direction != self.direction_combo.currentText():
-            patch["direction"] = self.direction_combo.currentText()
         if entry.priority != self.priority_combo.currentText():
             patch["priority"] = self.priority_combo.currentText()
         if entry.from_unit != self.from_field.text():

--- a/modules/communications/traffic_log/ui/log_detail.py
+++ b/modules/communications/traffic_log/ui/log_detail.py
@@ -1,0 +1,245 @@
+"""Detail drawer widget for reviewing and editing an entry."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..models import (
+    CommsLogEntry,
+    DISPOSITION_CLOSED,
+    DISPOSITION_OPEN,
+    DIRECTION_INCOMING,
+    DIRECTION_INTERNAL,
+    DIRECTION_OUTGOING,
+    PRIORITY_EMERGENCY,
+    PRIORITY_PRIORITY,
+    PRIORITY_ROUTINE,
+)
+
+
+class LogDetailDrawer(QWidget):
+    """Slide-in widget presenting the full entry view."""
+
+    saveRequested = Signal(int, dict)
+    createTaskRequested = Signal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._entry: Optional[CommsLogEntry] = None
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(6)
+
+        self.header_label = QLabel("Select a log entry to view details")
+        self.header_label.setWordWrap(True)
+        layout.addWidget(self.header_label)
+
+        form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignLeft)
+        form.setFormAlignment(Qt.AlignTop)
+
+        self.ts_label = QLabel("—")
+        form.addRow("Timestamp", self.ts_label)
+
+        self.direction_combo = QComboBox()
+        self.direction_combo.addItems([DIRECTION_INCOMING, DIRECTION_OUTGOING, DIRECTION_INTERNAL])
+        form.addRow("Direction", self.direction_combo)
+
+        self.priority_combo = QComboBox()
+        self.priority_combo.addItems([PRIORITY_ROUTINE, PRIORITY_PRIORITY, PRIORITY_EMERGENCY])
+        form.addRow("Priority", self.priority_combo)
+
+        self.channel_field = QLineEdit()
+        self.channel_field.setReadOnly(True)
+        form.addRow("Channel", self.channel_field)
+
+        self.from_field = QLineEdit()
+        self.to_field = QLineEdit()
+        form.addRow("From", self.from_field)
+        form.addRow("To", self.to_field)
+
+        self.message_edit = QTextEdit()
+        self.message_edit.setPlaceholderText("Message content")
+        form.addRow("Message", self.message_edit)
+
+        self.action_edit = QTextEdit()
+        self.action_edit.setPlaceholderText("Action taken")
+        form.addRow("Action", self.action_edit)
+
+        self.disposition_combo = QComboBox()
+        self.disposition_combo.addItems([DISPOSITION_OPEN, DISPOSITION_CLOSED])
+        form.addRow("Disposition", self.disposition_combo)
+
+        self.follow_checkbox = QCheckBox("Follow-up Required")
+        form.addRow("Follow-up", self.follow_checkbox)
+
+        self.status_checkbox = QCheckBox("Status Update")
+        form.addRow("Status", self.status_checkbox)
+
+        self.notification_field = QLineEdit()
+        form.addRow("Notification", self.notification_field)
+
+        self.related_label = QLabel("—")
+        self.related_label.setWordWrap(True)
+        form.addRow("Related", self.related_label)
+
+        layout.addLayout(form)
+
+        layout.addWidget(QLabel("Attachments"))
+        self.attachment_list = QListWidget()
+        layout.addWidget(self.attachment_list)
+
+        self.diff_label = QLabel("")
+        self.diff_label.setWordWrap(True)
+        self.diff_label.setStyleSheet("color: #5A5F6A; font-size: 11px;")
+        layout.addWidget(self.diff_label)
+
+        button_row = QHBoxLayout()
+        self.save_button = QPushButton("Save Changes")
+        self.save_button.clicked.connect(self._on_save)
+        button_row.addWidget(self.save_button)
+
+        self.task_button = QPushButton("Create Task")
+        self.task_button.clicked.connect(self._on_create_task)
+        button_row.addWidget(self.task_button)
+        button_row.addStretch(1)
+        layout.addLayout(button_row)
+
+        # Track edits to update diff preview
+        self.from_field.textChanged.connect(self._update_diff)
+        self.to_field.textChanged.connect(self._update_diff)
+        self.message_edit.textChanged.connect(self._update_diff)
+        self.action_edit.textChanged.connect(self._update_diff)
+        self.notification_field.textChanged.connect(self._update_diff)
+        self.follow_checkbox.toggled.connect(self._update_diff)
+        self.status_checkbox.toggled.connect(self._update_diff)
+        self.direction_combo.currentIndexChanged.connect(self._update_diff)
+        self.priority_combo.currentIndexChanged.connect(self._update_diff)
+        self.disposition_combo.currentIndexChanged.connect(self._update_diff)
+
+    # ------------------------------------------------------------------
+    def display_entry(self, entry: Optional[CommsLogEntry]) -> None:
+        self._entry = entry
+        if not entry:
+            self.header_label.setText("Select a log entry to view details")
+            self.ts_label.setText("—")
+            self.channel_field.setText("")
+            self.from_field.setText("")
+            self.to_field.setText("")
+            self.message_edit.clear()
+            self.action_edit.clear()
+            self.disposition_combo.setCurrentIndex(0)
+            self.follow_checkbox.setChecked(False)
+            self.status_checkbox.setChecked(False)
+            self.notification_field.clear()
+            self.attachment_list.clear()
+            self.related_label.setText("—")
+            self.diff_label.clear()
+            self.setEnabled(False)
+            return
+
+        self.setEnabled(True)
+        self.header_label.setText(f"Entry #{entry.id} — {entry.ts_local}")
+        self.ts_label.setText(f"Local: {entry.ts_local}\nUTC: {entry.ts_utc}")
+        self.direction_combo.setCurrentText(entry.direction)
+        self.priority_combo.setCurrentText(entry.priority)
+        self.channel_field.setText(entry.resource_label)
+        self.from_field.setText(entry.from_unit)
+        self.to_field.setText(entry.to_unit)
+        self.message_edit.setPlainText(entry.message)
+        self.action_edit.setPlainText(entry.action_taken)
+        self.disposition_combo.setCurrentText(entry.disposition)
+        self.follow_checkbox.setChecked(entry.follow_up_required)
+        self.status_checkbox.setChecked(entry.is_status_update)
+        self.notification_field.setText(entry.notification_level or "")
+        related_bits = []
+        if entry.task_id:
+            related_bits.append(f"Task {entry.task_id}")
+        if entry.team_id:
+            related_bits.append(f"Team {entry.team_id}")
+        if entry.vehicle_id:
+            related_bits.append(f"Vehicle {entry.vehicle_id}")
+        if entry.personnel_id:
+            related_bits.append(f"Personnel {entry.personnel_id}")
+        self.related_label.setText(", ".join(related_bits) if related_bits else "—")
+        self.attachment_list.clear()
+        for item in entry.attachments:
+            self.attachment_list.addItem(QListWidgetItem(item))
+        self._update_diff()
+
+    def _collect_patch(self) -> dict:
+        if not self._entry:
+            return {}
+        entry = self._entry
+        patch = {}
+        if entry.direction != self.direction_combo.currentText():
+            patch["direction"] = self.direction_combo.currentText()
+        if entry.priority != self.priority_combo.currentText():
+            patch["priority"] = self.priority_combo.currentText()
+        if entry.from_unit != self.from_field.text():
+            patch["from_unit"] = self.from_field.text()
+        if entry.to_unit != self.to_field.text():
+            patch["to_unit"] = self.to_field.text()
+        if entry.message != self.message_edit.toPlainText():
+            patch["message"] = self.message_edit.toPlainText()
+        if entry.action_taken != self.action_edit.toPlainText():
+            patch["action_taken"] = self.action_edit.toPlainText()
+        if entry.disposition != self.disposition_combo.currentText():
+            patch["disposition"] = self.disposition_combo.currentText()
+        if entry.follow_up_required != self.follow_checkbox.isChecked():
+            patch["follow_up_required"] = self.follow_checkbox.isChecked()
+        if entry.is_status_update != self.status_checkbox.isChecked():
+            patch["is_status_update"] = self.status_checkbox.isChecked()
+        if (entry.notification_level or "") != self.notification_field.text():
+            patch["notification_level"] = self.notification_field.text()
+        attachments = [self.attachment_list.item(i).text() for i in range(self.attachment_list.count())]
+        if attachments != entry.attachments:
+            patch["attachments"] = attachments
+        return patch
+
+    def pending_patch(self) -> dict:
+        """Return the current unsaved modifications."""
+        return self._collect_patch()
+
+    def _update_diff(self) -> None:
+        patch = self._collect_patch()
+        if not patch:
+            self.diff_label.setText("")
+            return
+        parts = [f"{key} → {value}" for key, value in patch.items()]
+        self.diff_label.setText("Pending changes: " + "; ".join(parts))
+
+    def _on_save(self) -> None:
+        if not self._entry:
+            return
+        patch = self._collect_patch()
+        if not patch:
+            return
+        self.saveRequested.emit(int(self._entry.id), patch)
+
+    def _on_create_task(self) -> None:
+        if not self._entry:
+            return
+        self.createTaskRequested.emit(int(self._entry.id))
+
+
+__all__ = ["LogDetailDrawer"]

--- a/modules/communications/traffic_log/ui/log_filters.py
+++ b/modules/communications/traffic_log/ui/log_filters.py
@@ -1,0 +1,312 @@
+"""Filter sidebar for the communications traffic log."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional
+
+from PySide6.QtCore import Qt, QDateTime, Signal
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDateTimeEdit,
+    QFormLayout,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QSpacerItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..models import CommsLogFilterPreset, CommsLogQuery
+
+
+class LogFilterPanel(QWidget):
+    """Sidebar widget holding filter controls and preset management."""
+
+    filtersChanged = Signal(object)
+    presetSaveRequested = Signal(str, dict)
+    presetDeleteRequested = Signal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(10)
+
+        form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignLeft)
+
+        self.start_enabled = QCheckBox("Start")
+        self.start_edit = QDateTimeEdit(QDateTime.currentDateTime())
+        self.start_edit.setDisplayFormat("yyyy-MM-dd HH:mm")
+        self.start_edit.setCalendarPopup(True)
+        start_row = QHBoxLayout()
+        start_row.addWidget(self.start_enabled)
+        start_row.addWidget(self.start_edit)
+        form.addRow(start_row)
+
+        self.end_enabled = QCheckBox("End")
+        self.end_edit = QDateTimeEdit(QDateTime.currentDateTime())
+        self.end_edit.setDisplayFormat("yyyy-MM-dd HH:mm")
+        self.end_edit.setCalendarPopup(True)
+        end_row = QHBoxLayout()
+        end_row.addWidget(self.end_enabled)
+        end_row.addWidget(self.end_edit)
+        form.addRow(end_row)
+
+        self.priority_combo = QComboBox()
+        self.priority_combo.addItems(["Any", "Routine", "Priority", "Emergency"])
+        form.addRow("Priority", self.priority_combo)
+
+        self.direction_combo = QComboBox()
+        self.direction_combo.addItems(["Any", "Incoming", "Outgoing", "Internal"])
+        form.addRow("Direction", self.direction_combo)
+
+        self.channel_combo = QComboBox()
+        self.channel_combo.setEditable(True)
+        self.channel_combo.addItem("Any", None)
+        form.addRow("Channel", self.channel_combo)
+
+        self.unit_field = QLineEdit()
+        form.addRow("Unit/Callsign", self.unit_field)
+
+        self.operator_field = QLineEdit()
+        form.addRow("Operator", self.operator_field)
+
+        self.disposition_combo = QComboBox()
+        self.disposition_combo.addItems(["Any", "Open", "Closed"])
+        form.addRow("Disposition", self.disposition_combo)
+
+        self.attachments_combo = QComboBox()
+        self.attachments_combo.addItems(["Any", "Yes", "No"])
+        form.addRow("Attachments", self.attachments_combo)
+
+        self.status_combo = QComboBox()
+        self.status_combo.addItems(["Any", "Status Updates", "Non Status"])
+        form.addRow("Status", self.status_combo)
+
+        self.follow_combo = QComboBox()
+        self.follow_combo.addItems(["Any", "Requires Follow-up", "No Follow-up"])
+        form.addRow("Follow-up", self.follow_combo)
+
+        self.notification_field = QLineEdit()
+        form.addRow("Notification", self.notification_field)
+
+        self.text_field = QLineEdit()
+        form.addRow("Search", self.text_field)
+
+        layout.addLayout(form)
+
+        clear_btn = QPushButton("Clear Filters")
+        clear_btn.clicked.connect(self.reset_filters)
+        layout.addWidget(clear_btn)
+
+        layout.addWidget(QLabel("Saved Presets"))
+        self.preset_list = QListWidget()
+        self.preset_list.itemDoubleClicked.connect(self._apply_selected_preset)
+        layout.addWidget(self.preset_list, 1)
+
+        preset_buttons = QHBoxLayout()
+        self.save_button = QPushButton("Save Preset")
+        self.save_button.clicked.connect(self._on_save_clicked)
+        preset_buttons.addWidget(self.save_button)
+        self.delete_button = QPushButton("Delete")
+        self.delete_button.clicked.connect(self._on_delete_clicked)
+        preset_buttons.addWidget(self.delete_button)
+        layout.addLayout(preset_buttons)
+
+        layout.addSpacerItem(QSpacerItem(1, 1))
+
+        # Connect change signals to re-emit filter updates
+        self.start_enabled.toggled.connect(self._emit_filters)
+        self.start_edit.dateTimeChanged.connect(self._emit_filters)
+        self.end_enabled.toggled.connect(self._emit_filters)
+        self.end_edit.dateTimeChanged.connect(self._emit_filters)
+        self.priority_combo.currentIndexChanged.connect(self._emit_filters)
+        self.direction_combo.currentIndexChanged.connect(self._emit_filters)
+        self.channel_combo.currentIndexChanged.connect(self._emit_filters)
+        self.unit_field.textChanged.connect(self._emit_filters)
+        self.operator_field.textChanged.connect(self._emit_filters)
+        self.disposition_combo.currentIndexChanged.connect(self._emit_filters)
+        self.attachments_combo.currentIndexChanged.connect(self._emit_filters)
+        self.status_combo.currentIndexChanged.connect(self._emit_filters)
+        self.follow_combo.currentIndexChanged.connect(self._emit_filters)
+        self.notification_field.textChanged.connect(self._emit_filters)
+        self.text_field.textChanged.connect(self._emit_filters)
+
+    # ------------------------------------------------------------------
+    # Filter management
+    # ------------------------------------------------------------------
+    def current_query(self) -> CommsLogQuery:
+        query = CommsLogQuery()
+        if self.start_enabled.isChecked():
+            query.start_ts_utc = self.start_edit.dateTime().toUTC().toString(Qt.ISODate)
+        if self.end_enabled.isChecked():
+            query.end_ts_utc = self.end_edit.dateTime().toUTC().toString(Qt.ISODate)
+        if self.priority_combo.currentIndex() > 0:
+            query.priorities = [self.priority_combo.currentText()]
+        if self.direction_combo.currentIndex() > 0:
+            query.directions = [self.direction_combo.currentText()]
+        if self.channel_combo.currentData():
+            query.resource_ids = [self.channel_combo.currentData()]
+        elif self.channel_combo.currentText() and self.channel_combo.currentIndex() == -1:
+            query.resource_labels = [self.channel_combo.currentText()]
+        if self.unit_field.text().strip():
+            query.unit_like = self.unit_field.text().strip()
+        if self.operator_field.text().strip():
+            query.operator_ids = [self.operator_field.text().strip()]
+        if self.disposition_combo.currentIndex() > 0:
+            query.dispositions = [self.disposition_combo.currentText()]
+        attachments_idx = self.attachments_combo.currentIndex()
+        if attachments_idx == 1:
+            query.has_attachments = True
+        elif attachments_idx == 2:
+            query.has_attachments = False
+        status_idx = self.status_combo.currentIndex()
+        if status_idx == 1:
+            query.is_status_update = True
+        elif status_idx == 2:
+            query.is_status_update = False
+        follow_idx = self.follow_combo.currentIndex()
+        if follow_idx == 1:
+            query.follow_up_required = True
+        elif follow_idx == 2:
+            query.follow_up_required = False
+        if self.notification_field.text().strip():
+            query.notification_levels = [self.notification_field.text().strip()]
+        if self.text_field.text().strip():
+            query.text_search = self.text_field.text().strip()
+        return query
+
+    def reset_filters(self) -> None:
+        self.start_enabled.setChecked(False)
+        self.end_enabled.setChecked(False)
+        self.priority_combo.setCurrentIndex(0)
+        self.direction_combo.setCurrentIndex(0)
+        self.channel_combo.setCurrentIndex(0)
+        self.channel_combo.setEditText("")
+        self.unit_field.clear()
+        self.operator_field.clear()
+        self.disposition_combo.setCurrentIndex(0)
+        self.attachments_combo.setCurrentIndex(0)
+        self.status_combo.setCurrentIndex(0)
+        self.follow_combo.setCurrentIndex(0)
+        self.notification_field.clear()
+        self.text_field.clear()
+        self._emit_filters()
+
+    def populate_channels(self, channels: Iterable[Dict[str, object]]) -> None:
+        current = self.channel_combo.currentData()
+        text = self.channel_combo.currentText()
+        self.channel_combo.blockSignals(True)
+        self.channel_combo.clear()
+        self.channel_combo.addItem("Any", None)
+        for channel in channels:
+            label = str(channel.get("display_name") or channel.get("name") or "")
+            self.channel_combo.addItem(label, channel.get("id"))
+        if current:
+            idx = self.channel_combo.findData(current)
+            if idx >= 0:
+                self.channel_combo.setCurrentIndex(idx)
+            else:
+                self.channel_combo.setEditText(text)
+        self.channel_combo.blockSignals(False)
+
+    # ------------------------------------------------------------------
+    # Preset helpers
+    # ------------------------------------------------------------------
+    def populate_presets(self, presets: Iterable[CommsLogFilterPreset]) -> None:
+        self.preset_list.clear()
+        for preset in presets:
+            item = QListWidgetItem(preset.name)
+            item.setData(Qt.UserRole, preset)
+            self.preset_list.addItem(item)
+
+    def _on_save_clicked(self) -> None:
+        name, ok = QInputDialog.getText(self, "Save Filter Preset", "Preset name:")
+        if not ok or not name.strip():
+            return
+        filters = {k: v for k, v in self.current_query().__dict__.items() if v not in (None, [], "")}
+        self.presetSaveRequested.emit(name.strip(), filters)
+
+    def _on_delete_clicked(self) -> None:
+        item = self.preset_list.currentItem()
+        if not item:
+            return
+        preset = item.data(Qt.UserRole)
+        if preset and getattr(preset, "id", None):
+            self.presetDeleteRequested.emit(int(preset.id))
+
+    def _apply_selected_preset(self, item: QListWidgetItem) -> None:
+        preset = item.data(Qt.UserRole)
+        if not preset:
+            return
+        filters = getattr(preset, "filters", {}) or {}
+        self.apply_filters(filters)
+
+    def apply_filters(self, filters: Dict[str, object]) -> None:
+        self.start_enabled.setChecked(bool(filters.get("start_ts_utc")))
+        if filters.get("start_ts_utc"):
+            self.start_edit.setDateTime(QDateTime.fromString(str(filters["start_ts_utc"]), Qt.ISODate))
+        self.end_enabled.setChecked(bool(filters.get("end_ts_utc")))
+        if filters.get("end_ts_utc"):
+            self.end_edit.setDateTime(QDateTime.fromString(str(filters["end_ts_utc"]), Qt.ISODate))
+        self._set_combo_value(self.priority_combo, filters.get("priorities"))
+        self._set_combo_value(self.direction_combo, filters.get("directions"))
+        if filters.get("resource_ids"):
+            value = filters["resource_ids"][0]
+            idx = self.channel_combo.findData(value)
+            if idx >= 0:
+                self.channel_combo.setCurrentIndex(idx)
+        elif filters.get("resource_labels"):
+            self.channel_combo.setEditText(str(filters["resource_labels"][0]))
+        else:
+            self.channel_combo.setCurrentIndex(0)
+            self.channel_combo.setEditText("")
+        self.unit_field.setText(str(filters.get("unit_like") or ""))
+        if filters.get("operator_ids"):
+            self.operator_field.setText(str(filters["operator_ids"][0]))
+        else:
+            self.operator_field.clear()
+        self._set_combo_value(self.disposition_combo, filters.get("dispositions"))
+        self._set_combo_bool_combo(self.attachments_combo, filters.get("has_attachments"))
+        self._set_combo_bool_combo(self.status_combo, filters.get("is_status_update"))
+        self._set_combo_bool_combo(self.follow_combo, filters.get("follow_up_required"))
+        if filters.get("notification_levels"):
+            self.notification_field.setText(str(filters["notification_levels"][0]))
+        else:
+            self.notification_field.clear()
+        self.text_field.setText(str(filters.get("text_search") or ""))
+        self._emit_filters()
+
+    def _set_combo_value(self, combo: QComboBox, values: Optional[List[str]]) -> None:
+        if values:
+            value = values[0]
+            idx = combo.findText(value)
+            if idx >= 0:
+                combo.setCurrentIndex(idx)
+                return
+        combo.setCurrentIndex(0)
+
+    def _set_combo_bool_combo(self, combo: QComboBox, value: Optional[bool]) -> None:
+        if value is True:
+            combo.setCurrentIndex(1)
+        elif value is False:
+            combo.setCurrentIndex(2)
+        else:
+            combo.setCurrentIndex(0)
+
+    # ------------------------------------------------------------------
+    def _emit_filters(self) -> None:
+        self.filtersChanged.emit(self.current_query())
+
+
+__all__ = ["LogFilterPanel"]

--- a/modules/communications/traffic_log/ui/log_filters.py
+++ b/modules/communications/traffic_log/ui/log_filters.py
@@ -66,10 +66,6 @@ class LogFilterPanel(QWidget):
         self.priority_combo.addItems(["Any", "Routine", "Priority", "Emergency"])
         form.addRow("Priority", self.priority_combo)
 
-        self.direction_combo = QComboBox()
-        self.direction_combo.addItems(["Any", "Incoming", "Outgoing", "Internal"])
-        form.addRow("Direction", self.direction_combo)
-
         self.channel_combo = QComboBox()
         self.channel_combo.setEditable(True)
         self.channel_combo.addItem("Any", None)
@@ -131,7 +127,6 @@ class LogFilterPanel(QWidget):
         self.end_enabled.toggled.connect(self._emit_filters)
         self.end_edit.dateTimeChanged.connect(self._emit_filters)
         self.priority_combo.currentIndexChanged.connect(self._emit_filters)
-        self.direction_combo.currentIndexChanged.connect(self._emit_filters)
         self.channel_combo.currentIndexChanged.connect(self._emit_filters)
         self.unit_field.textChanged.connect(self._emit_filters)
         self.operator_field.textChanged.connect(self._emit_filters)
@@ -153,8 +148,6 @@ class LogFilterPanel(QWidget):
             query.end_ts_utc = self.end_edit.dateTime().toUTC().toString(Qt.ISODate)
         if self.priority_combo.currentIndex() > 0:
             query.priorities = [self.priority_combo.currentText()]
-        if self.direction_combo.currentIndex() > 0:
-            query.directions = [self.direction_combo.currentText()]
         if self.channel_combo.currentData():
             query.resource_ids = [self.channel_combo.currentData()]
         elif self.channel_combo.currentText() and self.channel_combo.currentIndex() == -1:
@@ -190,7 +183,6 @@ class LogFilterPanel(QWidget):
         self.start_enabled.setChecked(False)
         self.end_enabled.setChecked(False)
         self.priority_combo.setCurrentIndex(0)
-        self.direction_combo.setCurrentIndex(0)
         self.channel_combo.setCurrentIndex(0)
         self.channel_combo.setEditText("")
         self.unit_field.clear()
@@ -260,7 +252,6 @@ class LogFilterPanel(QWidget):
         if filters.get("end_ts_utc"):
             self.end_edit.setDateTime(QDateTime.fromString(str(filters["end_ts_utc"]), Qt.ISODate))
         self._set_combo_value(self.priority_combo, filters.get("priorities"))
-        self._set_combo_value(self.direction_combo, filters.get("directions"))
         if filters.get("resource_ids"):
             value = filters["resource_ids"][0]
             idx = self.channel_combo.findData(value)

--- a/modules/communications/traffic_log/ui/log_table.py
+++ b/modules/communications/traffic_log/ui/log_table.py
@@ -1,0 +1,208 @@
+"""Table model and view for the communications traffic log."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt
+from PySide6.QtGui import QColor, QBrush
+from PySide6.QtWidgets import QHeaderView, QTableView
+
+from ..models import (
+    CommsLogEntry,
+    PRIORITY_EMERGENCY,
+    PRIORITY_PRIORITY,
+    PRIORITY_ROUTINE,
+)
+
+
+PRIORITY_PALETTE = {
+    PRIORITY_EMERGENCY: (QColor("#FDECEA"), QColor("#7A1E1E")),
+    PRIORITY_PRIORITY: (QColor("#FFF4E5"), QColor("#6A4B00")),
+    PRIORITY_ROUTINE: (QColor("#EEF2FF"), QColor("#1F2937")),
+}
+
+
+class CommsLogTableModel(QAbstractTableModel):
+    """QAbstractTableModel representing log entries."""
+
+    headers = [
+        "Timestamp",
+        "Direction",
+        "Priority",
+        "Channel/Resource",
+        "Frequency",
+        "Band",
+        "Mode",
+        "From",
+        "To",
+        "Message",
+        "Action Taken",
+        "Follow-up",
+        "Disposition",
+        "Operator",
+        "Related",
+        "Attachments",
+        "Geotag",
+        "Notification",
+        "Status Update",
+    ]
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._entries: List[CommsLogEntry] = []
+        self._use_utc = False
+
+    # Basic model API --------------------------------------------------
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # type: ignore[override]
+        if parent.isValid():
+            return 0
+        return len(self._entries)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:  # type: ignore[override]
+        return len(self.headers)
+
+    def headerData(self, section: int, orientation: Qt.Orientation, role: int = Qt.DisplayRole):  # type: ignore[override]
+        if role != Qt.DisplayRole:
+            return None
+        if orientation == Qt.Horizontal:
+            try:
+                return self.headers[section]
+            except IndexError:
+                return None
+        return section + 1
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole):  # type: ignore[override]
+        if not index.isValid():
+            return None
+        entry = self._entries[index.row()]
+        column = index.column()
+        if role == Qt.DisplayRole:
+            return self._display_value(entry, column)
+        if role == Qt.ToolTipRole:
+            return self._tooltip_value(entry, column)
+        if role == Qt.BackgroundRole:
+            bg, _ = PRIORITY_PALETTE.get(entry.priority, (None, None))
+            if bg is not None:
+                return QBrush(bg)
+        if role == Qt.ForegroundRole:
+            _, fg = PRIORITY_PALETTE.get(entry.priority, (None, None))
+            if fg is not None:
+                return QBrush(fg)
+        return None
+
+    # Helpers ----------------------------------------------------------
+    def _display_value(self, entry: CommsLogEntry, column: int) -> str:
+        if column == 0:
+            return entry.ts_utc if self._use_utc else entry.ts_local
+        if column == 1:
+            return entry.direction
+        if column == 2:
+            return entry.priority
+        if column == 3:
+            return entry.resource_label
+        if column == 4:
+            return entry.frequency
+        if column == 5:
+            return entry.band
+        if column == 6:
+            return entry.mode
+        if column == 7:
+            return entry.from_unit
+        if column == 8:
+            return entry.to_unit
+        if column == 9:
+            return entry.message
+        if column == 10:
+            return entry.action_taken
+        if column == 11:
+            return "Yes" if entry.follow_up_required else "No"
+        if column == 12:
+            return entry.disposition
+        if column == 13:
+            return entry.operator_user_id or ""
+        if column == 14:
+            related_parts = []
+            if entry.task_id:
+                related_parts.append(f"Task {entry.task_id}")
+            if entry.team_id:
+                related_parts.append(f"Team {entry.team_id}")
+            if entry.vehicle_id:
+                related_parts.append(f"Vehicle {entry.vehicle_id}")
+            if entry.personnel_id:
+                related_parts.append(f"Personnel {entry.personnel_id}")
+            return ", ".join(related_parts)
+        if column == 15:
+            return str(len(entry.attachments)) if entry.attachments else ""
+        if column == 16:
+            if entry.geotag_lat is not None and entry.geotag_lon is not None:
+                return f"{entry.geotag_lat:.5f}, {entry.geotag_lon:.5f}"
+            return ""
+        if column == 17:
+            return entry.notification_level or ""
+        if column == 18:
+            return "Yes" if entry.is_status_update else "No"
+        return ""
+
+    def _tooltip_value(self, entry: CommsLogEntry, column: int) -> Optional[str]:
+        if column in (9, 10):
+            return self._display_value(entry, column)
+        if column == 15 and entry.attachments:
+            return "\n".join(entry.attachments)
+        return None
+
+    # Public API -------------------------------------------------------
+    def set_entries(self, entries: List[CommsLogEntry]) -> None:
+        self.beginResetModel()
+        self._entries = list(entries)
+        self.endResetModel()
+
+    def entry_at(self, row: int) -> Optional[CommsLogEntry]:
+        if 0 <= row < len(self._entries):
+            return self._entries[row]
+        return None
+
+    def set_use_utc(self, value: bool) -> None:
+        if self._use_utc == value:
+            return
+        self._use_utc = value
+        if self._entries:
+            top_left = self.index(0, 0)
+            bottom_right = self.index(len(self._entries) - 1, 0)
+            self.dataChanged.emit(top_left, bottom_right, [Qt.DisplayRole])
+        else:
+            self.layoutChanged.emit()
+
+
+class CommsLogTableView(QTableView):
+    """Table view wrapper with sensible defaults."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAlternatingRowColors(True)
+        self.setSelectionBehavior(QTableView.SelectRows)
+        self.setSelectionMode(QTableView.SingleSelection)
+        self.setSortingEnabled(False)
+        self.horizontalHeader().setStretchLastSection(True)
+        self.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
+        self.verticalHeader().setVisible(False)
+        self.setWordWrap(False)
+        self.setModel(CommsLogTableModel(self))
+
+    @property
+    def model(self) -> CommsLogTableModel:  # type: ignore[override]
+        return super().model()  # type: ignore[return-value]
+
+    def set_entries(self, entries: List[CommsLogEntry]) -> None:
+        self.model.set_entries(entries)
+        if entries:
+            self.selectRow(0)
+
+    def selected_entry(self) -> Optional[CommsLogEntry]:
+        index = self.selectionModel().currentIndex()
+        if not index.isValid():
+            return None
+        return self.model.entry_at(index.row())
+
+
+__all__ = ["CommsLogTableModel", "CommsLogTableView"]

--- a/modules/communications/traffic_log/ui/log_window.py
+++ b/modules/communications/traffic_log/ui/log_window.py
@@ -1,0 +1,241 @@
+"""Main window for the communications traffic log."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtWidgets import (
+    QFileDialog,
+    QHBoxLayout,
+    QMainWindow,
+    QMessageBox,
+    QShortcut,
+    QSplitter,
+    QStatusBar,
+    QToolBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..models import CommsLogQuery
+from ..services import CommsLogService
+from .log_detail import LogDetailDrawer
+from .log_filters import LogFilterPanel
+from .log_table import CommsLogTableView
+from .quick_entry import QuickEntryWidget
+
+
+class CommunicationsLogWindow(QMainWindow):
+    """Dockable window implementing the traffic log workflow."""
+
+    def __init__(self, service: CommsLogService, parent=None):
+        super().__init__(parent)
+        self.service = service
+        self._current_query = CommsLogQuery()
+        self._build_ui()
+        self._load_initial_data()
+        self._refresh_entries()
+
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        self.setWindowTitle("Communications Traffic Log")
+
+        toolbar = QToolBar("Log Toolbar")
+        toolbar.setMovable(False)
+        self.addToolBar(toolbar)
+
+        self.action_new = QAction("New Entry", self)
+        self.action_new.setShortcut(QKeySequence("Ctrl+N"))
+        self.action_new.triggered.connect(self._focus_quick_entry)
+        toolbar.addAction(self.action_new)
+
+        self.action_save = QAction("Save", self)
+        self.action_save.setShortcut(QKeySequence("Ctrl+S"))
+        self.action_save.triggered.connect(self._save_current_entry)
+        toolbar.addAction(self.action_save)
+
+        self.action_export_csv = QAction("Export CSV", self)
+        self.action_export_csv.triggered.connect(lambda: self._export("csv"))
+        toolbar.addAction(self.action_export_csv)
+
+        self.action_export_pdf = QAction("Export PDF", self)
+        self.action_export_pdf.triggered.connect(lambda: self._export("pdf"))
+        toolbar.addAction(self.action_export_pdf)
+
+        toolbar.addSeparator()
+        self.action_toggle_time = QAction("Toggle UTC", self)
+        self.action_toggle_time.setShortcut(QKeySequence("Ctrl+U"))
+        self.action_toggle_time.setCheckable(True)
+        self.action_toggle_time.triggered.connect(self._toggle_time_view)
+        toolbar.addAction(self.action_toggle_time)
+
+        self.action_create_task = QAction("Create Task", self)
+        self.action_create_task.triggered.connect(self._create_follow_up_task)
+        toolbar.addAction(self.action_create_task)
+
+        central = QWidget()
+        central_layout = QVBoxLayout(central)
+        central_layout.setContentsMargins(0, 0, 0, 0)
+        central_layout.setSpacing(0)
+
+        splitter = QSplitter()
+        splitter.setOrientation(Qt.Horizontal)
+        central_layout.addWidget(splitter, 1)
+
+        self.filter_panel = LogFilterPanel()
+        splitter.addWidget(self.filter_panel)
+
+        center_container = QWidget()
+        center_layout = QVBoxLayout(center_container)
+        center_layout.setContentsMargins(6, 6, 6, 6)
+        center_layout.setSpacing(6)
+        self.table_view = CommsLogTableView()
+        center_layout.addWidget(self.table_view)
+        splitter.addWidget(center_container)
+
+        self.detail_drawer = LogDetailDrawer()
+        splitter.addWidget(self.detail_drawer)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 3)
+        splitter.setStretchFactor(2, 2)
+
+        self.quick_entry = QuickEntryWidget()
+        central_layout.addWidget(self.quick_entry, 0)
+
+        self.setCentralWidget(central)
+        self.setStatusBar(QStatusBar())
+
+        # Wire signals
+        self.filter_panel.filtersChanged.connect(self._on_filters_changed)
+        self.filter_panel.presetSaveRequested.connect(self._on_save_preset)
+        self.filter_panel.presetDeleteRequested.connect(self._on_delete_preset)
+        self.quick_entry.submitted.connect(self._on_quick_entry_submitted)
+        self.quick_entry.attachmentsRequested.connect(self._on_quick_entry_attachments)
+        self.detail_drawer.saveRequested.connect(self._on_detail_save)
+        self.detail_drawer.createTaskRequested.connect(lambda entry_id: self._create_follow_up_task(entry_id))
+        self.table_view.selectionModel().currentChanged.connect(self._on_selection_changed)
+
+        QShortcut(QKeySequence("Ctrl+F"), self, activated=self._focus_filters)
+
+    # ------------------------------------------------------------------
+    def _load_initial_data(self) -> None:
+        channels = self.service.list_channels()
+        self.filter_panel.populate_channels(channels)
+        self.quick_entry.set_channels(channels)
+        self.quick_entry.set_default_resource(self.service.last_used_resource())
+        presets = self.service.list_filter_presets()
+        self.filter_panel.populate_presets(presets)
+
+    # ------------------------------------------------------------------
+    def _refresh_entries(self, *, select_id: Optional[int] = None) -> None:
+        entries = self.service.list_entries(self._current_query)
+        self.table_view.set_entries(entries)
+        if select_id is not None:
+            for row, entry in enumerate(entries):
+                if entry.id == select_id:
+                    self.table_view.selectRow(row)
+                    self.detail_drawer.display_entry(entry)
+                    break
+        else:
+            self._update_detail_from_selection()
+        self.statusBar().showMessage(f"{len(entries)} entries")
+
+    def _update_detail_from_selection(self) -> None:
+        entry = self.table_view.selected_entry()
+        self.detail_drawer.display_entry(entry)
+
+    # ------------------------------------------------------------------
+    def _on_filters_changed(self, query: CommsLogQuery) -> None:
+        self._current_query = query
+        self._refresh_entries()
+
+    def _on_selection_changed(self, current, previous) -> None:  # noqa: D401
+        self._update_detail_from_selection()
+
+    def _on_quick_entry_submitted(self, payload: dict) -> None:
+        try:
+            entry = self.service.create_entry(payload)
+        except Exception as exc:
+            QMessageBox.warning(self, "Entry Error", str(exc))
+            return
+        self.statusBar().showMessage("Entry added", 2000)
+        self._refresh_entries(select_id=entry.id)
+        self.quick_entry.set_default_resource(self.service.last_used_resource())
+
+    def _on_quick_entry_attachments(self) -> None:
+        paths, _ = QFileDialog.getOpenFileNames(self, "Select Attachments")
+        if paths:
+            self.quick_entry.add_attachments(paths)
+
+    def _on_detail_save(self, entry_id: int, patch: dict) -> None:
+        try:
+            updated = self.service.update_entry(entry_id, patch)
+        except Exception as exc:
+            QMessageBox.warning(self, "Save Error", str(exc))
+            return
+        self.statusBar().showMessage("Entry updated", 2000)
+        self._refresh_entries(select_id=updated.id)
+
+    def _save_current_entry(self) -> None:
+        entry = self.table_view.selected_entry()
+        if not entry:
+            return
+        patch = self.detail_drawer.pending_patch()
+        if not patch:
+            return
+        self._on_detail_save(int(entry.id), patch)
+
+    def _focus_quick_entry(self) -> None:
+        self.quick_entry.message_edit.setFocus()
+
+    def _focus_filters(self) -> None:
+        self.filter_panel.text_field.setFocus()
+
+    def _toggle_time_view(self) -> None:
+        self.table_view.model.set_use_utc(self.action_toggle_time.isChecked())
+
+    def _create_follow_up_task(self, entry_id: Optional[int] = None) -> None:
+        entry = self.table_view.selected_entry() if entry_id is None else self.service.get_entry(entry_id)
+        if not entry:
+            return
+        task_id = self.service.create_follow_up_task(int(entry.id))
+        if task_id:
+            self.statusBar().showMessage(f"Task {task_id} created", 3000)
+            self._refresh_entries(select_id=entry.id)
+        else:
+            QMessageBox.information(self, "Task Creation", "Task module unavailable or task could not be created.")
+
+    def _export(self, fmt: str) -> None:
+        if fmt == "csv":
+            path, _ = QFileDialog.getSaveFileName(self, "Export CSV", filter="CSV Files (*.csv)")
+            if not path:
+                return
+            self.service.export_to_csv(Path(path), self._current_query)
+            QMessageBox.information(self, "Export", f"Exported to {path}")
+        elif fmt == "pdf":
+            path, _ = QFileDialog.getSaveFileName(self, "Export PDF", filter="PDF Files (*.pdf)")
+            if not path:
+                return
+            self.service.export_to_pdf(Path(path), self._current_query)
+            QMessageBox.information(self, "Export", f"Exported to {path}")
+
+    def _on_save_preset(self, name: str, filters: dict) -> None:
+        preset = self.service.save_filter_preset(name, filters)
+        presets = self.service.list_filter_presets()
+        self.filter_panel.populate_presets(presets)
+        self.statusBar().showMessage(f"Preset '{preset.name}' saved", 2000)
+
+    def _on_delete_preset(self, preset_id: int) -> None:
+        try:
+            self.service.delete_filter_preset(preset_id)
+        except Exception as exc:
+            QMessageBox.warning(self, "Preset", str(exc))
+            return
+        presets = self.service.list_filter_presets()
+        self.filter_panel.populate_presets(presets)
+
+
+__all__ = ["CommunicationsLogWindow"]

--- a/modules/communications/traffic_log/ui/log_window.py
+++ b/modules/communications/traffic_log/ui/log_window.py
@@ -6,13 +6,12 @@ from pathlib import Path
 from typing import Optional
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtGui import QAction, QKeySequence, QShortcut
 from PySide6.QtWidgets import (
     QFileDialog,
     QHBoxLayout,
     QMainWindow,
     QMessageBox,
-    QShortcut,
     QSplitter,
     QStatusBar,
     QToolBar,

--- a/modules/communications/traffic_log/ui/log_window.py
+++ b/modules/communications/traffic_log/ui/log_window.py
@@ -110,16 +110,28 @@ class CommunicationsLogWindow(QMainWindow):
         central_layout.addWidget(self.quick_entry)
 
         content_splitter = QSplitter(Qt.Vertical)
-        content_splitter.setChildrenCollapsible(False)
         self.table_view = CommsLogTableView()
         content_splitter.addWidget(self.table_view)
 
         self._populate_column_menu()
 
         self.detail_drawer = LogDetailDrawer()
+        self.detail_drawer.setMinimumHeight(0)
         content_splitter.addWidget(self.detail_drawer)
-        content_splitter.setStretchFactor(0, 3)
-        content_splitter.setStretchFactor(1, 2)
+        content_splitter.setCollapsible(0, False)
+        content_splitter.setCollapsible(1, True)
+        content_splitter.setStretchFactor(0, 6)
+        content_splitter.setStretchFactor(1, 1)
+
+        def _set_initial_splitter_sizes() -> None:
+            total = content_splitter.size().height()
+            if total <= 0:
+                total = self.height() or 600
+            table_height = int(total * 0.72)
+            detail_height = max(120, total - table_height)
+            content_splitter.setSizes([table_height, detail_height])
+
+        QTimer.singleShot(0, _set_initial_splitter_sizes)
 
         central_layout.addWidget(content_splitter, 1)
         central_layout.setStretch(0, 0)

--- a/modules/communications/traffic_log/ui/quick_entry.py
+++ b/modules/communications/traffic_log/ui/quick_entry.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, List, Optional
 
-from PySide6.QtCore import Qt, QDateTime, Signal
+from PySide6.QtCore import QDateTime, Qt, Signal, QStringListModel
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QCompleter,
     QDateTimeEdit,
     QHBoxLayout,
     QLabel,
@@ -19,13 +20,38 @@ from PySide6.QtWidgets import (
 )
 
 from ..models import (
-    DIRECTION_INCOMING,
-    DIRECTION_INTERNAL,
-    DIRECTION_OUTGOING,
     PRIORITY_EMERGENCY,
     PRIORITY_PRIORITY,
     PRIORITY_ROUTINE,
 )
+
+
+class GrowingTextEdit(QTextEdit):
+    """QTextEdit that starts as a single line and grows with content."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setAcceptRichText(False)
+        self.setTabChangesFocus(True)
+        self.document().documentLayout().documentSizeChanged.connect(self._update_height)  # type: ignore[arg-type]
+        self.textChanged.connect(self._update_height)
+        self._minimum_height = self._calculate_min_height()
+        self._maximum_height = 220
+        self._update_height()
+
+    def _calculate_min_height(self) -> int:
+        margins = self.contentsMargins()
+        frame = int(self.frameWidth() * 2)
+        return int(self.fontMetrics().lineSpacing() + margins.top() + margins.bottom() + frame + 4)
+
+    def _update_height(self, *_) -> None:
+        margins = self.contentsMargins()
+        frame = int(self.frameWidth() * 2)
+        doc_height = self.document().size().height()
+        target = int(doc_height + margins.top() + margins.bottom() + frame)
+        target = max(self._minimum_height, target)
+        target = min(self._maximum_height, target)
+        self.setFixedHeight(target)
 
 
 class QuickEntryWidget(QWidget):
@@ -36,7 +62,11 @@ class QuickEntryWidget(QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._attachments: list[str] = []
+        self._attachments: List[str] = []
+        self._alias_lookup: Dict[str, Dict[str, object]] = {}
+        self._from_link: Optional[Dict[str, object]] = None
+        self._to_link: Optional[Dict[str, object]] = None
+        self._completer_model = QStringListModel(self)
         self._build_ui()
 
     def _build_ui(self) -> None:
@@ -53,11 +83,6 @@ class QuickEntryWidget(QWidget):
         top_row.addWidget(QLabel("Timestamp"))
         top_row.addWidget(self.timestamp_edit)
 
-        self.direction_combo = QComboBox()
-        self.direction_combo.addItems([DIRECTION_INCOMING, DIRECTION_OUTGOING, DIRECTION_INTERNAL])
-        top_row.addWidget(QLabel("Direction"))
-        top_row.addWidget(self.direction_combo)
-
         self.priority_combo = QComboBox()
         self.priority_combo.addItems([PRIORITY_ROUTINE, PRIORITY_PRIORITY, PRIORITY_EMERGENCY])
         top_row.addWidget(QLabel("Priority"))
@@ -69,9 +94,9 @@ class QuickEntryWidget(QWidget):
         top_row.addWidget(self.resource_combo, 1)
 
         self.from_field = QLineEdit()
-        self.from_field.setPlaceholderText("From unit/callsign")
+        self.from_field.setPlaceholderText("From team or position")
         self.to_field = QLineEdit()
-        self.to_field.setPlaceholderText("To unit/callsign")
+        self.to_field.setPlaceholderText("To team or position")
 
         names_layout = QHBoxLayout()
         names_layout.addWidget(QLabel("From"))
@@ -80,10 +105,16 @@ class QuickEntryWidget(QWidget):
         names_layout.addWidget(self.to_field)
         layout.addLayout(names_layout)
 
+        self._create_completer(self.from_field, "from")
+        self._create_completer(self.to_field, "to")
+        self.from_field.editingFinished.connect(lambda: self._resolve_field_match("from"))
+        self.to_field.editingFinished.connect(lambda: self._resolve_field_match("to"))
+        self.from_field.textChanged.connect(lambda text: self._handle_field_change("from", text))
+        self.to_field.textChanged.connect(lambda text: self._handle_field_change("to", text))
+
         message_layout = QHBoxLayout()
-        self.message_edit = QTextEdit()
+        self.message_edit = GrowingTextEdit()
         self.message_edit.setPlaceholderText("Message body")
-        self.message_edit.setTabChangesFocus(True)
         message_layout.addWidget(QLabel("Message"))
         message_layout.addWidget(self.message_edit, 1)
         layout.addLayout(message_layout)
@@ -123,6 +154,47 @@ class QuickEntryWidget(QWidget):
             label = chan.get("display_name") or chan.get("name") or ""
             self.resource_combo.addItem(label, chan.get("id"))
 
+    def set_contact_suggestions(self, suggestions: Iterable[Dict[str, object]]) -> None:
+        entries: List[Dict[str, object]] = []
+        alias_lookup: Dict[str, Dict[str, object]] = {}
+        display_values: List[str] = []
+        for item in suggestions:
+            if not isinstance(item, dict):
+                continue
+            entity_id = item.get("id")
+            if entity_id is None:
+                continue
+            primary = str(item.get("primary") or item.get("display") or item.get("name") or "").strip()
+            if not primary:
+                continue
+            secondary = str(item.get("secondary") or "").strip()
+            display = primary if not secondary else f"{primary} — {secondary}"
+            alias_values = list(item.get("aliases") or [])
+            alias_values.extend([primary, secondary, display])
+            alias_keys = {self._normalize(alias) for alias in alias_values if alias}
+            # Include split tokens such as callsigns separated by '/'
+            for alias in list(alias_keys):
+                if "/" in alias:
+                    for segment in alias.split("/"):
+                        normalized_segment = self._normalize(segment)
+                        if normalized_segment:
+                            alias_keys.add(normalized_segment)
+            entry = {
+                "type": str(item.get("type") or "unit"),
+                "id": int(entity_id),
+                "display": display,
+                "primary": primary,
+                "aliases": alias_keys,
+            }
+            entries.append(entry)
+            display_values.append(display)
+            for key in alias_keys:
+                alias_lookup[key] = entry
+        self._alias_lookup = alias_lookup
+        self._completer_model.setStringList(display_values)
+        self._resolve_field_match("from", update_text=False)
+        self._resolve_field_match("to", update_text=False)
+
     def set_default_resource(self, resource_id: Optional[int]) -> None:
         if resource_id is None:
             return
@@ -138,6 +210,8 @@ class QuickEntryWidget(QWidget):
         self.status_checkbox.setChecked(False)
         self.from_field.clear()
         self.to_field.clear()
+        self._from_link = None
+        self._to_link = None
         self._attachments.clear()
         self.attach_button.setText("Attach…")
         self.message_edit.setFocus()
@@ -145,15 +219,66 @@ class QuickEntryWidget(QWidget):
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------
+    def _normalize(self, text: str) -> str:
+        return text.strip().lower()
+
+    def _create_completer(self, line_edit: QLineEdit, role: str) -> QCompleter:
+        completer = QCompleter(self._completer_model, line_edit)
+        completer.setCaseSensitivity(Qt.CaseInsensitive)
+        completer.setFilterMode(Qt.MatchContains)
+        completer.setCompletionMode(QCompleter.PopupCompletion)
+        completer.activated[str].connect(lambda value, r=role: self._on_completer_selected(r, value))
+        line_edit.setCompleter(completer)
+        return completer
+
+    def _on_completer_selected(self, role: str, value: str) -> None:
+        field = self.from_field if role == "from" else self.to_field
+        field.setText(value)
+        self._resolve_field_match(role)
+
+    def _lookup_suggestion(self, text: str) -> Optional[Dict[str, object]]:
+        key = self._normalize(text)
+        if not key:
+            return None
+        suggestion = self._alias_lookup.get(key)
+        if suggestion:
+            return suggestion
+        return None
+
+    def _resolve_field_match(self, role: str, update_text: bool = True) -> None:
+        field = self.from_field if role == "from" else self.to_field
+        suggestion = self._lookup_suggestion(field.text())
+        if suggestion:
+            if update_text:
+                field.setText(str(suggestion.get("display", "")))
+            if role == "from":
+                self._from_link = suggestion
+            else:
+                self._to_link = suggestion
+        else:
+            if role == "from":
+                self._from_link = None
+            else:
+                self._to_link = None
+
+    def _handle_field_change(self, role: str, text: str) -> None:
+        suggestion = self._from_link if role == "from" else self._to_link
+        if not suggestion:
+            return
+        if self._normalize(text) not in suggestion.get("aliases", set()):
+            if role == "from":
+                self._from_link = None
+            else:
+                self._to_link = None
+
     def _on_submit(self) -> None:
         message = self.message_edit.toPlainText().strip()
         if not message:
             return
         ts_local = self.timestamp_edit.dateTime()
-        payload = {
+        payload: Dict[str, object] = {
             "ts_local": ts_local.toString(Qt.ISODate),
             "ts_utc": ts_local.toUTC().toString(Qt.ISODate),
-            "direction": self.direction_combo.currentText(),
             "priority": self.priority_combo.currentText(),
             "resource_label": self.resource_combo.currentText().strip(),
             "resource_id": self.resource_combo.currentData(),
@@ -165,6 +290,17 @@ class QuickEntryWidget(QWidget):
             "is_status_update": self.status_checkbox.isChecked(),
             "attachments": list(self._attachments),
         }
+        for match in (self._from_link, self._to_link):
+            if not match:
+                continue
+            entity_type = str(match.get("type"))
+            entity_id = match.get("id")
+            if entity_id is None:
+                continue
+            if entity_type == "team" and "team_id" not in payload:
+                payload["team_id"] = int(entity_id)
+            elif entity_type in {"personnel", "position"} and "personnel_id" not in payload:
+                payload["personnel_id"] = int(entity_id)
         self.submitted.emit(payload)
         self.reset()
 

--- a/modules/communications/traffic_log/ui/quick_entry.py
+++ b/modules/communications/traffic_log/ui/quick_entry.py
@@ -1,0 +1,180 @@
+"""Quick entry widget for rapid logging."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional
+
+from PySide6.QtCore import Qt, QDateTime, Signal
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDateTimeEdit,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..models import (
+    DIRECTION_INCOMING,
+    DIRECTION_INTERNAL,
+    DIRECTION_OUTGOING,
+    PRIORITY_EMERGENCY,
+    PRIORITY_PRIORITY,
+    PRIORITY_ROUTINE,
+)
+
+
+class QuickEntryWidget(QWidget):
+    """Bottom dock widget used for rapid keyboard-first data entry."""
+
+    submitted = Signal(dict)
+    attachmentsRequested = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._attachments: list[str] = []
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(6)
+
+        top_row = QHBoxLayout()
+        layout.addLayout(top_row)
+
+        self.timestamp_edit = QDateTimeEdit(QDateTime.currentDateTime())
+        self.timestamp_edit.setDisplayFormat("yyyy-MM-dd HH:mm:ss")
+        self.timestamp_edit.setCalendarPopup(True)
+        top_row.addWidget(QLabel("Timestamp"))
+        top_row.addWidget(self.timestamp_edit)
+
+        self.direction_combo = QComboBox()
+        self.direction_combo.addItems([DIRECTION_INCOMING, DIRECTION_OUTGOING, DIRECTION_INTERNAL])
+        top_row.addWidget(QLabel("Direction"))
+        top_row.addWidget(self.direction_combo)
+
+        self.priority_combo = QComboBox()
+        self.priority_combo.addItems([PRIORITY_ROUTINE, PRIORITY_PRIORITY, PRIORITY_EMERGENCY])
+        top_row.addWidget(QLabel("Priority"))
+        top_row.addWidget(self.priority_combo)
+
+        self.resource_combo = QComboBox()
+        self.resource_combo.setEditable(True)
+        top_row.addWidget(QLabel("Resource"))
+        top_row.addWidget(self.resource_combo, 1)
+
+        self.from_field = QLineEdit()
+        self.from_field.setPlaceholderText("From unit/callsign")
+        self.to_field = QLineEdit()
+        self.to_field.setPlaceholderText("To unit/callsign")
+
+        names_layout = QHBoxLayout()
+        names_layout.addWidget(QLabel("From"))
+        names_layout.addWidget(self.from_field)
+        names_layout.addWidget(QLabel("To"))
+        names_layout.addWidget(self.to_field)
+        layout.addLayout(names_layout)
+
+        message_layout = QHBoxLayout()
+        self.message_edit = QTextEdit()
+        self.message_edit.setPlaceholderText("Message body")
+        self.message_edit.setTabChangesFocus(True)
+        message_layout.addWidget(QLabel("Message"))
+        message_layout.addWidget(self.message_edit, 1)
+        layout.addLayout(message_layout)
+
+        action_layout = QHBoxLayout()
+        self.action_edit = QLineEdit()
+        self.action_edit.setPlaceholderText("Action taken")
+        action_layout.addWidget(QLabel("Action"))
+        action_layout.addWidget(self.action_edit, 1)
+        layout.addLayout(action_layout)
+
+        toggle_layout = QHBoxLayout()
+        self.status_checkbox = QCheckBox("Status Update")
+        self.followup_checkbox = QCheckBox("Follow-up Required")
+        toggle_layout.addWidget(self.status_checkbox)
+        toggle_layout.addWidget(self.followup_checkbox)
+        toggle_layout.addStretch(1)
+
+        self.attach_button = QPushButton("Attach…")
+        self.attach_button.clicked.connect(self.attachmentsRequested.emit)
+        toggle_layout.addWidget(self.attach_button)
+
+        self.save_button = QPushButton("Save")
+        self.save_button.setDefault(True)
+        self.save_button.clicked.connect(self._on_submit)
+        toggle_layout.addWidget(self.save_button)
+
+        layout.addLayout(toggle_layout)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def set_channels(self, channels: Iterable[Dict[str, str]]) -> None:
+        self.resource_combo.clear()
+        self.resource_combo.addItem("", None)
+        for chan in channels:
+            label = chan.get("display_name") or chan.get("name") or ""
+            self.resource_combo.addItem(label, chan.get("id"))
+
+    def set_default_resource(self, resource_id: Optional[int]) -> None:
+        if resource_id is None:
+            return
+        for row in range(self.resource_combo.count()):
+            if self.resource_combo.itemData(row) == resource_id:
+                self.resource_combo.setCurrentIndex(row)
+                break
+
+    def reset(self) -> None:
+        self.message_edit.clear()
+        self.action_edit.clear()
+        self.followup_checkbox.setChecked(False)
+        self.status_checkbox.setChecked(False)
+        self.from_field.clear()
+        self.to_field.clear()
+        self._attachments.clear()
+        self.attach_button.setText("Attach…")
+        self.message_edit.setFocus()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+    def _on_submit(self) -> None:
+        message = self.message_edit.toPlainText().strip()
+        if not message:
+            return
+        ts_local = self.timestamp_edit.dateTime()
+        payload = {
+            "ts_local": ts_local.toString(Qt.ISODate),
+            "ts_utc": ts_local.toUTC().toString(Qt.ISODate),
+            "direction": self.direction_combo.currentText(),
+            "priority": self.priority_combo.currentText(),
+            "resource_label": self.resource_combo.currentText().strip(),
+            "resource_id": self.resource_combo.currentData(),
+            "from_unit": self.from_field.text().strip(),
+            "to_unit": self.to_field.text().strip(),
+            "message": message,
+            "action_taken": self.action_edit.text().strip(),
+            "follow_up_required": self.followup_checkbox.isChecked(),
+            "is_status_update": self.status_checkbox.isChecked(),
+            "attachments": list(self._attachments),
+        }
+        self.submitted.emit(payload)
+        self.reset()
+
+    # ------------------------------------------------------------------
+    def add_attachments(self, paths: Iterable[str]) -> None:
+        for path in paths:
+            if path and path not in self._attachments:
+                self._attachments.append(path)
+        if self._attachments:
+            self.attach_button.setText(f"Attach… ({len(self._attachments)})")
+
+
+__all__ = ["QuickEntryWidget"]


### PR DESCRIPTION
## Summary
- implement the communications traffic log module with models, repository logic, service layer, and Qt widgets for filters, detail drawer, table view, and quick entry
- add CSV and PDF exporters plus saved filter preset support and task integration hooks
- provide unit tests for the repository/service flow and update shared communications helpers for incident-aware database paths

## Testing
- pytest modules/communications/traffic_log/tests/test_repository.py

------
https://chatgpt.com/codex/tasks/task_b_68d1faeb22bc832ba8708047ba530652