### PR TITLE
Initialize new incident databases from template

### DIFF
--- a/modules/forms_creator/services/db.py
+++ b/modules/forms_creator/services/db.py
@@ -13,6 +13,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator, Iterable
 
+from utils.incident_db import ensure_incident_database
+
 
 DATA_DIR = Path("data")
 MASTER_DB_PATH = DATA_DIR / "master.db"
@@ -50,7 +52,7 @@ def ensure_incident_db(incident_id: str) -> Path:
     if not safe_id:
         raise ValueError("incident_id cannot be empty")
 
-    db_path = INCIDENTS_DIR / f"{safe_id}.db"
+    db_path = ensure_incident_database(safe_id)
     with get_incident_connection(safe_id) as conn:
         conn.executescript(
             """

--- a/modules/incidents/new_incident_dialog.py
+++ b/modules/incidents/new_incident_dialog.py
@@ -118,6 +118,9 @@ class NewIncidentDialog(QDialog):
         except FileExistsError as e:
             QMessageBox.warning(self, "Already Exists", str(e))
             return
+        except Exception as e:
+            QMessageBox.critical(self, "Incident Database Error", str(e))
+            return
 
         self.created.emit(meta, str(db_path))
         self.accept()

--- a/tests/test_incident_db.py
+++ b/tests/test_incident_db.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from utils import incident_context
+from utils.incident_db import create_incident_database
+from utils.state import AppState
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_TABLES = {
+    "agency_contacts",
+    "assignment_air",
+    "assignment_ground",
+    "attachments",
+    "audit_logs",
+    "debriefs",
+    "equipment",
+    "narrative_entries",
+    "operationalperiods",
+    "personnel",
+    "planning_logs",
+    "planning_notes",
+    "task_personnel",
+    "task_teams",
+    "task_vehicles",
+    "tasks",
+    "teams",
+    "vehicles",
+}
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        module.__path__ = [str(path)]
+        sys.modules[name] = module
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_package("modules.operations", REPO_ROOT / "modules" / "operations")
+_ensure_package("modules.operations.data", REPO_ROOT / "modules" / "operations" / "data")
+_ensure_package("modules.operations.teams", REPO_ROOT / "modules" / "operations" / "teams")
+_ensure_package("modules.operations.teams.data", REPO_ROOT / "modules" / "operations" / "teams" / "data")
+_ensure_package("modules.operations.taskings", REPO_ROOT / "modules" / "operations" / "taskings")
+
+_load_module(
+    "modules.operations.data.repository",
+    REPO_ROOT / "modules" / "operations" / "data" / "repository.py",
+)
+team_model_module = _load_module(
+    "modules.operations.teams.data.team",
+    REPO_ROOT / "modules" / "operations" / "teams" / "data" / "team.py",
+)
+team_repository = _load_module(
+    "modules.operations.teams.data.repository",
+    REPO_ROOT / "modules" / "operations" / "teams" / "data" / "repository.py",
+)
+_load_module(
+    "modules.operations.taskings.models",
+    REPO_ROOT / "modules" / "operations" / "taskings" / "models.py",
+)
+task_repository = _load_module(
+    "modules.operations.taskings.repository",
+    REPO_ROOT / "modules" / "operations" / "taskings" / "repository.py",
+)
+Team = team_model_module.Team
+
+
+@pytest.fixture()
+def incident_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    base = tmp_path / "data"
+    incidents_dir = base / "incidents"
+    incidents_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_template = REPO_ROOT / "data" / "incidents" / "template.db"
+    shutil.copy2(repo_template, incidents_dir / "template.db")
+
+    monkeypatch.setenv("CHECKIN_DATA_DIR", str(base))
+    monkeypatch.setattr(incident_context, "_DATA_DIR", base)
+
+    previous_incident = AppState.get_active_incident()
+    AppState.set_active_incident(None)
+    try:
+        yield base
+    finally:
+        AppState.set_active_incident(previous_incident)
+
+
+def _table_names(db_path: Path) -> set[str]:
+    with sqlite3.connect(db_path) as conn:
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )
+        }
+
+
+def test_create_incident_database_initializes_template_schema(incident_data_dir: Path) -> None:
+    db_path = create_incident_database("INC/001")
+
+    assert db_path == incident_data_dir / "incidents" / "INC-001.db"
+    assert db_path.exists()
+    assert db_path.stat().st_size > 0
+
+    tables = _table_names(db_path)
+    assert REQUIRED_TABLES.issubset(tables)
+    assert "notifications" in tables
+
+
+def test_fresh_incident_supports_team_task_and_assignment_creation(incident_data_dir: Path) -> None:
+    incident_number = "INC-OPS-001"
+    db_path = create_incident_database(incident_number)
+    AppState.set_active_incident(incident_number)
+
+    team = team_repository.save_team(Team(name="Alpha", team_type="GT"))
+    assert team.team_id is not None
+
+    task_id = task_repository.create_task(title="Search Sector Alpha")
+    assert task_id > 0
+
+    task_team_id = task_repository.add_task_team(task_id, team.team_id, "S-001", True)
+    assert task_team_id > 0
+
+    with sqlite3.connect(db_path) as conn:
+        team_row = conn.execute(
+            "SELECT id, name, team_type, current_task_id FROM teams WHERE id=?",
+            (team.team_id,),
+        ).fetchone()
+        task_row = conn.execute(
+            "SELECT id, task_id, title, status FROM tasks WHERE id=?",
+            (task_id,),
+        ).fetchone()
+        link_row = conn.execute(
+            "SELECT task_id, teamid, sortie_id, is_primary FROM task_teams WHERE id=?",
+            (task_team_id,),
+        ).fetchone()
+
+    assert team_row == (team.team_id, "Alpha", "GT", task_id)
+    assert task_row[0] == task_id
+    assert task_row[2] == "Search Sector Alpha"
+    assert task_row[3] == "Draft"
+    assert link_row == (task_id, team.team_id, "S-001", 1)

--- a/utils/incident_db.py
+++ b/utils/incident_db.py
@@ -1,9 +1,231 @@
 from __future__ import annotations
 
+import os
+import shutil
+import sqlite3
 from pathlib import Path
 from typing import Optional
 
 _active_incident_id: Optional[str] = None
+
+_REQUIRED_INCIDENT_TABLES = {
+    "agency_contacts",
+    "assignment_air",
+    "assignment_ground",
+    "attachments",
+    "audit_logs",
+    "debriefs",
+    "equipment",
+    "narrative_entries",
+    "operationalperiods",
+    "personnel",
+    "planning_logs",
+    "planning_notes",
+    "task_personnel",
+    "task_teams",
+    "task_vehicles",
+    "tasks",
+    "teams",
+    "vehicles",
+}
+
+
+def _data_dir() -> Path:
+    return Path(os.environ.get("CHECKIN_DATA_DIR", "data"))
+
+
+def _incidents_dir() -> Path:
+    base = _data_dir() / "incidents"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _sanitize_incident_number(incident_number: str) -> str:
+    return str(incident_number).strip().replace("/", "-")
+
+
+def get_incident_database_path(incident_number: str) -> Path:
+    safe_number = _sanitize_incident_number(incident_number)
+    if not safe_number:
+        raise ValueError("Incident number is required to create an incident database.")
+    return _incidents_dir() / f"{safe_number}.db"
+
+
+def get_template_database_path() -> Path:
+    candidates: list[Path] = []
+
+    explicit = os.environ.get("INCIDENT_TEMPLATE_DB")
+    if explicit:
+        candidates.append(Path(explicit))
+
+    data_template = _incidents_dir() / "template.db"
+    candidates.append(data_template)
+
+    repo_template = Path(__file__).resolve().parents[1] / "data" / "incidents" / "template.db"
+    if repo_template not in candidates:
+        candidates.append(repo_template)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    searched = "\n - ".join(str(path) for path in candidates)
+    raise FileNotFoundError(
+        "Incident database template was not found. "
+        "Place template.db in the incident data directory or set INCIDENT_TEMPLATE_DB."
+        f"\nSearched:\n - {searched}"
+    )
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+    ).fetchall()
+    return {str(row[0]) for row in rows}
+
+
+def _ensure_column(conn: sqlite3.Connection, table: str, column: str, decl: str) -> None:
+    cols = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+    if column not in cols:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+
+
+def _ensure_notifications_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts INTEGER,
+            title TEXT,
+            message TEXT,
+            severity TEXT,
+            source TEXT,
+            entity_type TEXT,
+            entity_id TEXT,
+            toast_mode TEXT,
+            toast_duration_ms INTEGER
+        )
+        """
+    )
+    _ensure_column(conn, "notifications", "toast_mode", "TEXT")
+    _ensure_column(conn, "notifications", "toast_duration_ms", "INTEGER")
+
+
+def _ensure_schema_compatibility(conn: sqlite3.Connection) -> None:
+    _ensure_notifications_schema(conn)
+
+    tables = _table_names(conn)
+    if "teams" in tables:
+        team_columns = {
+            "name": "TEXT",
+            "status": "TEXT",
+            "status_updated": "TEXT",
+            "current_task_id": "INTEGER",
+            "needs_attention": "BOOLEAN DEFAULT 0",
+            "callsign": "TEXT",
+            "role": "TEXT",
+            "priority": "INTEGER",
+            "leader_phone": "TEXT",
+            "phone": "TEXT",
+            "notes": "TEXT",
+            "primary_task": "TEXT",
+            "assignment": "TEXT",
+            "last_known_lat": "REAL",
+            "last_known_lon": "REAL",
+            "route": "TEXT",
+            "members_json": "TEXT",
+            "vehicles_json": "TEXT",
+            "equipment_json": "TEXT",
+            "aircraft_json": "TEXT",
+            "comms_preset_id": "INTEGER",
+            "radio_ids": "TEXT",
+            "team_type": "TEXT",
+            "last_comm_ping": "TEXT",
+            "emergency_flag": "BOOLEAN",
+            "last_checkin_at": "TEXT",
+            "checkin_reference_at": "TEXT",
+        }
+        for column, decl in team_columns.items():
+            _ensure_column(conn, "teams", column, decl)
+
+    if "tasks" in tables:
+        task_columns = {
+            "category": "TEXT",
+            "task_type": "TEXT",
+            "assignment": "TEXT",
+            "team_leader": "TEXT",
+            "team_phone": "TEXT",
+        }
+        for column, decl in task_columns.items():
+            _ensure_column(conn, "tasks", column, decl)
+
+    conn.commit()
+
+
+def _validate_initialized_schema(conn: sqlite3.Connection) -> None:
+    missing = sorted(_REQUIRED_INCIDENT_TABLES.difference(_table_names(conn)))
+    if missing:
+        raise RuntimeError(
+            "Incident database initialization failed because required tables are missing: "
+            + ", ".join(missing)
+        )
+
+
+def initialize_incident_database(
+    db_path: Path,
+    *,
+    incident_number: str | None = None,
+    template_path: Path | None = None,
+    exist_ok: bool = False,
+) -> Path:
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if path.exists() and not exist_ok:
+        raise FileExistsError(f"Incident database already exists: {path}")
+
+    if path.exists() and path.stat().st_size == 0:
+        path.unlink()
+
+    template = Path(template_path) if template_path is not None else get_template_database_path()
+    if not template.is_file():
+        raise FileNotFoundError(
+            f"Incident database template was not found: {template}"
+        )
+
+    shutil.copy2(template, path)
+
+    try:
+        with sqlite3.connect(path) as conn:
+            _ensure_schema_compatibility(conn)
+            _validate_initialized_schema(conn)
+    except Exception as exc:
+        try:
+            path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        incident_label = f" for incident '{incident_number}'" if incident_number else ""
+        raise RuntimeError(
+            "Failed to initialize the incident database"
+            f"{incident_label} from template '{template}'."
+        ) from exc
+
+    return path
+
+
+def ensure_incident_database(incident_number: str) -> Path:
+    db_path = get_incident_database_path(incident_number)
+    if not db_path.exists() or db_path.stat().st_size == 0:
+        return initialize_incident_database(
+            db_path,
+            incident_number=incident_number,
+            exist_ok=True,
+        )
+
+    with sqlite3.connect(db_path) as conn:
+        _ensure_schema_compatibility(conn)
+        _validate_initialized_schema(conn)
+    return db_path
 
 
 def set_active_incident_id(value: object | None) -> None:
@@ -27,18 +249,11 @@ def get_active_incident_id() -> Optional[str]:
 
 
 def create_incident_database(incident_number: str) -> Path:
-    """Create an incident database named after the incident number.
+    """Create a fully initialized incident database named after the incident number.
 
-    The file will be created at data/incidents/<incident_number>.db. If a file
-    with that name already exists, a FileExistsError is raised and nothing is
-    modified.
+    The file is created at ``data/incidents/<incident_number>.db``. The schema is
+    initialized by copying the incident template database and applying small
+    compatibility adjustments required by the current application code.
     """
-    base = Path("data") / "incidents"
-    base.mkdir(parents=True, exist_ok=True)
-    # Use the raw number to keep 1:1 mapping; light sanitation for filesystem
-    safe_number = str(incident_number).strip().replace("/", "-")
-    db_path = base / f"{safe_number}.db"
-    if db_path.exists():
-        raise FileExistsError(f"Incident database already exists: {db_path}")
-    db_path.touch()
-    return db_path
+    db_path = get_incident_database_path(incident_number)
+    return initialize_incident_database(db_path, incident_number=incident_number)


### PR DESCRIPTION
### Motivation
- Creating a new incident previously produced a mostly-empty SQLite file (created with `touch()`), so only the notifications table got bootstrapped later and runtime code hit `no such table` errors for `teams`, `tasks`, and other core tables. 
- The intent is to ensure new per-incident DBs have the full schema from the shipped `template.db` so team/task workflows work immediately after incident creation. 
- The fix assumes a canonical template location can be configured with the `INCIDENT_TEMPLATE_DB` environment variable and otherwise falls back to `data/incidents/template.db` (repo default). 

### Description
- Replace blank-file creation with template-based initialization in `utils/incident_db.py`, including: locating the template (env override → `data/incidents/template.db` → repo `data/incidents/template.db`), copying it to the new incident path, validating required core tables, and applying a small compatibility layer for notifications and commonly-expected `teams`/`tasks` columns. 
- Wire other code paths to reuse the new initializer by updating `modules/forms_creator/services/db.py` to call `ensure_incident_database()` instead of creating a raw empty DB. 
- Surface initialization errors to the UI by adding explicit exception handling in `modules/incidents/new_incident_dialog.py` so failures are shown as `Incident Database Error`. 
- Add regression tests `tests/test_incident_db.py` that copy `data/incidents/template.db` into a temporary `data/incidents/` and verify that: a new incident DB is created from the template, core required tables exist, and fresh team creation, task creation, and task->team linking succeed against a freshly-created DB. 
- Files changed: `utils/incident_db.py`, `modules/forms_creator/services/db.py`, `modules/incidents/new_incident_dialog.py`, and new tests `tests/test_incident_db.py`. 

### Testing
- Ran the new incident tests with `pytest -q tests/test_incident_db.py`, which passed (2 passed). 
- Verified module compilation with `python -m compileall utils/incident_db.py modules/incidents/new_incident_dialog.py modules/forms_creator/services/db.py tests/test_incident_db.py`, which succeeded. 
- Attempting to run a broader subset of the GUI test suite in this environment produced import-time failures for PySide6 system libraries (missing `libGL.so.1`), which is an environment/system dependency and unrelated to the changes here; the targeted incident DB tests exercise the new code paths that fix the missing-table runtime failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69be3888c7f8832b8097859cfb9bde3e)