### PR TITLE
MVP LAN host/client sync: FastAPI host, Qt client, WebSocket events

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,0 +1,3 @@
+from .lan_client_connector import LanClientConnector
+
+__all__ = ["LanClientConnector"]

--- a/client/lan_client_connector.py
+++ b/client/lan_client_connector.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from PySide6.QtCore import QObject, QSettings, QTimer, Signal
+from PySide6.QtNetwork import QAbstractSocket
+from PySide6.QtWebSockets import QWebSocket
+
+from shared.lan_config import (
+    DEFAULT_LAN_CLIENT_TIMEOUT_S,
+    DEFAULT_LAN_HOST,
+    DEFAULT_LAN_PORT,
+    SETTINGS_GROUP,
+    SETTINGS_HOST_KEY,
+    SETTINGS_PORT_KEY,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LanClientConnector(QObject):
+    connectionStateChanged = Signal(str, str)
+    bootstrapReceived = Signal(dict)
+    eventReceived = Signal(dict)
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._host = DEFAULT_LAN_HOST
+        self._port = DEFAULT_LAN_PORT
+        self._state = "disconnected"
+        self._ws: QWebSocket | None = None
+        self._reconnect_timer = QTimer(self)
+        self._reconnect_timer.setInterval(3000)
+        self._reconnect_timer.timeout.connect(self._try_reconnect)
+        self._last_error = ""
+        self._load_last_target()
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    @property
+    def port(self) -> int:
+        return int(self._port)
+
+    @property
+    def connected(self) -> bool:
+        return self._state == "connected"
+
+    def _set_state(self, state: str, detail: str = "") -> None:
+        self._state = state
+        self._last_error = detail
+        self.connectionStateChanged.emit(state, detail)
+
+    def _load_last_target(self) -> None:
+        s = QSettings()
+        s.beginGroup(SETTINGS_GROUP)
+        self._host = str(s.value(SETTINGS_HOST_KEY, DEFAULT_LAN_HOST))
+        self._port = int(s.value(SETTINGS_PORT_KEY, DEFAULT_LAN_PORT))
+        s.endGroup()
+
+    def _save_last_target(self) -> None:
+        s = QSettings()
+        s.beginGroup(SETTINGS_GROUP)
+        s.setValue(SETTINGS_HOST_KEY, self._host)
+        s.setValue(SETTINGS_PORT_KEY, int(self._port))
+        s.endGroup()
+
+    def connect_to_host(self, host: str, port: int) -> tuple[bool, str]:
+        self._host = str(host).strip()
+        self._port = int(port)
+        self._save_last_target()
+        self._set_state("reconnecting", "Connecting to host...")
+        ok, msg = self.refresh_from_host()
+        if not ok:
+            self._set_state("disconnected", msg)
+            return False, msg
+        self._start_websocket()
+        return True, "Connected to host."
+
+    def disconnect(self) -> None:
+        self._reconnect_timer.stop()
+        if self._ws is not None:
+            try:
+                self._ws.abort()
+                self._ws.deleteLater()
+            except Exception:
+                pass
+            self._ws = None
+        self._set_state("disconnected", "Disconnected")
+
+    def refresh_from_host(self) -> tuple[bool, str]:
+        try:
+            with httpx.Client(timeout=DEFAULT_LAN_CLIENT_TIMEOUT_S) as client:
+                session = client.get(f"http://{self._host}:{self._port}/lan/session")
+                session.raise_for_status()
+                payload = session.json()
+                if not bool(payload.get("hosting")):
+                    return False, "Host is not currently hosting."
+                snap = client.get(f"http://{self._host}:{self._port}/lan/bootstrap")
+                snap.raise_for_status()
+                snapshot = snap.json()
+                self.bootstrapReceived.emit(snapshot)
+                return True, "Bootstrap synced."
+        except Exception as exc:
+            logger.warning("LAN refresh failed: %s", exc)
+            return False, f"Connection failed: {exc}"
+
+    def post(self, path: str, payload: dict[str, Any]) -> tuple[bool, dict[str, Any] | str]:
+        try:
+            with httpx.Client(timeout=DEFAULT_LAN_CLIENT_TIMEOUT_S) as client:
+                res = client.post(f"http://{self._host}:{self._port}{path}", json=payload)
+                res.raise_for_status()
+                return True, res.json()
+        except Exception as exc:
+            return False, str(exc)
+
+    def update_team(self, *, team_id: int, status: str) -> tuple[bool, str]:
+        ok, res = self.post("/lan/team/update", {"team_id": int(team_id), "status": str(status), "status_only": True})
+        return ok, "ok" if ok else str(res)
+
+    def update_task(self, *, task_id: int, status: str) -> tuple[bool, str]:
+        ok, res = self.post("/lan/task/update", {"task_id": int(task_id), "status": str(status), "status_only": True})
+        return ok, "ok" if ok else str(res)
+
+    def create_comms(self, payload: dict[str, Any]) -> tuple[bool, dict[str, Any] | str]:
+        return self.post("/lan/comms/create", payload)
+
+    def create_alert(self, payload: dict[str, Any]) -> tuple[bool, dict[str, Any] | str]:
+        return self.post("/lan/alert/create", payload)
+
+    def _start_websocket(self) -> None:
+        if self._ws is not None:
+            try:
+                self._ws.abort()
+                self._ws.deleteLater()
+            except Exception:
+                pass
+        self._ws = QWebSocket()
+        self._ws.connected.connect(self._on_ws_connected)
+        self._ws.disconnected.connect(self._on_ws_disconnected)
+        self._ws.textMessageReceived.connect(self._on_ws_message)
+        self._ws.errorOccurred.connect(self._on_ws_error)
+        self._ws.open(f"ws://{self._host}:{self._port}/lan/ws")
+
+    def _on_ws_connected(self) -> None:
+        self._set_state("connected", f"Connected to {self._host}:{self._port}")
+        self._reconnect_timer.stop()
+
+    def _on_ws_disconnected(self) -> None:
+        if self._state == "disconnected":
+            return
+        self._set_state("reconnecting", "Connection lost. Reconnecting...")
+        if not self._reconnect_timer.isActive():
+            self._reconnect_timer.start()
+
+    def _on_ws_error(self, _err: QAbstractSocket.SocketError) -> None:
+        if self._ws is None:
+            return
+        self._set_state("reconnecting", self._ws.errorString())
+        if not self._reconnect_timer.isActive():
+            self._reconnect_timer.start()
+
+    def _try_reconnect(self) -> None:
+        ok, msg = self.refresh_from_host()
+        if not ok:
+            self._set_state("reconnecting", msg)
+            return
+        self._start_websocket()
+
+    def _on_ws_message(self, text: str) -> None:
+        import json
+
+        try:
+            payload = json.loads(text)
+            if isinstance(payload, dict):
+                self.eventReceived.emit(payload)
+        except Exception:
+            logger.debug("Ignoring malformed WS event payload")
+
+
+__all__ = ["LanClientConnector"]

--- a/main.py
+++ b/main.py
@@ -356,6 +356,7 @@ class MainWindow(QMainWindow):
             pass
 
         self._init_notifications()
+        self._init_lan_sync()
 
     # ----- Part 2.A: Physical Menu Builder ----------------------------------
     def _add_action(self, menu: QMenu, text: str, keyseq: str | None, module_key: str):
@@ -631,6 +632,10 @@ class MainWindow(QMainWindow):
         self._add_action(m_comms, "Messaging", None, "comms.chat")
         self._add_action(m_comms, "ICS 213 Messages", None, "comms.213")
 
+        # ----- LAN Sync -----
+        m_lan = mb.addMenu("LAN")
+        self._add_action(m_lan, "Client Connection", None, "lan.client")
+        self._add_action(m_lan, "Host Status", None, "lan.host")
 
         # ----- Intel -----
         m_intel = mb.addMenu("Intel")
@@ -940,6 +945,10 @@ class MainWindow(QMainWindow):
             "comms.chat": self.open_comms_chat,
             "comms.213": self.open_comms_213,
             "comms.205": self.open_comms_205,
+
+            # ----- LAN -----
+            "lan.client": self.open_lan_client_connection,
+            "lan.host": self.open_lan_host_status,
 
             # ----- Intel -----
             "intel.unit_log": self.open_intel_unit_log,
@@ -1978,6 +1987,27 @@ class MainWindow(QMainWindow):
         incident_id = getattr(self, "current_incident_id", None)
         panel = create_quick_entry_window(self, incident_id=incident_id)
         self._open_dock_widget(panel, title="New Communications Entry")
+
+    def open_lan_client_connection(self) -> None:
+        from panels.lan import LanClientConnectionPanel
+
+        panel = LanClientConnectionPanel(self)
+        self._open_dock_widget(panel, title="LAN Client")
+
+    def open_lan_host_status(self) -> None:
+        from panels.lan import LanHostStatusPanel
+
+        panel = LanHostStatusPanel(self)
+        self._open_dock_widget(panel, title="LAN Host")
+
+    def _init_lan_sync(self) -> None:
+        try:
+            from shared.lan_runtime import lan_runtime
+
+            lan_runtime.client.bootstrapReceived.connect(lan_runtime.apply_bootstrap_to_signals)
+            lan_runtime.client.eventReceived.connect(lan_runtime.apply_event_to_signals)
+        except Exception:
+            pass
 
     def _register_child_window(self, window):
         if window is None:

--- a/modules/communications/traffic_log/ui/log_window.py
+++ b/modules/communications/traffic_log/ui/log_window.py
@@ -30,6 +30,9 @@ from ..models import (
 from ..services import CommsLogService
 from notifications.models.notification import Notification
 from notifications.services import get_notifier
+from shared.lan_runtime import lan_runtime
+from shared import lan_events
+from utils.app_signals import app_signals
 from .log_detail import LogDetailDrawer
 from .log_filters import LogFilterPanel
 from .log_table import CommsLogTableView
@@ -175,6 +178,10 @@ class CommunicationsLogWindow(QMainWindow):
 
         QShortcut(QKeySequence("Ctrl+F"), self, activated=self._focus_filters)
         QShortcut(QKeySequence("Ctrl+M"), self, activated=self._toggle_status_update_shortcut)
+        try:
+            app_signals.lanEventReceived.connect(self._on_lan_event)
+        except Exception:
+            pass
 
         self._set_detail_visible(False)
         self._update_detail_button_state()
@@ -316,7 +323,23 @@ class CommunicationsLogWindow(QMainWindow):
 
     def _on_quick_entry_submitted(self, payload: dict) -> None:
         try:
+            if lan_runtime.is_client_mode():
+                if not lan_runtime.writes_allowed():
+                    raise RuntimeError("Disconnected from host. Reconnect before editing shared data.")
+                ok, res = lan_runtime.client.create_comms(payload)
+                if not ok:
+                    raise RuntimeError(str(res))
+                entry_id = int(((res if isinstance(res, dict) else {}).get("entry") or {}).get("id") or 0)
+                self.statusBar().showMessage("Entry sent to host", 2000)
+                self._refresh_entries(select_id=entry_id if entry_id > 0 else None)
+                return
             entry = self.service.create_entry(payload)
+            if lan_runtime.is_host_mode():
+                try:
+                    from server import lan_host_service
+                    lan_host_service.broadcast_event(lan_events.COMMS_CREATED, {"entry": entry.to_record()})
+                except Exception:
+                    pass
         except Exception as exc:
             QMessageBox.warning(self, "Entry Error", str(exc))
             return
@@ -429,6 +452,12 @@ class CommunicationsLogWindow(QMainWindow):
 
         menu.exec(self.table_view.viewport().mapToGlobal(pos))
 
+
+    def _on_lan_event(self, event: dict) -> None:
+        event_type = str(event.get("type") or "")
+        if event_type in {lan_events.COMMS_CREATED, lan_events.ALERT_CREATED, lan_events.INCIDENT_SNAPSHOT}:
+            self._refresh_entries()
+
     def _send_notification(self, entry_id: int, severity: str) -> None:
         try:
             entry = self.service.get_entry(entry_id)
@@ -452,6 +481,27 @@ class CommunicationsLogWindow(QMainWindow):
         if entry.message:
             parts.append(entry.message)
         msg = " — ".join([p for p in parts if p]) or "Log entry notification"
+
+        if lan_runtime.is_client_mode():
+            if not lan_runtime.writes_allowed():
+                QMessageBox.warning(self, "Notification", "Disconnected from host. Reconnect first.")
+                return
+            ok, res = lan_runtime.client.create_alert(
+                {
+                    "title": title,
+                    "message": msg,
+                    "severity": "warning" if severity != "error" else "error",
+                    "source": "Communications Log",
+                    "entity_type": "comms_entry",
+                    "entity_id": str(entry_id),
+                }
+            )
+            if not ok:
+                QMessageBox.warning(self, "Notification", str(res))
+                return
+            self.statusBar().showMessage("Alert sent to host", 2000)
+            return
+
         notifier = get_notifier()
         notifier.notify(
             Notification(
@@ -463,6 +513,17 @@ class CommunicationsLogWindow(QMainWindow):
                 entity_id=str(entry_id),
             )
         )
+        if lan_runtime.is_host_mode():
+            try:
+                from server import lan_host_service
+
+                alerts = notifier.recent(limit=1)
+                lan_host_service.broadcast_event(
+                    lan_events.ALERT_CREATED,
+                    {"alert": alerts[0] if alerts else {"title": title, "message": msg}},
+                )
+            except Exception:
+                pass
         self.statusBar().showMessage("Notification sent", 2000)
 
     def _on_entry_message_focus_changed(self, focused: bool) -> None:

--- a/modules/operations/panels/task_status_panel.py
+++ b/modules/operations/panels/task_status_panel.py
@@ -18,6 +18,8 @@ from utils.styles import task_status_colors, subscribe_theme, get_palette
 from utils.itemview_delegates import RowOutlineSelectionDelegate
 from utils.audit import write_audit
 from utils.app_signals import app_signals
+from shared.lan_runtime import lan_runtime
+from shared import lan_events
 
 # Require incident DB repository (no sample fallback)
 try:
@@ -299,11 +301,24 @@ class TaskStatusPanel(QWidget):
             task_id = int(item_id.data(Qt.UserRole)) if item_id and item_id.data(Qt.UserRole) is not None else None
             if not task_id:
                 raise RuntimeError("No task id associated with row")
-            if not set_task_status:
-                raise RuntimeError("DB repository not available")
             item_status = self.table.item(row, 3)
             old_status = (item_status.text() if item_status else "").strip().lower()
-            set_task_status(task_id, str(new_status))
+            if lan_runtime.is_client_mode():
+                if not lan_runtime.writes_allowed():
+                    raise RuntimeError("Disconnected from host. Reconnect before editing shared data.")
+                ok, msg = lan_runtime.client.update_task(task_id=task_id, status=str(new_status))
+                if not ok:
+                    raise RuntimeError(msg)
+            else:
+                if not set_task_status:
+                    raise RuntimeError("DB repository not available")
+                set_task_status(task_id, str(new_status))
+                if lan_runtime.is_host_mode():
+                    try:
+                        from server import lan_host_service
+                        lan_host_service.broadcast_event(lan_events.TASK_STATUS_CHANGED, {"task_id": task_id, "status": str(new_status)})
+                    except Exception:
+                        pass
             # Update UI
             display = str(new_status).title()
             self.table.item(row, 3).setText(display)

--- a/modules/operations/panels/team_status_panel.py
+++ b/modules/operations/panels/team_status_panel.py
@@ -27,6 +27,9 @@ import logging
 import re
 from pathlib import Path
 
+from shared.lan_runtime import lan_runtime
+from shared import lan_events
+
 from .team_alerts import (
     AlertKind,
     TeamAlertState,
@@ -872,9 +875,23 @@ class TeamStatusPanel(QWidget):
                 from modules.operations.data.repository import set_team_status  # local import to avoid cycles
             except Exception:
                 set_team_status = None  # type: ignore[assignment]
-            if not set_team_status:
-                raise RuntimeError("DB repository not available")
-            set_team_status(team_id, str(new_status))
+            if lan_runtime.is_client_mode():
+                if not lan_runtime.writes_allowed():
+                    raise RuntimeError("Disconnected from host. Reconnect before editing shared data.")
+                ok, msg = lan_runtime.client.update_team(team_id=team_id, status=str(new_status))
+                if not ok:
+                    raise RuntimeError(msg)
+            else:
+                if not set_team_status:
+                    raise RuntimeError("DB repository not available")
+                set_team_status(team_id, str(new_status))
+                if lan_runtime.is_host_mode():
+                    lan_events_payload = {"team_id": team_id, "status": str(new_status)}
+                    try:
+                        from server import lan_host_service
+                        lan_host_service.broadcast_event(lan_events.TEAM_STATUS_CHANGED, lan_events_payload)
+                    except Exception:
+                        pass
             # Update UI
             display = str(new_status).title()
             # Status column index is 6 after adding Needs + Sortie + Name + Type + Leader + Contact

--- a/panels/lan/__init__.py
+++ b/panels/lan/__init__.py
@@ -1,0 +1,4 @@
+from .client_connection_panel import LanClientConnectionPanel
+from .host_status_panel import LanHostStatusPanel
+
+__all__ = ["LanClientConnectionPanel", "LanHostStatusPanel"]

--- a/panels/lan/client_connection_panel.py
+++ b/panels/lan/client_connection_panel.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QMessageBox,
+)
+
+from shared.lan_runtime import lan_runtime
+
+
+class LanClientConnectionPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("LAN Client Connection")
+        root = QVBoxLayout(self)
+
+        host_row = QHBoxLayout()
+        host_row.addWidget(QLabel("Host IP:"))
+        self.host_edit = QLineEdit(lan_runtime.client.host)
+        host_row.addWidget(self.host_edit, 1)
+        root.addLayout(host_row)
+
+        port_row = QHBoxLayout()
+        port_row.addWidget(QLabel("Port:"))
+        self.port_edit = QLineEdit(str(lan_runtime.client.port))
+        port_row.addWidget(self.port_edit)
+        root.addLayout(port_row)
+
+        btn_row = QHBoxLayout()
+        self.connect_btn = QPushButton("Connect")
+        self.disconnect_btn = QPushButton("Disconnect")
+        self.refresh_btn = QPushButton("Refresh from host")
+        btn_row.addWidget(self.connect_btn)
+        btn_row.addWidget(self.disconnect_btn)
+        btn_row.addWidget(self.refresh_btn)
+        root.addLayout(btn_row)
+
+        self.status_label = QLabel("Disconnected")
+        self.target_label = QLabel("Host: -")
+        root.addWidget(self.status_label)
+        root.addWidget(self.target_label)
+        root.addStretch(1)
+
+        self.connect_btn.clicked.connect(self._connect)
+        self.disconnect_btn.clicked.connect(self._disconnect)
+        self.refresh_btn.clicked.connect(self._refresh)
+
+        lan_runtime.client.connectionStateChanged.connect(self._on_state_changed)
+        lan_runtime.client.bootstrapReceived.connect(lan_runtime.apply_bootstrap_to_signals)
+        lan_runtime.client.eventReceived.connect(lan_runtime.apply_event_to_signals)
+
+    def _connect(self) -> None:
+        host = self.host_edit.text().strip()
+        try:
+            port = int(self.port_edit.text().strip())
+        except Exception:
+            QMessageBox.warning(self, "LAN", "Port must be a number")
+            return
+        ok, msg = lan_runtime.client.connect_to_host(host, port)
+        if ok:
+            lan_runtime.set_mode("client")
+        else:
+            QMessageBox.warning(self, "LAN Connect Failed", msg)
+
+    def _disconnect(self) -> None:
+        lan_runtime.client.disconnect()
+        if lan_runtime.mode == "client":
+            lan_runtime.set_mode("local")
+
+    def _refresh(self) -> None:
+        ok, msg = lan_runtime.client.refresh_from_host()
+        if not ok:
+            QMessageBox.warning(self, "LAN Refresh", msg)
+
+    def _on_state_changed(self, state: str, detail: str) -> None:
+        self.status_label.setText(f"State: {state.title()}" + (f" ({detail})" if detail else ""))
+        self.target_label.setText(f"Host: {lan_runtime.client.host}:{lan_runtime.client.port}")
+
+
+__all__ = ["LanClientConnectionPanel"]

--- a/panels/lan/host_status_panel.py
+++ b/panels/lan/host_status_panel.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QPushButton,
+    QHBoxLayout,
+    QMessageBox,
+)
+
+from server import lan_host_service
+from shared.lan_config import DEFAULT_LAN_PORT
+from shared.lan_runtime import lan_runtime
+
+
+class LanHostStatusPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("LAN Host Status")
+        root = QVBoxLayout(self)
+
+        self.status = QLabel()
+        self.address = QLabel()
+        self.incident = QLabel()
+        self.clients = QLabel()
+        self.warn = QLabel()
+        root.addWidget(self.status)
+        root.addWidget(self.address)
+        root.addWidget(self.incident)
+        root.addWidget(self.clients)
+        root.addWidget(self.warn)
+
+        btns = QHBoxLayout()
+        self.start_btn = QPushButton("Start hosting")
+        self.stop_btn = QPushButton("Stop hosting")
+        self.copy_btn = QPushButton("Copy address")
+        self.refresh_btn = QPushButton("Refresh network info")
+        btns.addWidget(self.start_btn)
+        btns.addWidget(self.stop_btn)
+        btns.addWidget(self.copy_btn)
+        btns.addWidget(self.refresh_btn)
+        root.addLayout(btns)
+        root.addStretch(1)
+
+        self.start_btn.clicked.connect(self._start)
+        self.stop_btn.clicked.connect(self._stop)
+        self.copy_btn.clicked.connect(self._copy)
+        self.refresh_btn.clicked.connect(self.refresh)
+
+        self.refresh()
+
+    def _start(self) -> None:
+        ok, msg = lan_host_service.start(port=DEFAULT_LAN_PORT)
+        if ok:
+            lan_runtime.set_mode("host")
+        else:
+            QMessageBox.warning(self, "Host Mode", msg)
+        self.refresh()
+
+    def _stop(self) -> None:
+        lan_host_service.stop()
+        if lan_runtime.mode == "host":
+            lan_runtime.set_mode("local")
+        self.refresh()
+
+    def _copy(self) -> None:
+        QGuiApplication.clipboard().setText(f"{lan_host_service.primary_lan_ip()}:{lan_host_service.port}")
+
+    def refresh(self) -> None:
+        active = lan_host_service.active_incident()
+        ip = lan_host_service.primary_lan_ip()
+        self.status.setText(f"Hosting: {'ON' if lan_host_service.is_running else 'OFF'}")
+        self.address.setText(f"Connect clients to: {ip}:{lan_host_service.port}")
+        self.incident.setText(f"Active incident: {active or '(none)'}")
+        self.clients.setText(f"Connected clients: {lan_host_service.connected_clients}")
+        if ip.startswith("127."):
+            self.warn.setText("Warning: only localhost is available; LAN clients cannot connect.")
+        else:
+            ips = ", ".join(lan_host_service.lan_ipv4_addresses())
+            self.warn.setText(f"LAN IPv4: {ips}")
+
+
+__all__ = ["LanHostStatusPanel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "reportlab",
     "PySide6-QtAds",
     "httpx",
+    "uvicorn",
     "sqlalchemy",
     "sqlmodel>=0.0.8",
     "pypdf",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ sqlmodel>=0.0.8
 pypdf>=4
 PyYAML
 openpyxl
+uvicorn

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,3 @@
+from .lan_host_service import lan_host_service, LanHostService
+
+__all__ = ["lan_host_service", "LanHostService"]

--- a/server/lan_host_service.py
+++ b/server/lan_host_service.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+import sqlite3
+import threading
+from typing import Any
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from models.database import get_incident_by_number
+from modules.communications.traffic_log.services import CommsLogService
+from modules.operations.data.repository import (
+    fetch_task_rows,
+    fetch_team_assignment_rows,
+    set_task_status,
+    set_team_status,
+)
+from notifications.models.notification import Notification
+from notifications.services import get_notifier
+from shared import lan_events
+from utils import incident_context, incident_storage
+from utils.state import AppState
+
+logger = logging.getLogger(__name__)
+
+
+class _SocketHub:
+    def __init__(self) -> None:
+        self._clients: set[WebSocket] = set()
+        self._lock = asyncio.Lock()
+
+    @property
+    def count(self) -> int:
+        return len(self._clients)
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        async with self._lock:
+            self._clients.add(websocket)
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        async with self._lock:
+            if websocket in self._clients:
+                self._clients.remove(websocket)
+
+    async def broadcast(self, payload: dict[str, Any]) -> None:
+        async with self._lock:
+            peers = list(self._clients)
+        stale: list[WebSocket] = []
+        for ws in peers:
+            try:
+                await ws.send_json(payload)
+            except Exception:
+                stale.append(ws)
+        if stale:
+            async with self._lock:
+                for ws in stale:
+                    self._clients.discard(ws)
+
+
+class LanHostService:
+    def __init__(self) -> None:
+        self._app = FastAPI(title="IMA LAN Host")
+        self._hub = _SocketHub()
+        self._server = None
+        self._thread: threading.Thread | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._host = "0.0.0.0"
+        self._port = 8000
+        self._is_running = False
+        self._register_routes()
+
+    @property
+    def app(self) -> FastAPI:
+        return self._app
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    @property
+    def is_running(self) -> bool:
+        return self._is_running
+
+    @property
+    def connected_clients(self) -> int:
+        return self._hub.count
+
+    def active_incident(self) -> str | None:
+        active = AppState.get_active_incident()
+        return None if active is None else str(active)
+
+    def lan_ipv4_addresses(self) -> list[str]:
+        found: list[str] = []
+        try:
+            for fam, _, _, _, sockaddr in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET):
+                if fam != socket.AF_INET:
+                    continue
+                ip = str(sockaddr[0])
+                if ip.startswith("127."):
+                    continue
+                if ip not in found:
+                    found.append(ip)
+        except Exception:
+            pass
+        if not found:
+            try:
+                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                s.connect(("8.8.8.8", 80))
+                ip = s.getsockname()[0]
+                s.close()
+                if ip and not ip.startswith("127."):
+                    found.append(ip)
+            except Exception:
+                pass
+        return found
+
+    def primary_lan_ip(self) -> str:
+        all_ips = self.lan_ipv4_addresses()
+        if all_ips:
+            return all_ips[0]
+        return "127.0.0.1"
+
+    def start(self, *, host: str = "0.0.0.0", port: int = 8000) -> tuple[bool, str]:
+        active = self.active_incident()
+        if not active:
+            return False, "Cannot start host mode without an active incident."
+        if self._is_running:
+            return True, "Host mode already running."
+        self._host = str(host)
+        self._port = int(port)
+        try:
+            import uvicorn
+        except Exception as exc:
+            return False, f"uvicorn is required for host mode: {exc}"
+
+        def _run() -> None:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+            config = uvicorn.Config(self._app, host=self._host, port=self._port, log_level="warning")
+            self._server = uvicorn.Server(config)
+            self._is_running = True
+            try:
+                self._server.run()
+            finally:
+                self._is_running = False
+
+        self._thread = threading.Thread(target=_run, name="lan-host-service", daemon=True)
+        self._thread.start()
+        return True, "Host mode started."
+
+    def stop(self) -> None:
+        if not self._is_running:
+            return
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        self._thread = None
+        self._server = None
+        self._is_running = False
+
+    def broadcast_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        if not self._is_running or self._loop is None:
+            return
+        event = lan_events.make_event(event_type, payload)
+        fut = asyncio.run_coroutine_threadsafe(self._hub.broadcast(event), self._loop)
+        try:
+            fut.result(timeout=1.0)
+        except Exception:
+            logger.debug("LAN broadcast failed", exc_info=True)
+
+    def build_bootstrap(self) -> dict[str, Any]:
+        incident_number = self.active_incident()
+        incident_meta = get_incident_by_number(incident_number) if incident_number else None
+        comms_service = CommsLogService(incident_id=incident_number)
+        comms_entries = [e.to_record() for e in comms_service.list_entries()[:250]]
+        alerts = get_notifier().recent(limit=100)
+        return {
+            "incident": {
+                "number": incident_number,
+                "name": (incident_meta or {}).get("name") if incident_meta else incident_number,
+                "type": (incident_meta or {}).get("type") if incident_meta else "",
+            },
+            "teams": fetch_team_assignment_rows(),
+            "tasks": fetch_task_rows(),
+            "comms": comms_entries,
+            "alerts": alerts,
+            "master_lookups": {
+                "channels": comms_service.list_channels(),
+            },
+        }
+
+    def _session_payload(self) -> dict[str, Any]:
+        incident_number = self.active_incident()
+        incident_meta = get_incident_by_number(incident_number) if incident_number else None
+        return {
+            "hosting": bool(self._is_running),
+            "incident": {
+                "number": incident_number,
+                "name": (incident_meta or {}).get("name") if incident_meta else incident_number,
+            },
+            "host_ip": self.primary_lan_ip(),
+            "lan_ips": self.lan_ipv4_addresses(),
+            "port": self._port,
+            "clients": self.connected_clients,
+            "master_db": str(incident_storage.master_db_path()),
+            "incident_db": str(incident_context.get_active_incident_db_path()) if incident_number else None,
+        }
+
+    def _register_routes(self) -> None:
+        @self._app.get("/lan/session")
+        async def lan_session() -> dict[str, Any]:
+            return self._session_payload()
+
+        @self._app.get("/lan/bootstrap")
+        async def lan_bootstrap() -> dict[str, Any]:
+            payload = self.build_bootstrap()
+            return payload
+
+        @self._app.post("/lan/team/update")
+        async def lan_team_update(body: dict[str, Any]) -> dict[str, Any]:
+            team_id = int(body.get("team_id"))
+            status = str(body.get("status") or "")
+            set_team_status(team_id, status)
+            rows = fetch_team_assignment_rows()
+            team_row = next((r for r in rows if int(r.get("team_id") or -1) == team_id), None)
+            event_type = lan_events.TEAM_STATUS_CHANGED if body.get("status_only", True) else lan_events.TEAM_UPDATED
+            self.broadcast_event(event_type, {"team_id": team_id, "status": status, "team": team_row})
+            return {"ok": True, "team": team_row}
+
+        @self._app.post("/lan/task/update")
+        async def lan_task_update(body: dict[str, Any]) -> dict[str, Any]:
+            task_id = int(body.get("task_id"))
+            status = str(body.get("status") or "")
+            set_task_status(task_id, status)
+            rows = fetch_task_rows()
+            task_row = next((r for r in rows if int(r.get("id") or -1) == task_id), None)
+            event_type = lan_events.TASK_STATUS_CHANGED if body.get("status_only", True) else lan_events.TASK_UPDATED
+            self.broadcast_event(event_type, {"task_id": task_id, "status": status, "task": task_row})
+            return {"ok": True, "task": task_row}
+
+        @self._app.post("/lan/comms/create")
+        async def lan_comms_create(body: dict[str, Any]) -> dict[str, Any]:
+            service = CommsLogService(incident_id=self.active_incident())
+            entry = service.create_entry(body)
+            payload = entry.to_record()
+            self.broadcast_event(lan_events.COMMS_CREATED, {"entry": payload})
+            return {"ok": True, "entry": payload}
+
+        @self._app.post("/lan/alert/create")
+        async def lan_alert_create(body: dict[str, Any]) -> dict[str, Any]:
+            note = Notification(
+                title=str(body.get("title") or "Alert"),
+                message=str(body.get("message") or ""),
+                severity=str(body.get("severity") or "warning"),
+                source=str(body.get("source") or "LAN"),
+                entity_type=body.get("entity_type"),
+                entity_id=str(body.get("entity_id")) if body.get("entity_id") is not None else None,
+            )
+            get_notifier().notify(note)
+            alert = get_notifier().recent(limit=1)
+            payload = alert[0] if alert else body
+            self.broadcast_event(lan_events.ALERT_CREATED, {"alert": payload})
+            return {"ok": True, "alert": payload}
+
+        @self._app.websocket("/lan/ws")
+        async def lan_ws(websocket: WebSocket) -> None:
+            await self._hub.connect(websocket)
+            await self._hub.broadcast(
+                lan_events.make_event(lan_events.CONNECTION_STATE, {"clients": self.connected_clients, "state": "connected"})
+            )
+            try:
+                while True:
+                    await websocket.receive_text()
+            except WebSocketDisconnect:
+                await self._hub.disconnect(websocket)
+                await self._hub.broadcast(
+                    lan_events.make_event(lan_events.CONNECTION_STATE, {"clients": self.connected_clients, "state": "disconnected"})
+                )
+
+
+lan_host_service = LanHostService()

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -1,0 +1,3 @@
+from . import lan_events
+
+__all__ = ["lan_events"]

--- a/shared/lan_config.py
+++ b/shared/lan_config.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+DEFAULT_LAN_PORT = 8000
+DEFAULT_LAN_HOST = "0.0.0.0"
+DEFAULT_LAN_CLIENT_TIMEOUT_S = 8.0
+SETTINGS_GROUP = "lan"
+SETTINGS_HOST_KEY = "host"
+SETTINGS_PORT_KEY = "port"

--- a/shared/lan_events.py
+++ b/shared/lan_events.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+INCIDENT_SNAPSHOT = "incident.snapshot"
+TEAM_UPDATED = "team.updated"
+TEAM_STATUS_CHANGED = "team.status_changed"
+TASK_CREATED = "task.created"
+TASK_UPDATED = "task.updated"
+TASK_STATUS_CHANGED = "task.status_changed"
+COMMS_CREATED = "comms.created"
+ALERT_CREATED = "alert.created"
+CONNECTION_STATE = "connection.state"
+
+
+def make_event(event_type: str, payload: dict[str, Any], *, source: str = "host") -> dict[str, Any]:
+    return {
+        "type": str(event_type),
+        "payload": payload,
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "source": source,
+    }

--- a/shared/lan_runtime.py
+++ b/shared/lan_runtime.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+from PySide6.QtCore import QObject, Signal
+
+from client.lan_client_connector import LanClientConnector
+from server.lan_host_service import lan_host_service
+
+
+class LanRuntime(QObject):
+    modeChanged = Signal(str)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._mode = "local"
+        self.client = LanClientConnector()
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    def set_mode(self, mode: str) -> None:
+        mode = str(mode).strip().lower()
+        if mode not in {"local", "host", "client"}:
+            mode = "local"
+        if mode != self._mode:
+            self._mode = mode
+            self.modeChanged.emit(self._mode)
+
+    def is_host_mode(self) -> bool:
+        return self._mode == "host"
+
+    def is_client_mode(self) -> bool:
+        return self._mode == "client"
+
+    def writes_allowed(self) -> bool:
+        if self.is_client_mode():
+            return self.client.connected
+        return True
+
+    def apply_bootstrap_to_signals(self, snapshot: dict[str, Any]) -> None:
+        from utils.app_signals import app_signals
+
+        app_signals.lanSnapshotReceived.emit(snapshot)
+        app_signals.lanEventReceived.emit({"type": "incident.snapshot", "payload": snapshot, "source": "host"})
+        app_signals.teamStatusChanged.emit(-1)
+        app_signals.taskHeaderChanged.emit(-1, {"refresh": True})
+        app_signals.messageLogged.emit("LAN", "LAN")
+
+    def apply_event_to_signals(self, event: dict[str, Any]) -> None:
+        from utils.app_signals import app_signals
+
+        app_signals.lanEventReceived.emit(event)
+        event_type = str(event.get("type") or "")
+        payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+        if event_type.startswith("team."):
+            team_id = int(payload.get("team_id") or -1)
+            app_signals.teamStatusChanged.emit(team_id)
+        if event_type.startswith("task."):
+            task_id = int(payload.get("task_id") or -1)
+            app_signals.taskHeaderChanged.emit(task_id, {"refresh": True})
+        if event_type.startswith("comms.") or event_type.startswith("alert."):
+            app_signals.messageLogged.emit("LAN", "LAN")
+
+
+lan_runtime = LanRuntime()

--- a/utils/app_signals.py
+++ b/utils/app_signals.py
@@ -24,6 +24,8 @@ class AppSignals(QObject):
     taskHeaderChanged = Signal(int, dict)
     # Emitted when ICP location (address/lat/lon) changes for active incident
     icpLocationChanged = Signal(dict)
+    lanEventReceived = Signal(dict)
+    lanSnapshotReceived = Signal(dict)
 
 
 # Global singleton instance


### PR DESCRIPTION
### Motivation
- Provide a small, host-authoritative LAN sync system so a host machine can serve shared incident state and clients can bootstrap and receive live updates for teams, tasks, communications entries, and alerts. 
- Keep the change additive and minimal so local single-machine behavior remains usable while enabling a simple last-write-wins sync flow for the MVP.

### Description
- Added a lightweight host service at `server/lan_host_service.py` that exposes `GET /lan/session`, `GET /lan/bootstrap`, `POST /lan/team/update`, `POST /lan/task/update`, `POST /lan/comms/create`, `POST /lan/alert/create`, and a WebSocket hub at `WS /lan/ws`, and broadcasts events after successful writes.
- Implemented a Qt-side LAN client connector at `client/lan_client_connector.py` with HTTP bootstrap, WebSocket subscription, reconnect logic, and saved host IP/port handling; and a small `shared/` layer with event constants (`shared/lan_events.py`), config (`shared/lan_config.py`), and runtime bridging (`shared/lan_runtime.py`).
- Added minimal UI panels: `panels/lan/client_connection_panel.py` (connect/disconnect/refresh UI) and `panels/lan/host_status_panel.py` (host state, IP/port, connected clients, start/stop host buttons), and integrated menu entries and launch handlers in `main.py`.
- Wired LAN behavior into existing write paths so client-mode edits call the host endpoints and host-mode commits broadcast events; updated team/task/comms flows to block edits when a client is disconnected and to emit events after host commits (team/task panels and comms log quick-entry / alert paths).
- Kept the host as the single source of truth (DB access remains host-only), favored simple event-driven refresh updates, and added `uvicorn` to dependencies to allow the host runtime.

### Testing
- Performed static compilation check with `python -m py_compile` over the modified/added LAN integration and UI files, which completed successfully.
- Ran the module repository test `pytest -q modules/communications/traffic_log/tests/test_repository.py`, which passed (`..  [100%]`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69c6574bfdd4832bbdc0588d20f0bc66)