### PR TITLE
Expand global QSS styling

### DIFF
--- a/styles/qss_helpers.py
+++ b/styles/qss_helpers.py
@@ -3,6 +3,48 @@ from textwrap import dedent
 
 def global_qss(tokens: dict) -> str:
     return dedent(f"""
+        QMainWindow {{
+            background: {tokens['bg_window']};
+            color: {tokens['fg_primary']};
+        }}
+        QMenuBar {{
+            background: {tokens['bg_panel']};
+            color: {tokens['fg_primary']};
+            border-bottom: 1px solid {tokens['divider']};
+        }}
+        QMenuBar::item {{
+            background: transparent;
+            color: {tokens['fg_primary']};
+            padding: 4px 8px;
+        }}
+        QMenuBar::item:selected {{
+            background: {tokens['bg_raised']};
+            color: {tokens['fg_primary']};
+        }}
+        QMenu {{
+            background: {tokens['bg_panel']};
+            color: {tokens['fg_primary']};
+            border: 1px solid {tokens['ctrl_border']};
+        }}
+        QMenu::item {{
+            background: transparent;
+            color: {tokens['fg_primary']};
+            padding: 4px 24px;
+        }}
+        QMenu::item:selected {{
+            background: {tokens['bg_raised']};
+            color: {tokens['fg_primary']};
+        }}
+        QDockWidget {{
+            background: {tokens['bg_panel']};
+            color: {tokens['fg_primary']};
+            border: 1px solid {tokens['divider']};
+        }}
+        QDockWidget::title {{
+            background: {tokens['bg_raised']};
+            color: {tokens['fg_primary']};
+            padding: 4px 8px;
+        }}
         QToolTip {{
             background: {tokens['bg_raised']};
             color: {tokens['fg_primary']};


### PR DESCRIPTION
## Summary
- style the main window, menu bar, menus, and dock widgets using the theme palette tokens
- retain the existing tooltip, header, and scrollbar styling helpers

## Testing
- not run (Qt stylesheet change)


------
https://chatgpt.com/codex/tasks/task_b_68d3b2ffda28832b8cbba1ea9a990fa5