### PR TITLE
Add incident objectives models and Qt panel scaffolding

### DIFF
--- a/modules/_infra/repository.py
+++ b/modules/_infra/repository.py
@@ -11,6 +11,7 @@ from modules._infra.base import Base
 # Import model modules so tables are registered on Base metadata
 import modules.ics214.models  # noqa: F401
 import modules.org.models  # noqa: F401
+import modules.command.models.objectives  # noqa: F401
 
 _engine_cache: Dict[str, Any] = {}
 

--- a/modules/command/models/objective_links.py
+++ b/modules/command/models/objective_links.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+"""Utility helpers for working with objective-task links."""
+
+from collections import defaultdict
+from typing import Dict, Iterable, Tuple
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .objectives import (
+    ObjectiveStrategy,
+    ObjectiveStrategyTaskLink,
+    _OPEN_TASK_STATUSES,
+)
+
+try:  # pragma: no cover - optional at design time
+    from modules.operations.taskings.repository import get_task  # type: ignore
+except Exception:  # pragma: no cover
+    def get_task(task_id: int):  # type: ignore[override]
+        raise RuntimeError("Operations tasking repository unavailable")
+
+
+def list_links_for_objective(session: Session, objective_id: int) -> list[ObjectiveStrategyTaskLink]:
+    """Return all task links for the supplied objective."""
+
+    return (
+        session.execute(
+            select(ObjectiveStrategyTaskLink).where(
+                ObjectiveStrategyTaskLink.objective_id == objective_id
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+def strategy_task_counts(session: Session, strategy_ids: Iterable[int]) -> Dict[int, Tuple[int, int]]:
+    """Return ``{strategy_id: (open_tasks, total_tasks)}`` counts."""
+
+    strategy_ids = list(strategy_ids)
+    if not strategy_ids:
+        return {}
+    rows = (
+        session.execute(
+            select(
+                ObjectiveStrategyTaskLink.strategy_id,
+                ObjectiveStrategyTaskLink.task_id,
+            ).where(ObjectiveStrategyTaskLink.strategy_id.in_(strategy_ids))
+        )
+        .all()
+    )
+    rollup: Dict[int, Tuple[int, int]] = {sid: (0, 0) for sid in strategy_ids}
+    for strategy_id, task_id in rows:
+        open_count, total_count = rollup[strategy_id]
+        status_key = ""
+        try:
+            task = get_task(int(task_id))
+            status_key = str(getattr(task, "status", "")).strip().lower()
+        except Exception:
+            status_key = ""
+        if status_key in _OPEN_TASK_STATUSES:
+            open_count += 1
+        total_count += 1
+        rollup[strategy_id] = (open_count, total_count)
+    return rollup
+
+
+def objective_task_counts(session: Session, objective_id: int) -> Tuple[int, int]:
+    """Return ``(open, total)`` counts for an objective."""
+
+    links = list_links_for_objective(session, objective_id)
+    open_total = 0
+    total = 0
+    for link in links:
+        total += 1
+        try:
+            task = get_task(int(link.task_id))
+            status_key = str(getattr(task, "status", "")).strip().lower()
+        except Exception:
+            status_key = ""
+        if status_key in _OPEN_TASK_STATUSES:
+            open_total += 1
+    return open_total, total
+
+
+def bulk_strategy_counts(session: Session, objective_ids: Iterable[int]) -> Dict[int, Dict[int, Tuple[int, int]]]:
+    """Return ``{objective_id: {strategy_id: (open, total)}}``."""
+
+    rows = (
+        session.execute(
+            select(
+                ObjectiveStrategyTaskLink.objective_id,
+                ObjectiveStrategyTaskLink.strategy_id,
+                ObjectiveStrategyTaskLink.task_id,
+            ).where(ObjectiveStrategyTaskLink.objective_id.in_(list(objective_ids)))
+        )
+        .all()
+    )
+    strategies = (
+        session.execute(
+            select(ObjectiveStrategy.id, ObjectiveStrategy.objective_id)
+            .where(ObjectiveStrategy.id.in_({row[1] for row in rows}))
+        )
+        .all()
+    )
+    strategy_to_objective = {strategy_id: objective_id for strategy_id, objective_id in strategies}
+    rollup: Dict[int, Dict[int, Tuple[int, int]]] = defaultdict(dict)
+    for objective_id, strategy_id, task_id in rows:
+        counts = rollup[objective_id].get(strategy_id, (0, 0))
+        open_count, total_count = counts
+        status_key = ""
+        try:
+            task = get_task(int(task_id))
+            status_key = str(getattr(task, "status", "")).strip().lower()
+        except Exception:
+            status_key = ""
+        if status_key in _OPEN_TASK_STATUSES:
+            open_count += 1
+        total_count += 1
+        rollup[objective_id][strategy_id] = (open_count, total_count)
+    for strategy_id, objective_id in strategy_to_objective.items():
+        rollup.setdefault(objective_id, {}).setdefault(strategy_id, (0, 0))
+    return rollup

--- a/modules/command/models/objectives.py
+++ b/modules/command/models/objectives.py
@@ -1,0 +1,787 @@
+from __future__ import annotations
+
+"""Incident Objectives data access layer for the Command module."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable, Optional, Sequence
+
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    func,
+    select,
+)
+from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
+
+from modules._infra.base import Base
+
+try:  # pragma: no cover - optional dependency in some runtimes
+    from modules.operations.taskings.models import Task  # type: ignore
+    from modules.operations.taskings.repository import get_task  # type: ignore
+except Exception:  # pragma: no cover - operations module not always available
+    Task = None  # type: ignore[assignment]
+
+    def get_task(task_id: int) -> Task:  # type: ignore[override]
+        raise RuntimeError("Taskings repository is not available in this environment")
+
+
+PRIORITY_VALUES = ["low", "normal", "high", "urgent"]
+STATUS_VALUES = ["draft", "active", "deferred", "completed", "cancelled"]
+STRATEGY_STATUS_VALUES = ["planned", "in_progress", "blocked", "done"]
+
+_OPEN_TASK_STATUSES = {"created", "draft", "planned", "assigned", "in progress"}
+
+
+class IncidentObjective(Base):
+    """SQLAlchemy ORM model for high-level incident objectives."""
+
+    __tablename__ = "incident_objectives"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    incident_id: Mapped[str] = mapped_column(String, index=True)
+    op_period_id: Mapped[int | None] = mapped_column(Integer, index=True, nullable=True)
+    code: Mapped[str] = mapped_column(String, index=True)
+    text: Mapped[str] = mapped_column(Text)
+    priority: Mapped[str] = mapped_column(String, default="normal")
+    status: Mapped[str] = mapped_column(String, default="draft")
+    owner_section: Mapped[str | None] = mapped_column(String, nullable=True)
+    tags_json: Mapped[list[str] | None] = mapped_column(JSON, default=list)
+    display_order: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    created_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    strategies = relationship(
+        "ObjectiveStrategy",
+        back_populates="objective",
+        cascade="all, delete-orphan",
+        order_by="ObjectiveStrategy.id",
+    )
+    task_links = relationship(
+        "ObjectiveStrategyTaskLink",
+        back_populates="objective",
+        cascade="all, delete-orphan",
+    )
+    audit_logs = relationship(
+        "ObjectiveAuditLog",
+        back_populates="objective",
+        cascade="all, delete-orphan",
+        order_by="ObjectiveAuditLog.ts.desc()",
+    )
+
+
+class ObjectiveStrategy(Base):
+    """Implementation strategy supporting an incident objective."""
+
+    __tablename__ = "objective_strategies"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    objective_id: Mapped[int] = mapped_column(
+        ForeignKey("incident_objectives.id", ondelete="CASCADE"), index=True
+    )
+    text: Mapped[str] = mapped_column(Text)
+    owner: Mapped[str | None] = mapped_column(String, nullable=True)
+    status: Mapped[str] = mapped_column(String, default="planned")
+    progress_pct: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(String, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    objective = relationship("IncidentObjective", back_populates="strategies")
+    task_links = relationship(
+        "ObjectiveStrategyTaskLink",
+        back_populates="strategy",
+        cascade="all, delete-orphan",
+    )
+
+
+class ObjectiveStrategyTaskLink(Base):
+    """Associates an Operations task with an objective strategy."""
+
+    __tablename__ = "objective_strategy_task_links"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    objective_id: Mapped[int] = mapped_column(
+        ForeignKey("incident_objectives.id", ondelete="CASCADE"), index=True
+    )
+    strategy_id: Mapped[int] = mapped_column(
+        ForeignKey("objective_strategies.id", ondelete="CASCADE"), index=True
+    )
+    task_id: Mapped[int] = mapped_column(Integer, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    objective = relationship("IncidentObjective", back_populates="task_links")
+    strategy = relationship("ObjectiveStrategy", back_populates="task_links")
+
+
+class ObjectiveAuditLog(Base):
+    """Simple audit log capturing mutations to objectives and strategies."""
+
+    __tablename__ = "objective_audit_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    objective_id: Mapped[int] = mapped_column(
+        ForeignKey("incident_objectives.id", ondelete="CASCADE"), index=True
+    )
+    ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    field: Mapped[str] = mapped_column(String)
+    old_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    new_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    user_id: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    objective = relationship("IncidentObjective", back_populates="audit_logs")
+
+
+@dataclass(slots=True)
+class ObjectiveStrategyView:
+    """Serializable view model for a strategy row."""
+
+    id: int
+    objective_id: int
+    text: str
+    owner: str | None
+    status: str
+    progress_pct: int | None
+    open_tasks: int = 0
+    total_tasks: int = 0
+
+
+@dataclass(slots=True)
+class ObjectiveTaskInfo:
+    """Task roll-up row for the Tasks tab."""
+
+    link_id: int
+    task_db_id: int
+    strategy_id: int
+    strategy_text: str
+    task_number: str
+    title: str
+    status: str
+    due: str | None
+    assignee: str | None
+    is_open: bool
+
+
+@dataclass(slots=True)
+class ObjectiveSummary:
+    """Summary row exposed to the table model."""
+
+    id: int
+    code: str
+    text: str
+    priority: str
+    status: str
+    owner_section: str | None
+    tags: list[str]
+    op_period_id: int | None
+    updated_at: datetime | None
+    updated_by: str | None
+    display_order: int
+    strategies: int = 0
+    open_tasks: int = 0
+    total_tasks: int = 0
+
+
+@dataclass(slots=True)
+class ObjectiveDetail:
+    """Complete objective detail for the dialog."""
+
+    summary: ObjectiveSummary
+    strategies: list[ObjectiveStrategyView] = field(default_factory=list)
+    tasks: list[ObjectiveTaskInfo] = field(default_factory=list)
+    narrative: str | None = None
+
+
+@dataclass(slots=True)
+class ObjectiveFilters:
+    """Filter parameters for list queries."""
+
+    status: Optional[Sequence[str]] = None
+    priority: Optional[Sequence[str]] = None
+    op_period_id: Optional[int] = None
+    search: Optional[str] = None
+    has_strategies: Optional[bool] = None
+    has_open_tasks: Optional[bool] = None
+
+
+class ObjectiveRepository:
+    """Repository encapsulating Objective persistence logic."""
+
+    def __init__(self, session: Session, incident_id: str):
+        self.session = session
+        self.incident_id = str(incident_id)
+
+    # ------------------------------------------------------------------
+    # Objective CRUD
+    # ------------------------------------------------------------------
+    def list_objectives(self, filters: ObjectiveFilters | None = None) -> list[ObjectiveSummary]:
+        filters = filters or ObjectiveFilters()
+        stmt = (
+            select(IncidentObjective)
+            .where(IncidentObjective.incident_id == self.incident_id)
+            .order_by(IncidentObjective.display_order.asc(), IncidentObjective.id.asc())
+        )
+        if filters.status:
+            stmt = stmt.where(IncidentObjective.status.in_(list(filters.status)))
+        if filters.priority:
+            stmt = stmt.where(IncidentObjective.priority.in_(list(filters.priority)))
+        if filters.op_period_id is not None:
+            stmt = stmt.where(IncidentObjective.op_period_id == filters.op_period_id)
+        if filters.search:
+            token = f"%{filters.search.lower()}%"
+            stmt = stmt.where(func.lower(IncidentObjective.text).like(token))
+
+        rows = self.session.execute(stmt).scalars().all()
+        objective_ids = [row.id for row in rows]
+        strategy_counts: dict[int, int] = {}
+        if objective_ids:
+            result = self.session.execute(
+                select(
+                    ObjectiveStrategy.objective_id, func.count(ObjectiveStrategy.id)
+                ).where(ObjectiveStrategy.objective_id.in_(objective_ids))
+                .group_by(ObjectiveStrategy.objective_id)
+            )
+            strategy_counts = {oid: count for oid, count in result}
+
+        task_totals: dict[int, int] = {}
+        if objective_ids:
+            result = self.session.execute(
+                select(
+                    ObjectiveStrategyTaskLink.objective_id,
+                    func.count(ObjectiveStrategyTaskLink.id),
+                )
+                .where(ObjectiveStrategyTaskLink.objective_id.in_(objective_ids))
+                .group_by(ObjectiveStrategyTaskLink.objective_id)
+            )
+            task_totals = {oid: total for oid, total in result}
+
+        summaries: list[ObjectiveSummary] = []
+        for obj in rows:
+            open_tasks = self._count_open_tasks(obj.id)
+            summary = ObjectiveSummary(
+                id=obj.id,
+                code=obj.code,
+                text=obj.text,
+                priority=obj.priority,
+                status=obj.status,
+                owner_section=obj.owner_section,
+                tags=list(obj.tags_json or []),
+                op_period_id=obj.op_period_id,
+                updated_at=obj.updated_at,
+                updated_by=obj.updated_by,
+                display_order=obj.display_order,
+                strategies=strategy_counts.get(obj.id, 0),
+                open_tasks=open_tasks,
+                total_tasks=task_totals.get(obj.id, 0),
+            )
+            if filters.has_open_tasks is None or bool(summary.open_tasks) == filters.has_open_tasks:
+                summaries.append(summary)
+        return summaries
+
+    def create_objective(self, payload: dict, user_id: str | None = None) -> ObjectiveDetail:
+        code = payload.get("code") or self._generate_objective_code()
+        display_order = payload.get("display_order")
+        if display_order is None:
+            display_order = self._next_display_order()
+        objective = IncidentObjective(
+            incident_id=self.incident_id,
+            op_period_id=payload.get("op_period_id"),
+            code=code,
+            text=payload.get("text", "").strip(),
+            priority=self._validate_priority(payload.get("priority", "normal")),
+            status=self._validate_status(payload.get("status", "draft")),
+            owner_section=payload.get("owner_section"),
+            tags_json=list(payload.get("tags", [])),
+            display_order=int(display_order),
+            created_by=user_id,
+            updated_by=user_id,
+        )
+        self.session.add(objective)
+        self.session.flush()
+        self._record_audit(objective.id, "objective.create", None, objective.text, user_id)
+        return self.get_objective_detail(objective.id)
+
+    def update_objective(self, objective_id: int, payload: dict, user_id: str | None = None) -> ObjectiveDetail:
+        objective = self.session.get(IncidentObjective, objective_id)
+        if not objective or objective.incident_id != self.incident_id:
+            raise ValueError(f"Objective {objective_id} not found for incident {self.incident_id}")
+
+        changed_fields: list[tuple[str, str | None, str | None]] = []
+        if "text" in payload:
+            new_text = str(payload["text"]).strip()
+            if new_text != objective.text:
+                changed_fields.append(("text", objective.text, new_text))
+                objective.text = new_text
+        if "priority" in payload:
+            new_priority = self._validate_priority(payload["priority"])
+            if new_priority != objective.priority:
+                changed_fields.append(("priority", objective.priority, new_priority))
+                objective.priority = new_priority
+        if "status" in payload:
+            new_status = self._validate_status(payload["status"])
+            if new_status != objective.status:
+                changed_fields.append(("status", objective.status, new_status))
+                objective.status = new_status
+        if "owner_section" in payload:
+            new_owner = payload.get("owner_section")
+            if new_owner != objective.owner_section:
+                changed_fields.append(("owner_section", objective.owner_section, new_owner))
+                objective.owner_section = new_owner
+        if "tags" in payload:
+            new_tags = list(payload.get("tags") or [])
+            if new_tags != list(objective.tags_json or []):
+                changed_fields.append(("tags", str(objective.tags_json or []), str(new_tags)))
+                objective.tags_json = new_tags
+        if "op_period_id" in payload:
+            new_op = payload.get("op_period_id")
+            if new_op != objective.op_period_id:
+                changed_fields.append(("op_period_id", str(objective.op_period_id), str(new_op)))
+                objective.op_period_id = new_op
+
+        objective.updated_by = user_id
+        objective.updated_at = datetime.utcnow()
+        self.session.flush()
+
+        for field, old, new in changed_fields:
+            self._record_audit(objective.id, f"objective.{field}", old, new, user_id)
+
+        return self.get_objective_detail(objective.id)
+
+    def set_status(self, objective_id: int, status: str, user_id: str | None = None) -> ObjectiveDetail:
+        return self.update_objective(objective_id, {"status": status}, user_id=user_id)
+
+    def reorder_objectives(self, ordered_ids: Sequence[int], user_id: str | None = None) -> None:
+        timestamp = datetime.utcnow()
+        for position, obj_id in enumerate(ordered_ids):
+            updated = self.session.execute(
+                select(IncidentObjective).where(
+                    IncidentObjective.id == obj_id,
+                    IncidentObjective.incident_id == self.incident_id,
+                )
+            ).scalars().first()
+            if not updated:
+                continue
+            if updated.display_order != position:
+                self._record_audit(
+                    updated.id,
+                    "objective.reorder",
+                    str(updated.display_order),
+                    str(position),
+                    user_id,
+                )
+                updated.display_order = position
+                updated.updated_at = timestamp
+                updated.updated_by = user_id
+        self.session.flush()
+
+    # ------------------------------------------------------------------
+    # Strategies
+    # ------------------------------------------------------------------
+    def list_strategies(self, objective_id: int) -> list[ObjectiveStrategyView]:
+        rows = (
+            self.session.execute(
+                select(ObjectiveStrategy).where(
+                    ObjectiveStrategy.objective_id == objective_id
+                ).order_by(ObjectiveStrategy.id.asc())
+            )
+            .scalars()
+            .all()
+        )
+        rollup = self._strategy_task_rollup([row.id for row in rows])
+        return [
+            ObjectiveStrategyView(
+                id=row.id,
+                objective_id=row.objective_id,
+                text=row.text,
+                owner=row.owner,
+                status=row.status,
+                progress_pct=row.progress_pct,
+                open_tasks=rollup.get(row.id, (0, 0))[0],
+                total_tasks=rollup.get(row.id, (0, 0))[1],
+            )
+            for row in rows
+        ]
+
+    def add_strategy(
+        self,
+        objective_id: int,
+        payload: dict,
+        user_id: str | None = None,
+    ) -> ObjectiveStrategyView:
+        objective = self.session.get(IncidentObjective, objective_id)
+        if not objective or objective.incident_id != self.incident_id:
+            raise ValueError("Objective not found")
+        strategy = ObjectiveStrategy(
+            objective_id=objective_id,
+            text=str(payload.get("text", "")).strip(),
+            owner=payload.get("owner"),
+            status=self._validate_strategy_status(payload.get("status", "planned")),
+            progress_pct=payload.get("progress_pct"),
+            created_by=user_id,
+            updated_by=user_id,
+        )
+        self.session.add(strategy)
+        self.session.flush()
+        self._record_audit(
+            objective_id,
+            "strategy.create",
+            None,
+            strategy.text,
+            user_id,
+        )
+        return ObjectiveStrategyView(
+            id=strategy.id,
+            objective_id=objective_id,
+            text=strategy.text,
+            owner=strategy.owner,
+            status=strategy.status,
+            progress_pct=strategy.progress_pct,
+        )
+
+    def update_strategy(
+        self,
+        objective_id: int,
+        strategy_id: int,
+        payload: dict,
+        user_id: str | None = None,
+    ) -> ObjectiveStrategyView:
+        strategy = self.session.get(ObjectiveStrategy, strategy_id)
+        if not strategy or strategy.objective_id != objective_id:
+            raise ValueError("Strategy not found")
+
+        changes: list[tuple[str, str | None, str | None]] = []
+        if "text" in payload:
+            new_text = str(payload["text"]).strip()
+            if new_text != strategy.text:
+                changes.append(("text", strategy.text, new_text))
+                strategy.text = new_text
+        if "owner" in payload:
+            new_owner = payload.get("owner")
+            if new_owner != strategy.owner:
+                changes.append(("owner", strategy.owner, new_owner))
+                strategy.owner = new_owner
+        if "status" in payload:
+            new_status = self._validate_strategy_status(payload["status"])
+            if new_status != strategy.status:
+                changes.append(("status", strategy.status, new_status))
+                strategy.status = new_status
+        if "progress_pct" in payload:
+            new_progress = payload.get("progress_pct")
+            if new_progress != strategy.progress_pct:
+                changes.append(("progress_pct", str(strategy.progress_pct), str(new_progress)))
+                strategy.progress_pct = new_progress
+
+        strategy.updated_at = datetime.utcnow()
+        strategy.updated_by = user_id
+        self.session.flush()
+
+        for field, old, new in changes:
+            self._record_audit(strategy.objective_id, f"strategy.{field}", old, new, user_id)
+
+        rollup = self._strategy_task_rollup([strategy.id]).get(strategy.id, (0, 0))
+        return ObjectiveStrategyView(
+            id=strategy.id,
+            objective_id=strategy.objective_id,
+            text=strategy.text,
+            owner=strategy.owner,
+            status=strategy.status,
+            progress_pct=strategy.progress_pct,
+            open_tasks=rollup[0],
+            total_tasks=rollup[1],
+        )
+
+    def delete_strategy(self, objective_id: int, strategy_id: int, user_id: str | None = None) -> None:
+        strategy = self.session.get(ObjectiveStrategy, strategy_id)
+        if not strategy or strategy.objective_id != objective_id:
+            return
+        self._record_audit(
+            objective_id,
+            "strategy.delete",
+            strategy.text,
+            None,
+            user_id,
+        )
+        self.session.delete(strategy)
+        self.session.flush()
+
+    # ------------------------------------------------------------------
+    # Tasks
+    # ------------------------------------------------------------------
+    def link_task(
+        self,
+        objective_id: int,
+        strategy_id: int,
+        task_id: int,
+        user_id: str | None = None,
+    ) -> ObjectiveTaskInfo:
+        objective = self.session.get(IncidentObjective, objective_id)
+        if not objective or objective.incident_id != self.incident_id:
+            raise ValueError("Objective not found")
+        strategy = self.session.get(ObjectiveStrategy, strategy_id)
+        if not strategy or strategy.objective_id != objective_id:
+            raise ValueError("Strategy not found")
+
+        link = ObjectiveStrategyTaskLink(
+            objective_id=objective_id,
+            strategy_id=strategy_id,
+            task_id=int(task_id),
+        )
+        self.session.add(link)
+        self.session.flush()
+        self._record_audit(
+            objective_id,
+            "task.link",
+            None,
+            f"task_id={task_id}",
+            user_id,
+        )
+        return self._build_task_info(link, strategy)
+
+    def unlink_task(self, link_id: int, user_id: str | None = None) -> None:
+        link = self.session.get(ObjectiveStrategyTaskLink, link_id)
+        if not link:
+            return
+        strategy = self.session.get(ObjectiveStrategy, link.strategy_id)
+        self._record_audit(
+            link.objective_id,
+            "task.unlink",
+            f"task_id={link.task_id}",
+            None,
+            user_id,
+        )
+        self.session.delete(link)
+        self.session.flush()
+        if strategy:
+            strategy.updated_at = datetime.utcnow()
+            strategy.updated_by = user_id
+
+    def list_tasks(self, objective_id: int) -> list[ObjectiveTaskInfo]:
+        strategies = {
+            s.id: s
+            for s in self.session.execute(
+                select(ObjectiveStrategy).where(ObjectiveStrategy.objective_id == objective_id)
+            )
+            .scalars()
+            .all()
+        }
+        links = (
+            self.session.execute(
+                select(ObjectiveStrategyTaskLink).where(
+                    ObjectiveStrategyTaskLink.objective_id == objective_id
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return [
+            self._build_task_info(link, strategies.get(link.strategy_id))
+            for link in links
+        ]
+
+    # ------------------------------------------------------------------
+    # Detail / Export
+    # ------------------------------------------------------------------
+    def get_objective_detail(self, objective_id: int) -> ObjectiveDetail:
+        objective = self.session.get(IncidentObjective, objective_id)
+        if not objective or objective.incident_id != self.incident_id:
+            raise ValueError("Objective not found")
+        summary = ObjectiveSummary(
+            id=objective.id,
+            code=objective.code,
+            text=objective.text,
+            priority=objective.priority,
+            status=objective.status,
+            owner_section=objective.owner_section,
+            tags=list(objective.tags_json or []),
+            op_period_id=objective.op_period_id,
+            updated_at=objective.updated_at,
+            updated_by=objective.updated_by,
+            display_order=objective.display_order,
+        )
+        strategies = self.list_strategies(objective_id)
+        tasks = self.list_tasks(objective_id)
+        summary.strategies = len(strategies)
+        summary.total_tasks = len(tasks)
+        summary.open_tasks = sum(1 for t in tasks if t.is_open)
+        return ObjectiveDetail(summary=summary, strategies=strategies, tasks=tasks)
+
+    def export_ics202(
+        self,
+        include_progress: bool = True,
+        include_task_counts: bool = True,
+        include_narrative: bool = False,
+    ) -> dict:
+        objectives = []
+        for detail in self.list_objectives():
+            obj_detail = self.get_objective_detail(detail.id)
+            obj_payload = {
+                "order": detail.display_order,
+                "code": detail.code,
+                "text": detail.text,
+                "priority": detail.priority,
+                "status": detail.status,
+                "strategies": [],
+            }
+            for strategy in obj_detail.strategies:
+                strat_payload = {
+                    "id": strategy.id,
+                    "text": strategy.text,
+                    "status": strategy.status,
+                }
+                if include_progress:
+                    strat_payload["progress_pct"] = strategy.progress_pct
+                if include_task_counts:
+                    strat_payload["open_tasks"] = strategy.open_tasks
+                    strat_payload["total_tasks"] = strategy.total_tasks
+                obj_payload["strategies"].append(strat_payload)
+            if include_narrative:
+                obj_payload["narrative"] = obj_detail.narrative or ""
+            objectives.append(obj_payload)
+        return {"operational_period": {}, "objectives": objectives}
+
+    def list_history(self, objective_id: int) -> list[ObjectiveAuditLog]:
+        return (
+            self.session.execute(
+                select(ObjectiveAuditLog)
+                .where(ObjectiveAuditLog.objective_id == objective_id)
+                .order_by(ObjectiveAuditLog.ts.desc())
+            )
+            .scalars()
+            .all()
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _generate_objective_code(self) -> str:
+        stmt = select(func.max(IncidentObjective.id)).where(
+            IncidentObjective.incident_id == self.incident_id
+        )
+        last_id = self.session.execute(stmt).scalar()
+        next_num = int(last_id or 0) + 1
+        return f"OBJ-{next_num}"
+
+    def _next_display_order(self) -> int:
+        stmt = select(func.max(IncidentObjective.display_order)).where(
+            IncidentObjective.incident_id == self.incident_id
+        )
+        current_max = self.session.execute(stmt).scalar()
+        return int(current_max or 0) + 1
+
+    def _validate_priority(self, value: str) -> str:
+        value = (value or "normal").strip().lower()
+        if value not in PRIORITY_VALUES:
+            raise ValueError(f"Unsupported priority: {value}")
+        return value
+
+    def _validate_status(self, value: str) -> str:
+        value = (value or "draft").strip().lower()
+        if value not in STATUS_VALUES:
+            raise ValueError(f"Unsupported status: {value}")
+        return value
+
+    def _validate_strategy_status(self, value: str) -> str:
+        value = (value or "planned").strip().lower()
+        if value not in STRATEGY_STATUS_VALUES:
+            raise ValueError(f"Unsupported strategy status: {value}")
+        return value
+
+    def _record_audit(
+        self,
+        objective_id: int,
+        field: str,
+        old: str | None,
+        new: str | None,
+        user_id: str | None,
+    ) -> None:
+        entry = ObjectiveAuditLog(
+            objective_id=objective_id,
+            field=field,
+            old_value=old,
+            new_value=new,
+            user_id=user_id,
+        )
+        self.session.add(entry)
+
+    def _count_open_tasks(self, objective_id: int) -> int:
+        tasks = self.list_tasks(objective_id)
+        return sum(1 for task in tasks if task.is_open)
+
+    def _strategy_task_rollup(self, strategy_ids: Iterable[int]) -> dict[int, tuple[int, int]]:
+        strategy_ids = list(strategy_ids)
+        if not strategy_ids:
+            return {}
+        rows = (
+            self.session.execute(
+                select(
+                    ObjectiveStrategyTaskLink.strategy_id,
+                    ObjectiveStrategyTaskLink.id,
+                    ObjectiveStrategyTaskLink.task_id,
+                ).where(ObjectiveStrategyTaskLink.strategy_id.in_(strategy_ids))
+            )
+            .all()
+        )
+        rollup: dict[int, tuple[int, int]] = {}
+        for strategy_id in strategy_ids:
+            rollup[strategy_id] = (0, 0)
+        for strategy_id, link_id, task_id in rows:
+            total_open, total = rollup.get(strategy_id, (0, 0))
+            task_status = self._resolve_task_status(task_id)
+            if task_status in _OPEN_TASK_STATUSES:
+                total_open += 1
+            total += 1
+            rollup[strategy_id] = (total_open, total)
+        return rollup
+
+    def _resolve_task_status(self, task_id: int) -> str:
+        try:
+            task = get_task(int(task_id))
+        except Exception:
+            return ""
+        status = getattr(task, "status", "")
+        return str(status or "").strip().lower()
+
+    def _build_task_info(
+        self,
+        link: ObjectiveStrategyTaskLink,
+        strategy: ObjectiveStrategy | None,
+    ) -> ObjectiveTaskInfo:
+        try:
+            task_obj = get_task(int(link.task_id))
+        except Exception:
+            task_obj = None
+        task_number = ""
+        title = ""
+        status = ""
+        due = None
+        assignee = None
+        if task_obj is not None:
+            task_number = getattr(task_obj, "task_id", "") or getattr(task_obj, "id", "")
+            title = getattr(task_obj, "title", "")
+            status = getattr(task_obj, "status", "")
+            due = getattr(task_obj, "due_time", None)
+            assignee = getattr(task_obj, "assignment", None) or getattr(task_obj, "assigned_to", None)
+        normalized_status = str(status or "").strip().lower()
+        is_open = normalized_status in _OPEN_TASK_STATUSES
+        return ObjectiveTaskInfo(
+            link_id=link.id,
+            task_db_id=int(link.task_id),
+            strategy_id=link.strategy_id,
+            strategy_text=strategy.text if strategy else "",
+            task_number=str(task_number),
+            title=title,
+            status=status,
+            due=due,
+            assignee=assignee,
+            is_open=is_open,
+        )

--- a/modules/command/panels/incident_objectives_panel.py
+++ b/modules/command/panels/incident_objectives_panel.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+"""Qt Widgets panel for managing Incident Objectives."""
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Optional
+
+from PySide6.QtCore import (  # type: ignore[attr-defined]
+    QAbstractTableModel,
+    QModelIndex,
+    QPoint,
+    Qt,
+    QSortFilterProxyModel,
+)
+from PySide6.QtGui import QAction, QIcon
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QHeaderView,
+    QHBoxLayout,
+    QLineEdit,
+    QMenu,
+    QMessageBox,
+    QSizePolicy,
+    QTableView,
+    QToolBar,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from modules._infra.repository import with_incident_session
+from modules.command.models.objectives import (
+    ObjectiveFilters,
+    ObjectiveRepository,
+    ObjectiveSummary,
+)
+from modules.command.widgets.objective_detail_dialog import ObjectiveDetailDialog
+from utils import incident_context, timefmt
+
+
+TABLE_COLUMNS = [
+    "#",
+    "Objective",
+    "Priority",
+    "Status",
+    "Owner/Section",
+    "Strategies",
+    "Open Tasks",
+    "OP",
+    "Updated",
+]
+
+
+class ObjectivesFilterProxyModel(QSortFilterProxyModel):
+    """Simple proxy that filters using a case-insensitive search string."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._search_text = ""
+
+    def set_search_text(self, text: str) -> None:
+        self._search_text = text.lower().strip()
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:  # type: ignore[override]
+        if not self._search_text:
+            return True
+        model = self.sourceModel()
+        if model is None:
+            return True
+        index = model.index(source_row, 1, source_parent)
+        code_index = model.index(source_row, 0, source_parent)
+        objective_text = str(model.data(index, Qt.DisplayRole) or "").lower()
+        code_text = str(model.data(code_index, Qt.DisplayRole) or "").lower()
+        return self._search_text in objective_text or self._search_text in code_text
+
+
+class ObjectivesTableModel(QAbstractTableModel):
+    """Table model driving the objectives grid."""
+
+    def __init__(self, reorder_callback: Callable[[List[int]], None] | None = None) -> None:
+        super().__init__()
+        self._objectives: List[ObjectiveSummary] = []
+        self._reorder_callback = reorder_callback
+
+    # -- Qt model overrides -------------------------------------------------
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # type: ignore[override]
+        if parent.isValid():
+            return 0
+        return len(self._objectives)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:  # type: ignore[override]
+        if parent.isValid():
+            return 0
+        return len(TABLE_COLUMNS)
+
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.DisplayRole,
+    ) -> object:  # type: ignore[override]
+        if role != Qt.DisplayRole:
+            return None
+        if orientation == Qt.Horizontal:
+            if 0 <= section < len(TABLE_COLUMNS):
+                return TABLE_COLUMNS[section]
+            return None
+        return section + 1
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole) -> object:  # type: ignore[override]
+        if not index.isValid():
+            return None
+        row = index.row()
+        col = index.column()
+        if row < 0 or row >= len(self._objectives):
+            return None
+        objective = self._objectives[row]
+        if role == Qt.DisplayRole:
+            if col == 0:
+                return objective.display_order
+            if col == 1:
+                return objective.text
+            if col == 2:
+                return objective.priority.title()
+            if col == 3:
+                return objective.status.title()
+            if col == 4:
+                return objective.owner_section or ""
+            if col == 5:
+                return objective.strategies
+            if col == 6:
+                return objective.open_tasks
+            if col == 7:
+                return objective.op_period_id or ""
+            if col == 8:
+                if objective.updated_at:
+                    return timefmt.relative_time(objective.updated_at)
+                return ""
+        if role == Qt.UserRole:
+            return objective.id
+        return None
+
+    def flags(self, index: QModelIndex) -> Qt.ItemFlags:  # type: ignore[override]
+        base = super().flags(index)
+        if not index.isValid():
+            return base
+        return base | Qt.ItemIsDragEnabled | Qt.ItemIsDropEnabled | Qt.ItemIsSelectable | Qt.ItemIsEnabled
+
+    def supportedDropActions(self) -> Qt.DropActions:  # type: ignore[override]
+        return Qt.MoveAction
+
+    def mimeTypes(self) -> List[str]:  # type: ignore[override]
+        return ["application/x-incident-objective-row"]
+
+    def mimeData(self, indexes: list[QModelIndex]):  # type: ignore[override]
+        from PySide6.QtCore import QMimeData, QByteArray
+
+        mime = QMimeData()
+        if not indexes:
+            return mime
+        row = indexes[0].row()
+        mime.setData("application/x-incident-objective-row", QByteArray(str(row).encode()))
+        return mime
+
+    def dropMimeData(
+        self,
+        data,
+        action: Qt.DropAction,
+        row: int,
+        column: int,
+        parent: QModelIndex,
+    ) -> bool:  # type: ignore[override]
+        if action != Qt.MoveAction:
+            return False
+        if not data.hasFormat("application/x-incident-objective-row"):
+            return False
+        try:
+            source_row = int(bytes(data.data("application/x-incident-objective-row")).decode())
+        except Exception:
+            return False
+        if row == -1:
+            row = parent.row()
+        if row == -1:
+            row = self.rowCount()
+        return self.moveRow(QModelIndex(), source_row, QModelIndex(), row)
+
+    def moveRow(
+        self,
+        sourceParent: QModelIndex,
+        sourceRow: int,
+        destinationParent: QModelIndex,
+        destinationChild: int,
+    ) -> bool:  # type: ignore[override]
+        return self.moveRows(sourceParent, sourceRow, 1, destinationParent, destinationChild)
+
+    def moveRows(
+        self,
+        sourceParent: QModelIndex,
+        sourceRow: int,
+        count: int,
+        destinationParent: QModelIndex,
+        destinationChild: int,
+    ) -> bool:  # type: ignore[override]
+        if count != 1:
+            return False
+        if sourceRow < 0 or sourceRow >= len(self._objectives):
+            return False
+        if destinationChild > len(self._objectives):
+            destinationChild = len(self._objectives)
+        if sourceRow == destinationChild or sourceRow + 1 == destinationChild:
+            return False
+        self.beginMoveRows(sourceParent, sourceRow, sourceRow, destinationParent, destinationChild)
+        objective = self._objectives.pop(sourceRow)
+        insert_row = destinationChild
+        if destinationChild > sourceRow:
+            insert_row -= 1
+        self._objectives.insert(insert_row, objective)
+        self.endMoveRows()
+        self._normalize_display_order()
+        if self._reorder_callback:
+            self._reorder_callback([obj.id for obj in self._objectives])
+        return True
+
+    # -- helpers ------------------------------------------------------------
+    def set_objectives(self, objectives: Iterable[ObjectiveSummary]) -> None:
+        self.beginResetModel()
+        self._objectives = list(objectives)
+        self.endResetModel()
+
+    def objective_for_row(self, row: int) -> Optional[ObjectiveSummary]:
+        if 0 <= row < len(self._objectives):
+            return self._objectives[row]
+        return None
+
+    def _normalize_display_order(self) -> None:
+        for idx, objective in enumerate(self._objectives):
+            objective.display_order = idx
+
+
+@dataclass
+class _ToolbarWidgets:
+    search: QLineEdit
+
+
+class IncidentObjectivesPanel(QWidget):
+    """Main QWidget surface for the Incident Objectives workspace."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._detail_windows: list[ObjectiveDetailDialog] = []
+        self._toolbar = QToolBar("Objectives", self)
+        self._toolbar.setIconSize(self._toolbar.iconSize())
+        self._toolbar.setMovable(False)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self._toolbar)
+
+        toolbar_widgets = self._build_toolbar()
+
+        table_container = QWidget(self)
+        table_layout = QVBoxLayout(table_container)
+        table_layout.setContentsMargins(0, 0, 0, 0)
+        self._table = QTableView(table_container)
+        self._table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._table.setSortingEnabled(True)
+        self._table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._table.setDragDropMode(QAbstractItemView.InternalMove)
+        self._table.setDragDropOverwriteMode(False)
+        self._table.setDefaultDropAction(Qt.MoveAction)
+
+        self._model = ObjectivesTableModel(self._persist_reorder)
+        self._proxy = ObjectivesFilterProxyModel(self)
+        self._proxy.setSourceModel(self._model)
+        self._table.setModel(self._proxy)
+        header = self._table.horizontalHeader()
+        header.setSectionsMovable(True)
+        header.setStretchLastSection(True)
+
+        self._table.doubleClicked.connect(self._on_double_clicked)
+        self._table.setContextMenuPolicy(Qt.CustomContextMenu)
+        self._table.customContextMenuRequested.connect(self._show_context_menu)
+
+        table_layout.addWidget(self._table)
+        layout.addWidget(table_container)
+
+        toolbar_widgets.search.textChanged.connect(self._proxy.set_search_text)
+
+        self.reload()
+
+    # ------------------------------------------------------------------
+    def _build_toolbar(self) -> _ToolbarWidgets:
+        new_action = QAction(QIcon.fromTheme("list-add"), "New Objective", self)
+        new_action.triggered.connect(self._create_objective)
+        self._toolbar.addAction(new_action)
+
+        clone_action = QAction("Clone From Previous OP", self)
+        clone_action.triggered.connect(self._clone_previous)
+        self._toolbar.addAction(clone_action)
+
+        reorder_action = QAction("Reorder", self)
+        reorder_action.triggered.connect(self._prompt_reorder_help)
+        self._toolbar.addAction(reorder_action)
+
+        self._toolbar.addSeparator()
+
+        search_edit = QLineEdit(self)
+        search_edit.setPlaceholderText("Search objectives…")
+        search_edit.setClearButtonEnabled(True)
+        search_edit.setMaximumWidth(260)
+        self._toolbar.addWidget(search_edit)
+
+        filters_action = QAction("Filters", self)
+        filters_action.triggered.connect(self._show_filters_dialog)
+        self._toolbar.addAction(filters_action)
+
+        export_button = QToolButton(self)
+        export_button.setText("Export")
+        export_button.setPopupMode(QToolButton.MenuButtonPopup)
+        export_menu = QMenu(export_button)
+        export_menu.addAction("ICS-202", self._export_ics202)
+        export_button.setMenu(export_menu)
+        export_button.clicked.connect(self._export_ics202)
+        self._toolbar.addWidget(export_button)
+
+        print_action = QAction("Print Preview", self)
+        print_action.triggered.connect(self._show_print_preview)
+        self._toolbar.addAction(print_action)
+
+        spacer = QWidget(self)
+        spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        self._toolbar.addWidget(spacer)
+        return _ToolbarWidgets(search=search_edit)
+
+    # ------------------------------------------------------------------
+    def reload(self) -> None:
+        incident_id = incident_context.get_active_incident()
+        if not incident_id:
+            self._model.set_objectives([])
+            return
+        try:
+            with with_incident_session(str(incident_id)) as session:
+                repository = ObjectiveRepository(session, str(incident_id))
+                objectives = repository.list_objectives(ObjectiveFilters())
+        except Exception as exc:  # pragma: no cover - UI fallback
+            QMessageBox.critical(self, "Incident Objectives", f"Failed to load objectives:\n{exc}")
+            objectives = []
+        self._model.set_objectives(objectives)
+        if self._table.model() is self._proxy:
+            self._table.sortByColumn(0, Qt.AscendingOrder)
+
+    # ------------------------------------------------------------------
+    def _create_objective(self) -> None:
+        dialog = ObjectiveDetailDialog(self)
+        dialog.setWindowTitle("New Objective")
+        dialog.show()
+        self._detail_windows.append(dialog)
+
+    def _clone_previous(self) -> None:
+        QMessageBox.information(
+            self,
+            "Clone Objectives",
+            "Cloning from the previous operational period is not yet implemented.",
+        )
+
+    def _prompt_reorder_help(self) -> None:
+        QMessageBox.information(
+            self,
+            "Reorder Objectives",
+            "Drag rows in the table to change their display order.",
+        )
+
+    def _show_filters_dialog(self) -> None:
+        QMessageBox.information(
+            self,
+            "Filters",
+            "Advanced filters will be available in a future update.",
+        )
+
+    def _export_ics202(self) -> None:
+        incident_id = incident_context.get_active_incident()
+        if not incident_id:
+            QMessageBox.warning(self, "Export", "Select an incident to export ICS-202 data.")
+            return
+        try:
+            with with_incident_session(str(incident_id)) as session:
+                repository = ObjectiveRepository(session, str(incident_id))
+                payload = repository.export_ics202()
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.critical(self, "Export", f"Failed to build ICS-202 export:\n{exc}")
+            return
+        QMessageBox.information(
+            self,
+            "Export",
+            "ICS-202 payload prepared. Hand-off to Forms module pending integration.",
+        )
+        print(payload)  # noqa: T201
+
+    def _show_print_preview(self) -> None:
+        QMessageBox.information(
+            self,
+            "Print Preview",
+            "Print preview is not yet implemented for the Objectives panel.",
+        )
+
+    def _on_double_clicked(self, index: QModelIndex) -> None:
+        self._open_detail_for_index(index)
+
+    def _show_context_menu(self, pos: QPoint) -> None:
+        index = self._table.indexAt(pos)
+        if not index.isValid():
+            return
+        menu = QMenu(self._table)
+        menu.addAction("Edit", lambda: self._open_detail_for_index(index))
+        menu.addAction("Quick Status", lambda: self._quick_status(index))
+        menu.addSeparator()
+        menu.addAction("Add Strategy", lambda: self._open_detail_for_index(index))
+        menu.addAction("Create Task", lambda: self._open_detail_for_index(index))
+        menu.addAction("View All Tasks", lambda: self._open_detail_for_index(index))
+        menu.addAction("Duplicate", lambda: self._duplicate_objective(index))
+        menu.addAction("Complete/Cancel", lambda: self._quick_status(index, target="completed"))
+        menu.exec(self._table.viewport().mapToGlobal(pos))
+
+    def _open_detail_for_index(self, proxy_index: QModelIndex) -> None:
+        source_index = self._proxy.mapToSource(proxy_index)
+        objective = self._model.objective_for_row(source_index.row())
+        if not objective:
+            return
+        dialog = ObjectiveDetailDialog(self)
+        dialog.load_objective(objective.id)
+        dialog.show()
+        self._detail_windows.append(dialog)
+
+    def _quick_status(self, proxy_index: QModelIndex, target: str | None = None) -> None:
+        source_index = self._proxy.mapToSource(proxy_index)
+        objective = self._model.objective_for_row(source_index.row())
+        if not objective:
+            return
+        incident_id = incident_context.get_active_incident()
+        if not incident_id:
+            return
+        next_status = target or ("active" if objective.status != "active" else "completed")
+        try:
+            with with_incident_session(str(incident_id)) as session:
+                repository = ObjectiveRepository(session, str(incident_id))
+                repository.set_status(objective.id, next_status)
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.critical(self, "Quick Status", f"Failed to update status:\n{exc}")
+            return
+        self.reload()
+
+    def _duplicate_objective(self, proxy_index: QModelIndex) -> None:
+        QMessageBox.information(
+            self,
+            "Duplicate Objective",
+            "Objective duplication is not yet available.",
+        )
+
+    def _persist_reorder(self, ordered_ids: List[int]) -> None:
+        incident_id = incident_context.get_active_incident()
+        if not incident_id:
+            return
+        try:
+            with with_incident_session(str(incident_id)) as session:
+                repository = ObjectiveRepository(session, str(incident_id))
+                repository.reorder_objectives(ordered_ids)
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.warning(self, "Reorder", f"Failed to persist order:\n{exc}")
+

--- a/modules/command/widgets/objective_detail_dialog.py
+++ b/modules/command/widgets/objective_detail_dialog.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+"""Modeless editor dialog for incident objectives."""
+
+from typing import Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QCloseEvent
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QPlainTextEdit,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from modules._infra.repository import with_incident_session
+from modules.command.models.objectives import (
+    PRIORITY_VALUES,
+    STATUS_VALUES,
+    ObjectiveDetail,
+    ObjectiveRepository,
+    ObjectiveStrategyView,
+)
+from utils import incident_context
+
+
+class ObjectiveDetailDialog(QDialog):
+    """Qt Widgets dialog that keeps focus on strategic outcomes."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_DeleteOnClose, True)
+        self.setModal(False)
+        self.setWindowTitle("Objective Detail")
+        self._objective_id: Optional[int] = None
+        self._detail: Optional[ObjectiveDetail] = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(8)
+
+        self._header_box = self._build_header()
+        layout.addWidget(self._header_box)
+
+        self._tab_widget = QTabWidget(self)
+        layout.addWidget(self._tab_widget, 1)
+
+        self._build_strategies_tab()
+        self._build_tasks_tab()
+        self._build_narrative_tab()
+        self._build_log_tab()
+
+        self.resize(960, 640)
+
+    # ------------------------------------------------------------------
+    def load_objective(self, objective_id: int) -> None:
+        self._objective_id = objective_id
+        self._refresh()
+
+    # ------------------------------------------------------------------
+    def _build_header(self) -> QWidget:
+        container = QGroupBox("Objective")
+        form = QFormLayout(container)
+        form.setLabelAlignment(Qt.AlignRight)
+        form.setContentsMargins(12, 12, 12, 12)
+        form.setSpacing(6)
+
+        self._code_label = QLabel("OBJ-")
+        self._objective_text = QTextEdit()
+        self._objective_text.setPlaceholderText("Objective statement")
+        self._objective_text.setAcceptRichText(False)
+        self._objective_text.setFixedHeight(80)
+
+        self._priority_combo = QComboBox()
+        self._priority_combo.addItems([p.title() for p in PRIORITY_VALUES])
+
+        self._status_combo = QComboBox()
+        self._status_combo.addItems([s.title() for s in STATUS_VALUES])
+
+        self._owner_edit = QLineEdit()
+        self._owner_edit.setPlaceholderText("Owner or Section")
+
+        self._tags_edit = QLineEdit()
+        self._tags_edit.setPlaceholderText("Tags (comma separated)")
+
+        self._op_label = QLabel("–")
+        self._updated_label = QLabel("–")
+
+        button_row = QHBoxLayout()
+        self._save_button = QPushButton("Save")
+        self._save_button.clicked.connect(self._save)
+        self._create_task_button = QPushButton("Create Task")
+        self._create_task_button.clicked.connect(self._create_task)
+        self._history_button = QPushButton("History")
+        self._history_button.clicked.connect(self._show_history)
+        self._snippet_button = QPushButton("ICS-202 Snippet")
+        self._snippet_button.clicked.connect(self._show_snippet)
+        button_row.addWidget(self._save_button)
+        button_row.addWidget(self._create_task_button)
+        button_row.addWidget(self._history_button)
+        button_row.addWidget(self._snippet_button)
+        button_row.addStretch(1)
+
+        form.addRow("Code", self._code_label)
+        form.addRow("Objective", self._objective_text)
+        form.addRow("Priority", self._priority_combo)
+        form.addRow("Status", self._status_combo)
+        form.addRow("Owner/Section", self._owner_edit)
+        form.addRow("Tags", self._tags_edit)
+        form.addRow("OP", self._op_label)
+        form.addRow("Updated", self._updated_label)
+        form.addRow(button_row)
+        return container
+
+    def _build_strategies_tab(self) -> None:
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(6)
+
+        self._strategies_table = QTableWidget(0, 5, tab)
+        self._strategies_table.setHorizontalHeaderLabels(
+            ["Strategy", "Owner", "Status", "Progress", "Open/Total"]
+        )
+        self._strategies_table.horizontalHeader().setStretchLastSection(True)
+        self._strategies_table.setSelectionBehavior(QTableWidget.SelectRows)
+        self._strategies_table.setEditTriggers(QTableWidget.NoEditTriggers)
+
+        layout.addWidget(self._strategies_table)
+
+        button_bar = QHBoxLayout()
+        add_btn = QPushButton("Add")
+        add_btn.clicked.connect(self._add_strategy)
+        edit_btn = QPushButton("Edit")
+        edit_btn.clicked.connect(self._edit_strategy)
+        delete_btn = QPushButton("Delete")
+        delete_btn.clicked.connect(self._delete_strategy)
+        button_bar.addWidget(add_btn)
+        button_bar.addWidget(edit_btn)
+        button_bar.addWidget(delete_btn)
+        button_bar.addStretch(1)
+        layout.addLayout(button_bar)
+
+        self._tab_widget.addTab(tab, "Strategies")
+
+    def _build_tasks_tab(self) -> None:
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(12, 12, 12, 12)
+
+        self._tasks_table = QTableWidget(0, 7, tab)
+        self._tasks_table.setHorizontalHeaderLabels(
+            ["Task", "Title", "Strategy", "Assignee/Team", "Status", "Due", "Open"]
+        )
+        self._tasks_table.horizontalHeader().setStretchLastSection(True)
+        self._tasks_table.setSelectionBehavior(QTableWidget.SelectRows)
+        self._tasks_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        layout.addWidget(self._tasks_table)
+
+        button_bar = QHBoxLayout()
+        new_task_btn = QPushButton("New Task")
+        new_task_btn.clicked.connect(self._create_task)
+        button_bar.addWidget(new_task_btn)
+        button_bar.addStretch(1)
+        layout.addLayout(button_bar)
+
+        self._tab_widget.addTab(tab, "Tasks")
+
+    def _build_narrative_tab(self) -> None:
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(12, 12, 12, 12)
+        self._narrative_edit = QPlainTextEdit()
+        self._narrative_edit.setPlaceholderText("Narrative notes for this objective")
+        layout.addWidget(self._narrative_edit)
+        self._tab_widget.addTab(tab, "Narrative")
+
+    def _build_log_tab(self) -> None:
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+        layout.setContentsMargins(12, 12, 12, 12)
+        self._log_list = QListWidget()
+        layout.addWidget(self._log_list)
+        self._tab_widget.addTab(tab, "Log")
+
+    # ------------------------------------------------------------------
+    def _refresh(self) -> None:
+        incident_id = incident_context.get_active_incident()
+        if not incident_id or self._objective_id is None:
+            return
+        try:
+            with with_incident_session(str(incident_id)) as session:
+                repository = ObjectiveRepository(session, str(incident_id))
+                detail = repository.get_objective_detail(self._objective_id)
+                history = repository.list_history(self._objective_id)
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.critical(self, "Objective Detail", f"Failed to load objective:\n{exc}")
+            return
+        self._detail = detail
+        summary = detail.summary
+        self._code_label.setText(summary.code)
+        self._objective_text.setPlainText(summary.text)
+        self._priority_combo.setCurrentIndex(PRIORITY_VALUES.index(summary.priority))
+        self._status_combo.setCurrentIndex(STATUS_VALUES.index(summary.status))
+        self._owner_edit.setText(summary.owner_section or "")
+        self._tags_edit.setText(", ".join(summary.tags))
+        self._op_label.setText(str(summary.op_period_id or ""))
+        updated_by = summary.updated_by or "Unknown"
+        updated_ts = summary.updated_at.isoformat(sep=" ") if summary.updated_at else ""
+        self._updated_label.setText(f"{updated_ts} by {updated_by}")
+        self._narrative_edit.setPlainText(self._detail.narrative or "")
+        self._populate_strategies(detail.strategies)
+        self._populate_tasks()
+        self._populate_history(history)
+
+    def _populate_strategies(self, strategies: list[ObjectiveStrategyView]) -> None:
+        self._strategies_table.setRowCount(0)
+        for strategy in strategies:
+            row = self._strategies_table.rowCount()
+            self._strategies_table.insertRow(row)
+            self._strategies_table.setItem(row, 0, QTableWidgetItem(strategy.text))
+            self._strategies_table.setItem(row, 1, QTableWidgetItem(strategy.owner or ""))
+            self._strategies_table.setItem(row, 2, QTableWidgetItem(strategy.status.title()))
+            progress = "" if strategy.progress_pct is None else f"{strategy.progress_pct}%"
+            self._strategies_table.setItem(row, 3, QTableWidgetItem(progress))
+            open_total = f"{strategy.open_tasks}/{strategy.total_tasks}"
+            self._strategies_table.setItem(row, 4, QTableWidgetItem(open_total))
+            self._strategies_table.item(row, 0).setData(Qt.UserRole, strategy.id)
+
+    def _populate_tasks(self) -> None:
+        self._tasks_table.setRowCount(0)
+        if not self._detail:
+            return
+        for task in self._detail.tasks:
+            row = self._tasks_table.rowCount()
+            self._tasks_table.insertRow(row)
+            self._tasks_table.setItem(row, 0, QTableWidgetItem(task.task_number))
+            self._tasks_table.setItem(row, 1, QTableWidgetItem(task.title))
+            self._tasks_table.setItem(row, 2, QTableWidgetItem(task.strategy_text))
+            self._tasks_table.setItem(row, 3, QTableWidgetItem(task.assignee or ""))
+            self._tasks_table.setItem(row, 4, QTableWidgetItem(task.status))
+            self._tasks_table.setItem(row, 5, QTableWidgetItem(task.due or ""))
+            self._tasks_table.setItem(row, 6, QTableWidgetItem("Yes" if task.is_open else "No"))
+
+    def _populate_history(self, history) -> None:
+        self._log_list.clear()
+        for entry in history:
+            label = f"{entry.ts:%Y-%m-%d %H:%M} – {entry.field}: {entry.old_value or ''} → {entry.new_value or ''}"
+            item = QListWidgetItem(label)
+            self._log_list.addItem(item)
+
+    # ------------------------------------------------------------------
+    def _save(self) -> None:
+        incident_id = incident_context.get_active_incident()
+        if not incident_id:
+            QMessageBox.warning(self, "Save", "Select an incident before saving objectives.")
+            return
+        payload = {
+            "text": self._objective_text.toPlainText().strip(),
+            "priority": self._priority_combo.currentText().lower(),
+            "status": self._status_combo.currentText().lower(),
+            "owner_section": self._owner_edit.text().strip() or None,
+            "tags": [tag.strip() for tag in self._tags_edit.text().split(",") if tag.strip()],
+        }
+        try:
+            with with_incident_session(str(incident_id)) as session:
+                repository = ObjectiveRepository(session, str(incident_id))
+                if self._objective_id is None:
+                    detail = repository.create_objective(payload)
+                else:
+                    detail = repository.update_objective(self._objective_id, payload)
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.critical(self, "Save", f"Failed to save objective:\n{exc}")
+            return
+        self._objective_id = detail.summary.id
+        self._detail = detail
+        QMessageBox.information(self, "Save", "Objective saved.")
+        self._refresh()
+
+    def _create_task(self) -> None:
+        QMessageBox.information(
+            self,
+            "Create Task",
+            "Task creation workflow will be available in a future update.",
+        )
+
+    def _show_history(self) -> None:
+        self._tab_widget.setCurrentIndex(3)
+
+    def _show_snippet(self) -> None:
+        incident_id = incident_context.get_active_incident()
+        if not incident_id or self._objective_id is None:
+            return
+        try:
+            with with_incident_session(str(incident_id)) as session:
+                repository = ObjectiveRepository(session, str(incident_id))
+                payload = repository.export_ics202()
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.critical(self, "ICS-202", f"Failed to prepare snippet:\n{exc}")
+            return
+        QMessageBox.information(self, "ICS-202", "Snippet prepared. Copy from console output.")
+        print(payload)  # noqa: T201
+
+    def _add_strategy(self) -> None:
+        if self._objective_id is None:
+            QMessageBox.warning(self, "Strategies", "Save the objective before adding strategies.")
+            return
+        text, ok = QInputDialog.getText(self, "New Strategy", "Strategy description")
+        if not ok or not text.strip():
+            return
+        incident_id = incident_context.get_active_incident()
+        if not incident_id:
+            return
+        try:
+            with with_incident_session(str(incident_id)) as session:
+                repository = ObjectiveRepository(session, str(incident_id))
+                repository.add_strategy(self._objective_id, {"text": text.strip()})
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.critical(self, "Strategy", f"Failed to add strategy:\n{exc}")
+            return
+        self._refresh()
+
+    def _edit_strategy(self) -> None:
+        current = self._current_strategy_id()
+        if current is None:
+            return
+        text, ok = QInputDialog.getText(self, "Edit Strategy", "Strategy description")
+        if not ok:
+            return
+        incident_id = incident_context.get_active_incident()
+        if not incident_id:
+            return
+        try:
+            with with_incident_session(str(incident_id)) as session:
+                repository = ObjectiveRepository(session, str(incident_id))
+                repository.update_strategy(self._objective_id, current, {"text": text.strip()})
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.critical(self, "Strategy", f"Failed to update strategy:\n{exc}")
+            return
+        self._refresh()
+
+    def _delete_strategy(self) -> None:
+        current = self._current_strategy_id()
+        if current is None:
+            return
+        incident_id = incident_context.get_active_incident()
+        if not incident_id:
+            return
+        if QMessageBox.question(
+            self,
+            "Delete Strategy",
+            "Remove the selected strategy?",
+        ) != QMessageBox.Yes:
+            return
+        try:
+            with with_incident_session(str(incident_id)) as session:
+                repository = ObjectiveRepository(session, str(incident_id))
+                repository.delete_strategy(self._objective_id, current)
+        except Exception as exc:  # pragma: no cover
+            QMessageBox.critical(self, "Strategy", f"Failed to delete strategy:\n{exc}")
+            return
+        self._refresh()
+
+    def _current_strategy_id(self) -> Optional[int]:
+        row = self._strategies_table.currentRow()
+        if row < 0:
+            return None
+        item = self._strategies_table.item(row, 0)
+        if not item:
+            return None
+        return int(item.data(Qt.UserRole))
+
+    def closeEvent(self, event: QCloseEvent) -> None:  # type: ignore[override]
+        super().closeEvent(event)
+        self._detail = None

--- a/modules/command/windows.py
+++ b/modules/command/windows.py
@@ -1,6 +1,7 @@
 from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from .panels.incident_dashboard_panel import IncidentDashboardPanel
+from .panels.incident_objectives_panel import IncidentObjectivesPanel
 from .ics203 import get_ics203_panel
 
 __all__ = [
@@ -48,10 +49,9 @@ def get_iap_builder_panel(incident_id: object | None = None) -> QWidget:
 
 
 def get_objectives_panel(incident_id: object | None = None) -> QWidget:
-    """Return the strategic objectives panel from Planning."""
-    from modules.planning.windows import get_strategic_objectives_panel
+    """Return the Qt Widgets incident objectives panel."""
 
-    return get_strategic_objectives_panel(incident_id)
+    return IncidentObjectivesPanel()
 
 
 def get_staff_org_panel(incident_id: object | None = None) -> QWidget:


### PR DESCRIPTION
## Summary
- add SQLAlchemy models, repositories, and task-link helpers for incident objectives
- introduce Qt Widgets Incident Objectives panel and modeless detail dialog
- register the new models with the incident DB repository and expose the panel via command windows

## Testing
- python -m compileall modules/command/models/objectives.py modules/command/panels/incident_objectives_panel.py modules/command/widgets/objective_detail_dialog.py modules/command/models/objective_links.py

------
https://chatgpt.com/codex/tasks/task_b_68d8ab84cf04832b9a182d4aadf284b1