### PR TITLE
Add Logistics Resource Status Board (checked-in resources) with ETA and audit logging

### DIFF
--- a/modules/logistics/__init__.py
+++ b/modules/logistics/__init__.py
@@ -21,6 +21,7 @@ try:  # pragma: no cover - executed only when Qt is available
         get_213rr_panel,
         get_personnel_panel,
         get_vehicles_panel,
+        get_resource_status_board_panel,
     )
 except Exception as exc:  # pragma: no cover - Qt not available
     def _missing(*_: object, __exc: Exception = exc, **__: object) -> None:
@@ -30,6 +31,7 @@ except Exception as exc:  # pragma: no cover - Qt not available
 
     get_logistics_panel = get_checkin_panel = get_equipment_panel = _missing
     get_213rr_panel = get_personnel_panel = get_vehicles_panel = _missing
+    get_resource_status_board_panel = _missing
 
 __all__ = [
     "get_logistics_panel",
@@ -38,4 +40,5 @@ __all__ = [
     "get_213rr_panel",
     "get_personnel_panel",
     "get_vehicles_panel",
+    "get_resource_status_board_panel",
 ]

--- a/modules/logistics/api.py
+++ b/modules/logistics/api.py
@@ -14,6 +14,8 @@ from modules.logistics.models import (
     EquipmentItemRead,
 )
 from .print_ics_213_rr import generate_pdf
+from modules.logistics.resource_status.service import get_service as get_resource_status_service
+from utils import incident_context
 
 router = APIRouter(tags=["logistics"])
 
@@ -76,3 +78,27 @@ def checkin_equipment_endpoint(incident_id: str, equipment_id: int, actor_id: in
 def print_request(incident_id: str, request_id: int):
     path, _bytes = generate_pdf(incident_id, request_id)
     return {"path": path}
+
+
+@router.get("/resource-status")
+def list_resource_status_board(incident_id: str | None = None):
+    if incident_id:
+        incident_context.set_active_incident(incident_id)
+    service = get_resource_status_service()
+    return [item.to_row() for item in service.list_resources()]
+
+
+@router.post("/resource-status")
+def create_resource_status_board_item(data: dict, incident_id: str | None = None):
+    if incident_id:
+        incident_context.set_active_incident(incident_id)
+    service = get_resource_status_service()
+    return service.create_resource(data).to_row()
+
+
+@router.patch("/resource-status/{resource_status_id}")
+def update_resource_status_board_item(resource_status_id: str, data: dict, incident_id: str | None = None):
+    if incident_id:
+        incident_context.set_active_incident(incident_id)
+    service = get_resource_status_service()
+    return service.update_resource(resource_status_id, data).to_row()

--- a/modules/logistics/panels/resource_status_board.py
+++ b/modules/logistics/panels/resource_status_board.py
@@ -1,0 +1,477 @@
+"""Desktop resource status board for the Logistics module."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+from PySide6.QtCore import QAbstractTableModel, QModelIndex, QSortFilterProxyModel, Qt, Signal
+from PySide6.QtGui import QColor, QBrush
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QComboBox,
+    QDateTimeEdit,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTableView,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from styles.styles import subscribe_theme
+
+from modules.logistics.resource_status import RESOURCE_STATUSES, ResourceBoardFilters
+from modules.logistics.resource_status.models import ResourceItem, format_display_datetime, parse_datetime
+from modules.logistics.resource_status.service import ResourceStatusService, get_service
+
+
+STATUS_BRUSHES: dict[str, tuple[str, str]] = {
+    "Pending": ("#fff8e1", "#5d4037"),
+    "Enroute": ("#e3f2fd", "#0d47a1"),
+    "Checked In": ("#e8f5e9", "#1b5e20"),
+    "Assigned": ("#ede7f6", "#4527a0"),
+    "Available": ("#e0f2f1", "#004d40"),
+    "Out of Service": ("#fbe9e7", "#bf360c"),
+    "Demobilized": ("#eceff1", "#37474f"),
+}
+
+
+@dataclass(slots=True)
+class _Column:
+    key: str
+    title: str
+
+
+COLUMNS: tuple[_Column, ...] = (
+    _Column("resource_id", "Resource ID"),
+    _Column("resource_name", "Resource Name"),
+    _Column("resource_type", "Resource Type"),
+    _Column("status", "Status"),
+    _Column("eta_utc", "ETA"),
+    _Column("assigned_to", "Assigned To"),
+    _Column("location", "Location"),
+    _Column("checked_in_time", "Checked-In Time"),
+    _Column("last_updated", "Last Updated"),
+    _Column("notes", "Notes"),
+)
+
+
+class ResourceStatusTableModel(QAbstractTableModel):
+    """Qt table model exposing tracked incident resources."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._items: list[ResourceItem] = []
+
+    def set_items(self, items: list[ResourceItem]) -> None:
+        self.beginResetModel()
+        self._items = list(items)
+        self.endResetModel()
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # noqa: N802
+        if parent.isValid():
+            return 0
+        return len(self._items)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:  # noqa: N802
+        if parent.isValid():
+            return 0
+        return len(COLUMNS)
+
+    def headerData(self, section: int, orientation: Qt.Orientation, role: int = Qt.DisplayRole) -> Any:  # noqa: N802
+        if role != Qt.DisplayRole:
+            return None
+        if orientation == Qt.Horizontal and 0 <= section < len(COLUMNS):
+            return COLUMNS[section].title
+        return super().headerData(section, orientation, role)
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole) -> Any:  # noqa: N802
+        if not index.isValid() or not (0 <= index.row() < len(self._items)):
+            return None
+        item = self._items[index.row()]
+        column = COLUMNS[index.column()].key
+        value = getattr(item, column)
+
+        if role == Qt.DisplayRole:
+            if column in {"eta_utc", "checked_in_time", "last_updated"}:
+                return format_display_datetime(value)
+            return "" if value is None else str(value)
+
+        if role == Qt.ToolTipRole:
+            if column == "eta_utc" and item.eta_overdue:
+                return "ETA is past due while the resource is still pending or enroute."
+            if value is None:
+                return None
+            return str(value)
+
+        if role == Qt.BackgroundRole:
+            bg, _ = STATUS_BRUSHES.get(item.status, ("#ffffff", "#212121"))
+            return QBrush(QColor(bg))
+
+        if role == Qt.ForegroundRole:
+            _, fg = STATUS_BRUSHES.get(item.status, ("#ffffff", "#212121"))
+            return QBrush(QColor(fg))
+
+        if role == Qt.TextAlignmentRole and column in {"eta_utc", "checked_in_time", "last_updated"}:
+            return int(Qt.AlignCenter | Qt.AlignVCenter)
+
+        if role == Qt.UserRole:
+            return item.id
+
+        if role == Qt.UserRole + 1:
+            return item
+
+        if role == Qt.UserRole + 2:
+            return parse_datetime(value).timestamp() if column in {"eta_utc", "checked_in_time", "last_updated"} and parse_datetime(value) else 0
+
+        if role == Qt.UserRole + 3:
+            return item.eta_overdue
+
+        return None
+
+    def item_at(self, row: int) -> Optional[ResourceItem]:
+        if 0 <= row < len(self._items):
+            return self._items[row]
+        return None
+
+
+class ResourceStatusFilterProxyModel(QSortFilterProxyModel):
+    """Combines text and structured filters for the resource board."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._filters = ResourceBoardFilters()
+        self.setDynamicSortFilter(True)
+
+    def set_filters(self, filters: ResourceBoardFilters) -> None:
+        self._filters = filters
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:  # noqa: N802
+        model = self.sourceModel()
+        if model is None:
+            return True
+        item = model.item_at(source_row)
+        if item is None:
+            return False
+
+        if self._filters.status and self._filters.status != "All" and item.status != self._filters.status:
+            return False
+        if self._filters.resource_type and self._filters.resource_type != "All" and item.resource_type != self._filters.resource_type:
+            return False
+        if self._filters.assignment == "Assigned" and not item.assigned_to:
+            return False
+        if self._filters.assignment == "Unassigned" and item.assigned_to:
+            return False
+        if self._filters.eta_presence == "ETA Present" and not item.eta_utc:
+            return False
+        if self._filters.eta_presence == "ETA Missing" and item.eta_utc:
+            return False
+
+        search = (self._filters.text_search or "").strip().lower()
+        if search:
+            haystack = "|".join(
+                filter(
+                    None,
+                    [
+                        item.resource_id,
+                        item.resource_name,
+                        item.resource_type,
+                        item.status,
+                        item.assigned_to,
+                        item.location,
+                        item.notes,
+                    ],
+                )
+            ).lower()
+            if search not in haystack:
+                return False
+        return True
+
+    def lessThan(self, left: QModelIndex, right: QModelIndex) -> bool:  # noqa: N802
+        model = self.sourceModel()
+        if model is None:
+            return False
+        column = COLUMNS[left.column()].key
+        left_item = model.item_at(left.row())
+        right_item = model.item_at(right.row())
+        if left_item is None or right_item is None:
+            return super().lessThan(left, right)
+
+        if column in {"eta_utc", "checked_in_time", "last_updated"}:
+            left_dt = parse_datetime(getattr(left_item, column))
+            right_dt = parse_datetime(getattr(right_item, column))
+            left_key = left_dt.timestamp() if left_dt else float("inf")
+            right_key = right_dt.timestamp() if right_dt else float("inf")
+            return left_key < right_key
+
+        left_value = str(getattr(left_item, column) or "").lower()
+        right_value = str(getattr(right_item, column) or "").lower()
+        return left_value < right_value
+
+
+class ResourceEditDialog(QDialog):
+    """Create/edit workflow for a tracked incident resource."""
+
+    def __init__(self, parent: Optional[QWidget] = None, item: Optional[ResourceItem] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Resource Details")
+        self._item = item
+        self._build_ui()
+        self._load_item(item)
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.resource_id_edit = QLineEdit()
+        self.resource_name_edit = QLineEdit()
+        self.resource_type_edit = QLineEdit()
+        self.status_combo = QComboBox()
+        self.status_combo.addItems(RESOURCE_STATUSES)
+        self.assigned_to_edit = QLineEdit()
+        self.assignment_reference_edit = QLineEdit()
+        self.location_edit = QLineEdit()
+        self.eta_unknown_check = QCheckBox("ETA unknown")
+        self.eta_edit = QDateTimeEdit(self)
+        self.eta_edit.setCalendarPopup(True)
+        self.eta_edit.setDisplayFormat("yyyy-MM-dd HH:mm")
+        self.eta_edit.setDateTime(datetime.now())
+        self.notes_edit = QTextEdit()
+        self.notes_edit.setFixedHeight(90)
+
+        eta_box = QWidget(self)
+        eta_layout = QHBoxLayout(eta_box)
+        eta_layout.setContentsMargins(0, 0, 0, 0)
+        eta_layout.addWidget(self.eta_edit, 1)
+        eta_layout.addWidget(self.eta_unknown_check)
+
+        form.addRow("Resource ID", self.resource_id_edit)
+        form.addRow("Resource Name", self.resource_name_edit)
+        form.addRow("Resource Type", self.resource_type_edit)
+        form.addRow("Status", self.status_combo)
+        form.addRow("ETA", eta_box)
+        form.addRow("Assigned To", self.assigned_to_edit)
+        form.addRow("Assignment Ref", self.assignment_reference_edit)
+        form.addRow("Location", self.location_edit)
+        form.addRow("Notes", self.notes_edit)
+
+        layout.addLayout(form)
+
+        self.eta_unknown_check.toggled.connect(self.eta_edit.setDisabled)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _load_item(self, item: Optional[ResourceItem]) -> None:
+        if item is None:
+            self.eta_unknown_check.setChecked(True)
+            return
+        self.resource_id_edit.setText(item.resource_id)
+        self.resource_name_edit.setText(item.resource_name)
+        self.resource_type_edit.setText(item.resource_type)
+        self.status_combo.setCurrentText(item.status)
+        self.assigned_to_edit.setText(item.assigned_to or "")
+        self.assignment_reference_edit.setText(item.assignment_reference or "")
+        self.location_edit.setText(item.location or "")
+        self.notes_edit.setPlainText(item.notes or "")
+        eta_dt = parse_datetime(item.eta_utc)
+        if eta_dt is None:
+            self.eta_unknown_check.setChecked(True)
+        else:
+            self.eta_unknown_check.setChecked(False)
+            self.eta_edit.setDateTime(eta_dt.replace(tzinfo=None))
+
+    def payload(self) -> dict[str, Any]:
+        eta_value: Optional[str]
+        if self.eta_unknown_check.isChecked():
+            eta_value = None
+        else:
+            eta_value = self.eta_edit.dateTime().toPython().astimezone().isoformat()
+        return {
+            "resource_id": self.resource_id_edit.text().strip(),
+            "resource_name": self.resource_name_edit.text().strip(),
+            "resource_type": self.resource_type_edit.text().strip(),
+            "status": self.status_combo.currentText(),
+            "eta_utc": eta_value,
+            "assigned_to": self.assigned_to_edit.text().strip() or None,
+            "assignment_reference": self.assignment_reference_edit.text().strip() or None,
+            "location": self.location_edit.text().strip() or None,
+            "notes": self.notes_edit.toPlainText().strip() or None,
+        }
+
+
+class ResourceStatusBoard(QWidget):
+    """Filterable and sortable status board for all tracked incident resources."""
+
+    dataChangedForWorkflow = Signal(str)
+
+    def __init__(
+        self,
+        service: Optional[ResourceStatusService] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._service = service or get_service()
+        self._model = ResourceStatusTableModel(self)
+        self._proxy = ResourceStatusFilterProxyModel(self)
+        self._proxy.setSourceModel(self._model)
+
+        self.setWindowTitle("Logistics — Resource Status Board")
+        self._build_ui()
+        self.refresh()
+        try:
+            subscribe_theme(self, lambda *_: self._table.viewport().update())
+        except Exception:
+            pass
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        title = QLabel("Checked-In Resources / Resource Status Board")
+        title.setStyleSheet("font-size: 18px; font-weight: 600;")
+        subtitle = QLabel(
+            "Tracks all resources tied to the active incident, including pending and enroute arrivals."
+        )
+        subtitle.setWordWrap(True)
+        layout.addWidget(title)
+        layout.addWidget(subtitle)
+
+        filters_box = QGroupBox("Filters")
+        filters_layout = QGridLayout(filters_box)
+        self.status_filter = QComboBox()
+        self.status_filter.addItem("All")
+        self.status_filter.addItems(RESOURCE_STATUSES)
+        self.resource_type_filter = QComboBox()
+        self.resource_type_filter.addItem("All")
+        self.assignment_filter = QComboBox()
+        self.assignment_filter.addItems(["All", "Assigned", "Unassigned"])
+        self.eta_filter = QComboBox()
+        self.eta_filter.addItems(["All", "ETA Present", "ETA Missing"])
+        self.search_edit = QLineEdit()
+        self.search_edit.setPlaceholderText("Search resource ID, name, assignment, location, or notes")
+
+        filters_layout.addWidget(QLabel("Status"), 0, 0)
+        filters_layout.addWidget(self.status_filter, 0, 1)
+        filters_layout.addWidget(QLabel("Resource Type"), 0, 2)
+        filters_layout.addWidget(self.resource_type_filter, 0, 3)
+        filters_layout.addWidget(QLabel("Assigned"), 1, 0)
+        filters_layout.addWidget(self.assignment_filter, 1, 1)
+        filters_layout.addWidget(QLabel("ETA"), 1, 2)
+        filters_layout.addWidget(self.eta_filter, 1, 3)
+        filters_layout.addWidget(QLabel("Search"), 2, 0)
+        filters_layout.addWidget(self.search_edit, 2, 1, 1, 3)
+        layout.addWidget(filters_box)
+
+        action_bar = QHBoxLayout()
+        self.add_button = QPushButton("Add Resource")
+        self.edit_button = QPushButton("Edit Selected")
+        self.refresh_button = QPushButton("Refresh")
+        self.audit_label = QLabel("Audit logging enabled for status, ETA, and assignment changes.")
+        action_bar.addWidget(self.add_button)
+        action_bar.addWidget(self.edit_button)
+        action_bar.addWidget(self.refresh_button)
+        action_bar.addStretch(1)
+        action_bar.addWidget(self.audit_label)
+        layout.addLayout(action_bar)
+
+        self._table = QTableView(self)
+        self._table.setModel(self._proxy)
+        self._table.setSortingEnabled(True)
+        self._table.sortByColumn(1, Qt.AscendingOrder)
+        self._table.setAlternatingRowColors(False)
+        self._table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self._table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self._table.doubleClicked.connect(lambda *_: self._edit_selected())
+        header = self._table.horizontalHeader()
+        header.setSectionsClickable(True)
+        header.setSortIndicatorShown(True)
+        header.setStretchLastSection(True)
+        for column in range(len(COLUMNS)):
+            header.setSectionResizeMode(column, QHeaderView.ResizeToContents)
+        layout.addWidget(self._table, 1)
+
+        self.status_filter.currentTextChanged.connect(self._apply_filters)
+        self.resource_type_filter.currentTextChanged.connect(self._apply_filters)
+        self.assignment_filter.currentTextChanged.connect(self._apply_filters)
+        self.eta_filter.currentTextChanged.connect(self._apply_filters)
+        self.search_edit.textChanged.connect(self._apply_filters)
+        self.add_button.clicked.connect(self._add_resource)
+        self.edit_button.clicked.connect(self._edit_selected)
+        self.refresh_button.clicked.connect(self.refresh)
+
+    def refresh(self) -> None:
+        items = self._service.list_resources()
+        self._model.set_items(items)
+        self._refresh_resource_type_filter(items)
+        self._apply_filters()
+        self._table.resizeRowsToContents()
+
+    def _refresh_resource_type_filter(self, items: list[ResourceItem]) -> None:
+        current = self.resource_type_filter.currentText() if hasattr(self, "resource_type_filter") else "All"
+        values = sorted({item.resource_type for item in items if item.resource_type})
+        self.resource_type_filter.blockSignals(True)
+        self.resource_type_filter.clear()
+        self.resource_type_filter.addItem("All")
+        self.resource_type_filter.addItems(values)
+        index = self.resource_type_filter.findText(current)
+        self.resource_type_filter.setCurrentIndex(index if index >= 0 else 0)
+        self.resource_type_filter.blockSignals(False)
+
+    def _apply_filters(self) -> None:
+        self._proxy.set_filters(
+            ResourceBoardFilters(
+                status=self.status_filter.currentText(),
+                resource_type=self.resource_type_filter.currentText(),
+                assignment=self.assignment_filter.currentText(),
+                eta_presence=self.eta_filter.currentText(),
+                text_search=self.search_edit.text(),
+            )
+        )
+
+    def _selected_item(self) -> Optional[ResourceItem]:
+        index = self._table.currentIndex()
+        if not index.isValid():
+            return None
+        source_index = self._proxy.mapToSource(index)
+        return self._model.item_at(source_index.row())
+
+    def _add_resource(self) -> None:
+        dialog = ResourceEditDialog(self)
+        if dialog.exec() != QDialog.Accepted:
+            return
+        try:
+            self._service.create_resource(dialog.payload(), actor_name="Desktop Logistics")
+        except Exception as exc:
+            QMessageBox.critical(self, "Unable to Save Resource", str(exc))
+            return
+        self.refresh()
+
+    def _edit_selected(self) -> None:
+        item = self._selected_item()
+        if item is None:
+            QMessageBox.information(self, "Select a Resource", "Choose a resource row to edit.")
+            return
+        dialog = ResourceEditDialog(self, item=item)
+        if dialog.exec() != QDialog.Accepted:
+            return
+        try:
+            self._service.update_resource(item.id, dialog.payload(), actor_name="Desktop Logistics")
+        except Exception as exc:
+            QMessageBox.critical(self, "Unable to Update Resource", str(exc))
+            return
+        self.refresh()
+        self.dataChangedForWorkflow.emit(item.id)

--- a/modules/logistics/resource_status/__init__.py
+++ b/modules/logistics/resource_status/__init__.py
@@ -1,0 +1,11 @@
+"""Public helpers for the Logistics resource status board."""
+from .models import RESOURCE_STATUSES, ResourceBoardFilters, ResourceItem
+from .service import ResourceStatusService, get_service
+
+__all__ = [
+    "RESOURCE_STATUSES",
+    "ResourceBoardFilters",
+    "ResourceItem",
+    "ResourceStatusService",
+    "get_service",
+]

--- a/modules/logistics/resource_status/models.py
+++ b/modules/logistics/resource_status/models.py
@@ -1,0 +1,193 @@
+"""Domain models for the Logistics resource status board."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+
+RESOURCE_STATUSES: tuple[str, ...] = (
+    "Pending",
+    "Enroute",
+    "Checked In",
+    "Assigned",
+    "Available",
+    "Out of Service",
+    "Demobilized",
+)
+
+PENDING_STATUSES = {"Pending", "Enroute"}
+ACTIVE_STATUSES = {"Checked In", "Assigned", "Available", "Out of Service"}
+CLOSED_STATUSES = {"Demobilized"}
+
+
+@dataclass(slots=True)
+class ResourceItem:
+    """A single tracked incident resource shown on the board."""
+
+    id: str
+    resource_id: str
+    resource_name: str
+    resource_type: str
+    status: str
+    eta_utc: Optional[str] = None
+    assigned_to: Optional[str] = None
+    assignment_reference: Optional[str] = None
+    location: Optional[str] = None
+    checked_in_time: Optional[str] = None
+    last_updated: Optional[str] = None
+    notes: Optional[str] = None
+    source_entity_type: Optional[str] = None
+    source_record_id: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+    def to_row(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "resource_id": self.resource_id,
+            "resource_name": self.resource_name,
+            "resource_type": self.resource_type,
+            "status": self.status,
+            "eta_utc": self.eta_utc,
+            "assigned_to": self.assigned_to,
+            "assignment_reference": self.assignment_reference,
+            "location": self.location,
+            "checked_in_time": self.checked_in_time,
+            "last_updated": self.last_updated,
+            "notes": self.notes,
+            "source_entity_type": self.source_entity_type,
+            "source_record_id": self.source_record_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> "ResourceItem":
+        return cls(
+            id=str(row["id"]),
+            resource_id=str(row.get("resource_id") or ""),
+            resource_name=str(row.get("resource_name") or ""),
+            resource_type=str(row.get("resource_type") or ""),
+            status=normalize_status(str(row.get("status") or "")),
+            eta_utc=_optional_text(row.get("eta_utc")),
+            assigned_to=_optional_text(row.get("assigned_to")),
+            assignment_reference=_optional_text(row.get("assignment_reference")),
+            location=_optional_text(row.get("location")),
+            checked_in_time=_optional_text(row.get("checked_in_time")),
+            last_updated=_optional_text(row.get("last_updated")),
+            notes=_optional_text(row.get("notes")),
+            source_entity_type=_optional_text(row.get("source_entity_type")),
+            source_record_id=_optional_text(row.get("source_record_id")),
+            created_at=_optional_text(row.get("created_at")),
+            updated_at=_optional_text(row.get("updated_at")),
+        )
+
+    @property
+    def eta_overdue(self) -> bool:
+        """Return ``True`` when the resource is overdue and not yet on-scene."""
+
+        if self.status not in PENDING_STATUSES or not self.eta_utc:
+            return False
+        eta_dt = parse_datetime(self.eta_utc)
+        if eta_dt is None:
+            return False
+        return eta_dt < datetime.now().astimezone()
+
+
+@dataclass(slots=True)
+class ResourceAuditEntry:
+    """Audit trail row for resource status changes."""
+
+    id: str
+    resource_status_id: str
+    field_name: str
+    old_value: Optional[str]
+    new_value: Optional[str]
+    actor_name: Optional[str]
+    changed_at: str
+
+    def to_row(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "resource_status_id": self.resource_status_id,
+            "field_name": self.field_name,
+            "old_value": self.old_value,
+            "new_value": self.new_value,
+            "actor_name": self.actor_name,
+            "changed_at": self.changed_at,
+        }
+
+
+@dataclass(slots=True)
+class ResourceBoardFilters:
+    """User-selected filters applied by the resource status table."""
+
+    status: Optional[str] = None
+    resource_type: Optional[str] = None
+    assignment: str = "All"
+    eta_presence: str = "All"
+    text_search: str = ""
+
+
+def normalize_status(value: str) -> str:
+    """Normalize legacy or loose values to the supported board statuses."""
+
+    text = (value or "").strip()
+    if not text:
+        raise ValueError("Resource status is required")
+
+    lowered = text.lower()
+    mapping = {
+        "pending": "Pending",
+        "enroute": "Enroute",
+        "en route": "Enroute",
+        "checked in": "Checked In",
+        "checked_in": "Checked In",
+        "checkedin": "Checked In",
+        "assigned": "Assigned",
+        "available": "Available",
+        "out of service": "Out of Service",
+        "oos": "Out of Service",
+        "demobilized": "Demobilized",
+        "demob": "Demobilized",
+    }
+    normalized = mapping.get(lowered)
+    if normalized is None and text in RESOURCE_STATUSES:
+        normalized = text
+    if normalized is None:
+        raise ValueError(f"Unsupported resource status: {value}")
+    return normalized
+
+
+def parse_datetime(value: Any) -> Optional[datetime]:
+    """Parse an ISO-like timestamp into a timezone-aware datetime when possible."""
+
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.astimezone()
+    text = str(value).strip()
+    if not text:
+        return None
+    cleaned = text.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.astimezone()
+
+
+def format_display_datetime(value: Any) -> str:
+    """Return a user-friendly board timestamp string."""
+
+    dt = parse_datetime(value)
+    if dt is None:
+        return ""
+    return dt.astimezone().strftime("%Y-%m-%d %H:%M")
+
+
+def _optional_text(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    return str(value)

--- a/modules/logistics/resource_status/repository.py
+++ b/modules/logistics/resource_status/repository.py
@@ -1,0 +1,214 @@
+"""SQLite repository for the Logistics resource status board."""
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import datetime
+from typing import Any, Iterable, Optional
+
+from utils.db import get_incident_conn
+
+from .models import ResourceAuditEntry, ResourceItem
+
+RESOURCE_STATUS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS logistics_resource_status_items (
+    id TEXT PRIMARY KEY,
+    resource_id TEXT NOT NULL,
+    resource_name TEXT NOT NULL,
+    resource_type TEXT NOT NULL,
+    status TEXT NOT NULL,
+    eta_utc TEXT,
+    assigned_to TEXT,
+    assignment_reference TEXT,
+    location TEXT,
+    checked_in_time TEXT,
+    last_updated TEXT NOT NULL,
+    notes TEXT,
+    source_entity_type TEXT,
+    source_record_id TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_resource_status_status
+    ON logistics_resource_status_items(status);
+CREATE INDEX IF NOT EXISTS idx_resource_status_type
+    ON logistics_resource_status_items(resource_type);
+CREATE INDEX IF NOT EXISTS idx_resource_status_source
+    ON logistics_resource_status_items(source_entity_type, source_record_id);
+
+CREATE TABLE IF NOT EXISTS logistics_resource_status_audit (
+    id TEXT PRIMARY KEY,
+    resource_status_id TEXT NOT NULL,
+    field_name TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    actor_name TEXT,
+    changed_at TEXT NOT NULL,
+    FOREIGN KEY(resource_status_id) REFERENCES logistics_resource_status_items(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_resource_status_audit_resource
+    ON logistics_resource_status_audit(resource_status_id, changed_at DESC);
+"""
+
+
+class ResourceStatusRepository:
+    """Persist and query resource status board rows in the active incident DB."""
+
+    def ensure_schema(self, conn: Optional[sqlite3.Connection] = None) -> None:
+        if conn is None:
+            with get_incident_conn() as managed:
+                managed.executescript(RESOURCE_STATUS_SCHEMA)
+                managed.commit()
+            return
+        conn.executescript(RESOURCE_STATUS_SCHEMA)
+
+    def list_resources(self) -> list[ResourceItem]:
+        with get_incident_conn() as conn:
+            self.ensure_schema(conn)
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM logistics_resource_status_items
+                ORDER BY resource_type COLLATE NOCASE, resource_name COLLATE NOCASE, resource_id COLLATE NOCASE
+                """
+            ).fetchall()
+        return [ResourceItem.from_row(dict(row)) for row in rows]
+
+    def get_resource(self, resource_status_id: str) -> Optional[ResourceItem]:
+        with get_incident_conn() as conn:
+            self.ensure_schema(conn)
+            row = conn.execute(
+                "SELECT * FROM logistics_resource_status_items WHERE id = ?",
+                (resource_status_id,),
+            ).fetchone()
+        return ResourceItem.from_row(dict(row)) if row else None
+
+    def get_by_source(self, source_entity_type: str, source_record_id: str) -> Optional[ResourceItem]:
+        with get_incident_conn() as conn:
+            self.ensure_schema(conn)
+            row = conn.execute(
+                """
+                SELECT *
+                FROM logistics_resource_status_items
+                WHERE source_entity_type = ? AND source_record_id = ?
+                """,
+                (source_entity_type, source_record_id),
+            ).fetchone()
+        return ResourceItem.from_row(dict(row)) if row else None
+
+    def save_resource(self, item: ResourceItem) -> ResourceItem:
+        payload = item.to_row()
+        with get_incident_conn() as conn:
+            self.ensure_schema(conn)
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO logistics_resource_status_items (
+                    id, resource_id, resource_name, resource_type, status, eta_utc,
+                    assigned_to, assignment_reference, location, checked_in_time,
+                    last_updated, notes, source_entity_type, source_record_id,
+                    created_at, updated_at
+                ) VALUES (
+                    :id, :resource_id, :resource_name, :resource_type, :status, :eta_utc,
+                    :assigned_to, :assignment_reference, :location, :checked_in_time,
+                    :last_updated, :notes, :source_entity_type, :source_record_id,
+                    :created_at, :updated_at
+                )
+                """,
+                payload,
+            )
+            conn.commit()
+        return item
+
+    def save_audit_entries(self, entries: Iterable[ResourceAuditEntry]) -> None:
+        entries = list(entries)
+        if not entries:
+            return
+        with get_incident_conn() as conn:
+            self.ensure_schema(conn)
+            conn.executemany(
+                """
+                INSERT INTO logistics_resource_status_audit (
+                    id, resource_status_id, field_name, old_value, new_value,
+                    actor_name, changed_at
+                ) VALUES (
+                    :id, :resource_status_id, :field_name, :old_value, :new_value,
+                    :actor_name, :changed_at
+                )
+                """,
+                [entry.to_row() for entry in entries],
+            )
+            conn.commit()
+
+    def list_audit_entries(self, resource_status_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        with get_incident_conn() as conn:
+            self.ensure_schema(conn)
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM logistics_resource_status_audit
+                WHERE resource_status_id = ?
+                ORDER BY changed_at DESC
+                LIMIT ?
+                """,
+                (resource_status_id, int(limit)),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def source_rows(self) -> list[dict[str, Any]]:
+        """Collect incident-scoped resources that can seed the status board."""
+
+        with get_incident_conn() as conn:
+            self.ensure_schema(conn)
+            sources: list[dict[str, Any]] = []
+            sources.extend(self._collect_table_rows(conn, "personnel", "personnel"))
+            sources.extend(self._collect_table_rows(conn, "vehicles", "vehicle"))
+            sources.extend(self._collect_table_rows(conn, "equipment", "equipment"))
+            sources.extend(self._collect_table_rows(conn, "aircraft", "aircraft"))
+            return sources
+
+    def _collect_table_rows(
+        self,
+        conn: sqlite3.Connection,
+        table_name: str,
+        entity_type: str,
+    ) -> list[dict[str, Any]]:
+        try:
+            info = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        except sqlite3.OperationalError:
+            return []
+        if not info:
+            return []
+
+        columns = [row[1] for row in info]
+        identifier = self._pick_column(columns, "id", "person_id", "tail_number", "serial_number")
+        if identifier is None:
+            return []
+        rows = conn.execute(f"SELECT * FROM {table_name}").fetchall()
+        return [
+            {
+                "entity_type": entity_type,
+                "table_name": table_name,
+                "identifier_column": identifier,
+                "record": dict(row),
+            }
+            for row in rows
+        ]
+
+    @staticmethod
+    def _pick_column(columns: list[str], *candidates: str) -> Optional[str]:
+        lowered = {name.lower(): name for name in columns}
+        for candidate in candidates:
+            match = lowered.get(candidate.lower())
+            if match:
+                return match
+        return columns[0] if columns else None
+
+
+def new_identifier() -> str:
+    return uuid.uuid4().hex
+
+
+def now_local_iso() -> str:
+    return datetime.now().astimezone().isoformat()

--- a/modules/logistics/resource_status/service.py
+++ b/modules/logistics/resource_status/service.py
@@ -1,0 +1,309 @@
+"""Service layer for the Logistics resource status board."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from utils.audit import write_audit
+from utils import incident_context
+from utils.state import AppState
+
+from .models import (
+    PENDING_STATUSES,
+    ResourceAuditEntry,
+    ResourceItem,
+    normalize_status,
+)
+from .repository import ResourceStatusRepository, new_identifier, now_local_iso
+
+
+class ResourceStatusService:
+    """Coordinates board reads, writes, source syncing, and audit logging."""
+
+    def __init__(self, repository: ResourceStatusRepository | None = None) -> None:
+        self.repository = repository or ResourceStatusRepository()
+
+    def list_resources(self) -> list[ResourceItem]:
+        self._ensure_active_incident_state()
+        self.sync_from_incident_sources()
+        return self.repository.list_resources()
+
+    def get_resource(self, resource_status_id: str) -> Optional[ResourceItem]:
+        return self.repository.get_resource(resource_status_id)
+
+    def list_audit_entries(self, resource_status_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        return self.repository.list_audit_entries(resource_status_id, limit=limit)
+
+    def create_resource(self, payload: dict[str, Any], actor_name: Optional[str] = None) -> ResourceItem:
+        self._ensure_active_incident_state()
+        now = now_local_iso()
+        item = ResourceItem(
+            id=new_identifier(),
+            resource_id=str(payload.get("resource_id") or "").strip(),
+            resource_name=str(payload.get("resource_name") or "").strip(),
+            resource_type=str(payload.get("resource_type") or "").strip(),
+            status=normalize_status(str(payload.get("status") or "Pending")),
+            eta_utc=self._normalize_optional_text(payload.get("eta_utc")),
+            assigned_to=self._normalize_optional_text(payload.get("assigned_to")),
+            assignment_reference=self._normalize_optional_text(payload.get("assignment_reference")),
+            location=self._normalize_optional_text(payload.get("location")),
+            checked_in_time=self._normalize_optional_text(payload.get("checked_in_time")),
+            last_updated=now,
+            notes=self._normalize_optional_text(payload.get("notes")),
+            source_entity_type=self._normalize_optional_text(payload.get("source_entity_type")),
+            source_record_id=self._normalize_optional_text(payload.get("source_record_id")),
+            created_at=now,
+            updated_at=now,
+        )
+        self._validate_item(item)
+        self.repository.save_resource(item)
+        self._write_audit(item, {}, item.to_row(), actor_name=actor_name, action="logistics.resource_status.create")
+        return item
+
+    def update_resource(
+        self,
+        resource_status_id: str,
+        patch: dict[str, Any],
+        actor_name: Optional[str] = None,
+    ) -> ResourceItem:
+        self._ensure_active_incident_state()
+        current = self.repository.get_resource(resource_status_id)
+        if current is None:
+            raise ValueError(f"Unknown tracked resource: {resource_status_id}")
+
+        next_item = ResourceItem(**current.to_row())
+        for key in (
+            "resource_id",
+            "resource_name",
+            "resource_type",
+            "assigned_to",
+            "assignment_reference",
+            "location",
+            "checked_in_time",
+            "notes",
+        ):
+            if key in patch:
+                setattr(next_item, key, self._normalize_optional_text(patch.get(key)))
+
+        if "status" in patch:
+            next_item.status = normalize_status(str(patch.get("status") or ""))
+        if "eta_utc" in patch:
+            next_item.eta_utc = self._normalize_optional_text(patch.get("eta_utc"))
+
+        if next_item.status == "Checked In" and not next_item.checked_in_time:
+            next_item.checked_in_time = now_local_iso()
+        next_item.last_updated = now_local_iso()
+        next_item.updated_at = next_item.last_updated
+
+        self._validate_item(next_item)
+        before = current.to_row()
+        after = next_item.to_row()
+        self.repository.save_resource(next_item)
+        self._write_audit(
+            next_item,
+            before,
+            after,
+            actor_name=actor_name,
+            action="logistics.resource_status.update",
+        )
+        return next_item
+
+    def sync_from_incident_sources(self) -> int:
+        """Create board rows for incident resources that are not tracked yet."""
+
+        self._ensure_active_incident_state()
+        created = 0
+        for source in self.repository.source_rows():
+            entity_type = str(source.get("entity_type") or "resource")
+            record = dict(source.get("record") or {})
+            identifier_column = str(source.get("identifier_column") or "id")
+            source_record_id = record.get(identifier_column)
+            if source_record_id in (None, ""):
+                continue
+            if self.repository.get_by_source(entity_type, str(source_record_id)) is not None:
+                continue
+            resource_payload = self._resource_payload_from_source(entity_type, record, source_record_id)
+            self.create_resource(resource_payload, actor_name="System Sync")
+            created += 1
+        return created
+
+
+    def _ensure_active_incident_state(self) -> None:
+        incident_id = incident_context.get_active_incident_id()
+        if incident_id and AppState.get_active_incident() != incident_id:
+            AppState.set_active_incident(incident_id)
+
+    def _resource_payload_from_source(
+        self,
+        entity_type: str,
+        record: dict[str, Any],
+        source_record_id: Any,
+    ) -> dict[str, Any]:
+        resource_type = {
+            "personnel": "Personnel",
+            "vehicle": "Vehicle",
+            "equipment": "Equipment",
+            "aircraft": "Aircraft",
+        }.get(entity_type, entity_type.title())
+        return {
+            "resource_id": str(source_record_id),
+            "resource_name": self._name_from_source(entity_type, record, source_record_id),
+            "resource_type": resource_type,
+            "status": self._status_from_source(entity_type, record),
+            "assigned_to": self._assignment_from_source(entity_type, record),
+            "location": self._location_from_source(record),
+            "checked_in_time": self._first_value(record, "created_at", "updated_at"),
+            "notes": self._first_value(record, "notes", "condition", "capabilities"),
+            "source_entity_type": entity_type,
+            "source_record_id": str(source_record_id),
+        }
+
+    def _validate_item(self, item: ResourceItem) -> None:
+        if not item.resource_id:
+            raise ValueError("Resource ID is required")
+        if not item.resource_name:
+            raise ValueError("Resource Name is required")
+        if not item.resource_type:
+            raise ValueError("Resource Type is required")
+        if item.status in PENDING_STATUSES:
+            # ETA is optional, but the data model must always include a place to store it.
+            item.eta_utc = self._normalize_optional_text(item.eta_utc)
+
+    def _write_audit(
+        self,
+        item: ResourceItem,
+        before: dict[str, Any],
+        after: dict[str, Any],
+        *,
+        actor_name: Optional[str],
+        action: str,
+    ) -> None:
+        changes = self._diff(before, after)
+        if not changes:
+            return
+        changed_at = now_local_iso()
+        entries: list[ResourceAuditEntry] = []
+        for field_name, change in changes.items():
+            entries.append(
+                ResourceAuditEntry(
+                    id=new_identifier(),
+                    resource_status_id=item.id,
+                    field_name=field_name,
+                    old_value=change.get("old"),
+                    new_value=change.get("new"),
+                    actor_name=actor_name,
+                    changed_at=changed_at,
+                )
+            )
+        self.repository.save_audit_entries(entries)
+        write_audit(
+            action,
+            {
+                "resource_status_id": item.id,
+                "resource_id": item.resource_id,
+                "resource_name": item.resource_name,
+                "changes": changes,
+            },
+        )
+
+    def _diff(self, before: dict[str, Any], after: dict[str, Any]) -> dict[str, dict[str, Optional[str]]]:
+        changes: dict[str, dict[str, Optional[str]]] = {}
+        for field_name, new_value in after.items():
+            old_value = before.get(field_name)
+            if self._normalize_optional_text(old_value) != self._normalize_optional_text(new_value):
+                changes[field_name] = {
+                    "old": self._normalize_optional_text(old_value),
+                    "new": self._normalize_optional_text(new_value),
+                }
+        return changes
+
+    def _status_from_source(self, entity_type: str, record: dict[str, Any]) -> str:
+        raw_status = str(
+            self._first_value(record, "status", "status_id", "ci_status", "personnel_status") or ""
+        ).strip()
+        if not raw_status:
+            if entity_type == "personnel" and record.get("team_id"):
+                return "Assigned"
+            return "Checked In"
+
+        lowered = raw_status.lower()
+        if lowered in {"pending", "enroute", "en route"}:
+            return normalize_status(raw_status)
+        if lowered in {"checkedin", "checked in", "aticp"}:
+            return "Checked In"
+        if lowered in {"assigned", "deployed", "checked_out"}:
+            return "Assigned"
+        if lowered in {"available", "ready", "in service"}:
+            return "Available"
+        if lowered in {"out of service", "maintenance", "unavailable", "offduty", "off duty"}:
+            return "Out of Service"
+        if lowered in {"demobilized", "retired", "released", "noshow", "no show"}:
+            return "Demobilized"
+        return "Checked In"
+
+    def _name_from_source(self, entity_type: str, record: dict[str, Any], source_record_id: Any) -> str:
+        if entity_type == "personnel":
+            return str(self._first_value(record, "name", "callsign", "id") or source_record_id)
+        if entity_type == "vehicle":
+            return str(
+                self._first_value(
+                    record,
+                    "callsign",
+                    "license_plate",
+                    "id",
+                )
+                or self._join_values(record.get("year"), record.get("make"), record.get("model"))
+                or source_record_id
+            )
+        if entity_type == "equipment":
+            return str(self._first_value(record, "name", "serial_number", "id") or source_record_id)
+        if entity_type == "aircraft":
+            return str(self._first_value(record, "callsign", "tail_number", "id") or source_record_id)
+        return str(source_record_id)
+
+    def _assignment_from_source(self, entity_type: str, record: dict[str, Any]) -> Optional[str]:
+        if entity_type == "personnel":
+            return self._normalize_optional_text(self._first_value(record, "team_id", "role_on_team"))
+        if entity_type in {"vehicle", "aircraft"}:
+            return self._normalize_optional_text(self._first_value(record, "current_assignment", "team_id"))
+        if entity_type == "equipment" and record.get("current_holder_id"):
+            return f"Holder {record['current_holder_id']}"
+        return None
+
+    def _location_from_source(self, record: dict[str, Any]) -> Optional[str]:
+        return self._normalize_optional_text(self._first_value(record, "location", "base_location", "home_unit"))
+
+    @staticmethod
+    def _first_value(record: dict[str, Any], *keys: str) -> Any:
+        for key in keys:
+            value = record.get(key)
+            if value not in (None, ""):
+                return value
+        return None
+
+    @staticmethod
+    def _join_values(*values: Any) -> Optional[str]:
+        parts = [str(value).strip() for value in values if value not in (None, "") and str(value).strip()]
+        return " ".join(parts) if parts else None
+
+    @staticmethod
+    def _normalize_optional_text(value: Any) -> Optional[str]:
+        if value in (None, ""):
+            return None
+        text = str(value).strip()
+        return text or None
+
+
+_SERVICE: ResourceStatusService | None = None
+
+
+def get_service() -> ResourceStatusService:
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = ResourceStatusService()
+    return _SERVICE
+
+
+__all__ = [
+    "ResourceStatusService",
+    "get_service",
+]

--- a/modules/logistics/tests/test_resource_status_service.py
+++ b/modules/logistics/tests/test_resource_status_service.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils import incident_context
+
+from modules.logistics.resource_status.repository import ResourceStatusRepository
+from modules.logistics.resource_status.service import ResourceStatusService
+
+
+def _setup_incident(tmp_path: Path, incident_id: str = "resource-status-test") -> Path:
+    data_dir = tmp_path / "data"
+    incident_context._DATA_DIR = data_dir  # type: ignore[attr-defined]
+    incident_context.set_active_incident(incident_id)
+    return data_dir / "incidents" / f"{incident_id}.db"
+
+
+def test_create_and_update_resource_logs_audit(tmp_path: Path) -> None:
+    db_path = _setup_incident(tmp_path)
+    service = ResourceStatusService(ResourceStatusRepository())
+
+    created = service.create_resource(
+        {
+            "resource_id": "ENG-12",
+            "resource_name": "Engine 12",
+            "resource_type": "Vehicle",
+            "status": "Pending",
+            "eta_utc": "2026-03-22T12:30:00+00:00",
+            "notes": "Incoming support",
+        },
+        actor_name="pytest",
+    )
+    updated = service.update_resource(
+        created.id,
+        {
+            "status": "Enroute",
+            "eta_utc": "2026-03-22T13:00:00+00:00",
+            "assigned_to": "Staging",
+        },
+        actor_name="pytest",
+    )
+
+    assert created.resource_id == "ENG-12"
+    assert updated.status == "Enroute"
+    audit_entries = service.list_audit_entries(created.id)
+    fields = {entry["field_name"] for entry in audit_entries}
+    assert {"status", "eta_utc", "assigned_to"}.issubset(fields)
+    assert db_path.exists()
+
+
+def test_sync_from_incident_sources_seeds_board_without_duplicates(tmp_path: Path) -> None:
+    _setup_incident(tmp_path, incident_id="resource-sync")
+    repo = ResourceStatusRepository()
+    service = ResourceStatusService(repo)
+
+    with incident_context.get_active_incident_db_path().open("a", encoding="utf-8"):
+        pass
+    import sqlite3
+
+    conn = sqlite3.connect(incident_context.get_active_incident_db_path())
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS equipment (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            type TEXT,
+            status TEXT,
+            location TEXT,
+            notes TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO equipment (id, name, type, status, location, notes) VALUES (?, ?, ?, ?, ?, ?)",
+        (7, "Cache Trailer", "Trailer", "available", "Base", "Ready"),
+    )
+    conn.commit()
+    conn.close()
+
+    created_first = service.sync_from_incident_sources()
+    created_second = service.sync_from_incident_sources()
+    items = service.list_resources()
+
+    assert created_first == 1
+    assert created_second == 0
+    assert len(items) == 1
+    assert items[0].resource_name == "Cache Trailer"
+    assert items[0].status == "Available"

--- a/modules/logistics/windows.py
+++ b/modules/logistics/windows.py
@@ -6,10 +6,12 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QSplitter,
     QMessageBox,
+    QTabWidget,
 )
 from utils import incident_context
 
 from modules.logistics.vehicle.panels.vehicle_inventory_panel import VehicleInventoryPanel
+from modules.logistics.panels.resource_status_board import ResourceStatusBoard
 
 __all__ = [
     "get_logistics_panel",
@@ -19,6 +21,7 @@ __all__ = [
     "get_213rr_panel",
     "get_personnel_panel",
     "get_vehicles_panel",
+    "get_resource_status_board_panel",
 ]
 
 
@@ -47,10 +50,15 @@ def _get_home_panel():
 
 
 def get_logistics_panel(incident_id: object | None = None) -> QWidget:
-    """Return the main Logistics dashboard panel (Qt Widgets)."""
+    """Return the main Logistics workspace with dashboard and status board tabs."""
+    if incident_id is not None:
+        incident_context.set_active_incident(str(incident_id))
+
     HomePanel = _get_home_panel()
-    # New dashboard does not require incident_id on init; controllers handle context
-    return HomePanel()
+    container = QTabWidget()
+    container.addTab(HomePanel(), "Dashboard")
+    container.addTab(ResourceStatusBoard(), "Checked-In Resources")
+    return container
 
 
 def get_checkin_panel(incident_id: object | None = None) -> QWidget:
@@ -138,5 +146,10 @@ def get_vehicles_panel(incident_id: object | None = None) -> QWidget:
     return VehicleInventoryPanel()
 
 
-    return VehicleInventoryWidget()
+def get_resource_status_board_panel(incident_id: object | None = None) -> QWidget:
+    """Return the Logistics resource status board panel."""
+
+    if incident_id is not None:
+        incident_context.set_active_incident(str(incident_id))
+    return ResourceStatusBoard()
 


### PR DESCRIPTION
### Motivation
- Provide Logistics with a desktop "Resource Status Board" that shows all resources tied to the active incident, including pre-arrival visibility for `Pending` and `Enroute` resources and an editable ETA field. 
- Integrate the board into the existing Logistics UI, data, and audit patterns so the view reads/writes the active incident database and uses existing row-color/status style conventions. 
- Ensure status/assignment/ETA changes are persisted and captured in incident-scoped audit logs for later history and ICS/assignment integration.

### Description
- Added a new incident-scoped resource status feature under `modules/logistics/resource_status` including domain models (`models.py`), SQLite repository/schema (`repository.py`), and a service layer (`service.py`) that validates statuses, syncs incident source tables, and writes audit entries. 
- Implemented a desktop Qt table panel `ResourceStatusBoard` with `QAbstractTableModel` + `QSortFilterProxyModel` in `modules/logistics/panels/resource_status_board.py` supporting the required columns, sorting (including ETA), filters (status, resource type, assigned/unassigned, ETA present/missing, text search), row color mapping, and an edit dialog that can create/update resource rows and ETA (supports unknown/blank ETA). 
- Wired the board into the Logistics module by exposing a panel factory (`get_resource_status_board_panel`), adding a tab to the main Logistics workspace, and adding FastAPI endpoints for listing/creating/updating board rows that set active incident context when supplied. 
- Persisted per-field audit entries in the incident DB (`logistics_resource_status_audit`) and produced higher-level audit records via the existing `utils.audit.write_audit` helper on status/assignment/ETA changes. 
- Added minimal seeding logic that harvests existing incident tables (`personnel`, `vehicles`, `equipment`, `aircraft`) to create board rows without duplicates, and left ETA preservation behavior (ETA kept as historical data) to support future history features. 
- New unit tests under `modules/logistics/tests/test_resource_status_service.py` exercise create/update auditing and the seed-from-incident-source behavior.

### Testing
- Ran static compilation with `python -m compileall modules/logistics/resource_status modules/logistics/panels/resource_status_board.py modules/logistics/windows.py modules/logistics/api.py modules/logistics/tests/test_resource_status_service.py`, which succeeded. 
- Executed the new unit tests with `pytest modules/logistics/tests/test_resource_status_service.py`, and all tests passed. 
- The board uses the existing incident DB helpers and the project’s `utils.audit` integration so audited changes appear in the incident audit store.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c0503ebc28832bbb85186de22dc0f1)