### PR TITLE
Add Resource Type Library module with SQLite repository, models, Qt UI, and tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -509,6 +509,7 @@ class MainWindow(QMainWindow):
         self._add_action(m_edit, "Vehicles", None, "edit.vehicles")
         self._add_action(m_edit, "Aircraft", None, "edit.aircraft")
         self._add_action(m_edit, "Equipment", None, "edit.equipment")
+        self._add_action(m_edit, "Resource Type Library", None, "edit.resource_types")
         self._add_action(m_edit, "Communications Resources (ICS-217)", None, "communications.217")
         self._add_action(m_edit, "Safety Analysis Templates", None, "edit.safety_templates")
 
@@ -860,6 +861,7 @@ class MainWindow(QMainWindow):
             "edit.vehicles": self.open_edit_vehicles,
             "edit.aircraft": self.open_edit_aircraft,
             "edit.equipment": self.open_edit_equipment,
+            "edit.resource_types": self.open_edit_resource_types,
             "communications.217": self.open_edit_comms_resources,
             "edit.safety_templates": self.open_edit_safety_templates,
 
@@ -1182,6 +1184,25 @@ class MainWindow(QMainWindow):
             return
         panel = EquipmentEditPanel(db_path="data/master.db")
         self._open_dock_widget(panel, title="Equipment")
+
+    def open_edit_resource_types(self) -> None:
+        """Open the Resource Type Library from the Edit menu.
+
+        The library window is modeless, so users can keep it open while working
+        elsewhere.  The module helper stores a parent-owned reference to avoid
+        Python garbage collection closing the window unexpectedly.
+        """
+        try:
+            from modules.admin.resource_types.windows import open_resource_type_library
+        except Exception as exc:
+            from PySide6.QtWidgets import QMessageBox
+            QMessageBox.critical(
+                self,
+                "Resource Type Library",
+                f"Unable to load Resource Type Library.\n{exc}",
+            )
+            return
+        open_resource_type_library(parent=self)
 
     def open_edit_comms_resources(self) -> None:
         # Open new QWidget-based Comms Resource Editor (dock-friendly)

--- a/modules/admin/resource_types/__init__.py
+++ b/modules/admin/resource_types/__init__.py
@@ -1,0 +1,33 @@
+"""Reusable Resource Type Library foundation module.
+
+Qt widgets/windows are imported lazily so repository-only code can run in
+headless or dependency-limited environments without loading PySide6.
+"""
+
+from .data import ResourceTypeRepository
+
+__all__ = [
+    "ResourceTypeRepository",
+    "ResourceTypeSearchBox",
+    "CapabilityManagerWindow",
+    "ResourceTypeEditorWindow",
+    "ResourceTypeLibraryWindow",
+    "open_resource_type_library",
+]
+
+
+def __getattr__(name: str):
+    if name == "ResourceTypeSearchBox":
+        from .widgets import ResourceTypeSearchBox
+
+        return ResourceTypeSearchBox
+    if name in {
+        "CapabilityManagerWindow",
+        "ResourceTypeEditorWindow",
+        "ResourceTypeLibraryWindow",
+        "open_resource_type_library",
+    }:
+        from . import windows
+
+        return getattr(windows, name)
+    raise AttributeError(name)

--- a/modules/admin/resource_types/data/__init__.py
+++ b/modules/admin/resource_types/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data access exports for the Resource Type Library."""
+
+from .resource_type_repository import ResourceTypeRepository
+
+__all__ = ["ResourceTypeRepository"]

--- a/modules/admin/resource_types/data/resource_type_repository.py
+++ b/modules/admin/resource_types/data/resource_type_repository.py
@@ -1,0 +1,852 @@
+"""SQLite repository for Resource Type Library master data.
+
+The UI intentionally calls this repository for all persistence so SQL stays in
+one beginner-friendly place.  The repository creates and lightly migrates the
+master database tables on startup; no demo rows are inserted.
+"""
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from models.database import DB_PATH as DEFAULT_DB_PATH
+
+from ..models.resource_type_models import (
+    FemaNimsMapping,
+    RESOURCE_CATEGORIES,
+    RESOURCE_SOURCES,
+    ResourceCapability,
+    ResourceType,
+    ResourceTypeComponent,
+    ResourceTypeSearchResult,
+)
+
+ISO_TIMESTAMP = "%Y-%m-%dT%H:%M:%S"
+
+
+def _now() -> str:
+    """Return the timestamp format used by existing repository modules."""
+
+    return datetime.now().strftime(ISO_TIMESTAMP)
+
+
+class ResourceTypeRepository:
+    """Persistence API for reusable resource type definitions.
+
+    All data is stored in the master database because these definitions are
+    shared across incidents.  Tests and tools can pass a temporary ``db_path``.
+    """
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        self.db_path = Path(db_path or DEFAULT_DB_PATH)
+        self.ensure_schema()
+
+    @contextmanager
+    def _connect(self) -> Iterable[sqlite3.Connection]:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys=ON")
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Schema management
+    # ------------------------------------------------------------------
+    def ensure_schema(self) -> None:
+        """Create or update Resource Type Library tables and indexes."""
+
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS resource_types (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    planning_display_name TEXT NOT NULL DEFAULT '',
+                    category TEXT NOT NULL DEFAULT 'Other',
+                    source TEXT NOT NULL DEFAULT 'AHJ Custom',
+                    owner_agency TEXT NOT NULL DEFAULT '',
+                    description TEXT NOT NULL DEFAULT '',
+                    default_unit TEXT NOT NULL DEFAULT 'each',
+                    typical_quantity REAL NOT NULL DEFAULT 1,
+                    typical_team_size INTEGER,
+                    is_kit_cache INTEGER NOT NULL DEFAULT 0,
+                    is_consumable INTEGER NOT NULL DEFAULT 0,
+                    is_active INTEGER NOT NULL DEFAULT 1,
+                    notes TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    created_by TEXT NOT NULL DEFAULT '',
+                    updated_by TEXT NOT NULL DEFAULT ''
+                );
+
+                CREATE TABLE IF NOT EXISTS resource_type_aliases (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    resource_type_id INTEGER NOT NULL,
+                    alias TEXT NOT NULL,
+                    UNIQUE(resource_type_id, alias),
+                    FOREIGN KEY(resource_type_id) REFERENCES resource_types(id) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS resource_capabilities (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    category TEXT NOT NULL DEFAULT '',
+                    description TEXT NOT NULL DEFAULT '',
+                    aliases TEXT NOT NULL DEFAULT '',
+                    is_active INTEGER NOT NULL DEFAULT 1,
+                    notes TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS resource_type_capabilities (
+                    resource_type_id INTEGER NOT NULL,
+                    capability_id INTEGER NOT NULL,
+                    PRIMARY KEY(resource_type_id, capability_id),
+                    FOREIGN KEY(resource_type_id) REFERENCES resource_types(id) ON DELETE CASCADE,
+                    FOREIGN KEY(capability_id) REFERENCES resource_capabilities(id) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS resource_type_components (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    parent_resource_type_id INTEGER NOT NULL,
+                    component_resource_type_id INTEGER NOT NULL,
+                    quantity REAL NOT NULL DEFAULT 1,
+                    unit TEXT NOT NULL DEFAULT 'each',
+                    required INTEGER NOT NULL DEFAULT 1,
+                    notes TEXT NOT NULL DEFAULT '',
+                    UNIQUE(parent_resource_type_id, component_resource_type_id),
+                    CHECK(parent_resource_type_id != component_resource_type_id),
+                    FOREIGN KEY(parent_resource_type_id) REFERENCES resource_types(id) ON DELETE CASCADE,
+                    FOREIGN KEY(component_resource_type_id) REFERENCES resource_types(id) ON DELETE RESTRICT
+                );
+
+                CREATE TABLE IF NOT EXISTS resource_type_fema_mappings (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    resource_type_id INTEGER NOT NULL,
+                    nims_name TEXT NOT NULL DEFAULT '',
+                    discipline TEXT NOT NULL DEFAULT '',
+                    type_code TEXT NOT NULL DEFAULT '',
+                    kind TEXT NOT NULL DEFAULT '',
+                    reference_url TEXT NOT NULL DEFAULT '',
+                    notes TEXT NOT NULL DEFAULT '',
+                    typed_level TEXT NOT NULL DEFAULT '',
+                    FOREIGN KEY(resource_type_id) REFERENCES resource_types(id) ON DELETE CASCADE
+                );
+                """
+            )
+
+            # Earlier versions of this foundation module created fewer columns.
+            # Add missing columns so existing master.db files continue to work.
+            self._ensure_columns(
+                conn,
+                "resource_types",
+                {
+                    "is_kit_cache": "INTEGER NOT NULL DEFAULT 0",
+                    "is_consumable": "INTEGER NOT NULL DEFAULT 0",
+                    "created_by": "TEXT NOT NULL DEFAULT ''",
+                    "updated_by": "TEXT NOT NULL DEFAULT ''",
+                },
+            )
+            self._ensure_columns(
+                conn,
+                "resource_capabilities",
+                {"notes": "TEXT NOT NULL DEFAULT ''"},
+            )
+            self._ensure_columns(
+                conn,
+                "resource_type_components",
+                {"required": "INTEGER NOT NULL DEFAULT 1"},
+            )
+            self._ensure_columns(
+                conn,
+                "resource_type_fema_mappings",
+                {
+                    "nims_name": "TEXT NOT NULL DEFAULT ''",
+                    "discipline": "TEXT NOT NULL DEFAULT ''",
+                    "type_code": "TEXT NOT NULL DEFAULT ''",
+                    "kind": "TEXT NOT NULL DEFAULT ''",
+                    "reference_url": "TEXT NOT NULL DEFAULT ''",
+                    "notes": "TEXT NOT NULL DEFAULT ''",
+                    "typed_level": "TEXT NOT NULL DEFAULT ''",
+                },
+            )
+            conn.executescript(
+                """
+                CREATE INDEX IF NOT EXISTS idx_resource_types_search
+                    ON resource_types(name, planning_display_name, category, source, owner_agency);
+                CREATE INDEX IF NOT EXISTS idx_resource_type_aliases_alias
+                    ON resource_type_aliases(alias);
+                CREATE INDEX IF NOT EXISTS idx_resource_capabilities_search
+                    ON resource_capabilities(name, category, aliases);
+                CREATE INDEX IF NOT EXISTS idx_resource_type_components_parent
+                    ON resource_type_components(parent_resource_type_id);
+                """
+            )
+
+    def _ensure_columns(
+        self, conn: sqlite3.Connection, table_name: str, columns: dict[str, str]
+    ) -> None:
+        """Add missing columns to an existing table.
+
+        SQLite supports simple ``ALTER TABLE ADD COLUMN`` statements, which is
+        enough for these additive master-data fields.
+        """
+
+        existing = {
+            row["name"] for row in conn.execute(f"PRAGMA table_info({table_name})")
+        }
+        for column_name, ddl in columns.items():
+            if column_name not in existing:
+                conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {ddl}")
+
+    # ------------------------------------------------------------------
+    # Resource type queries and commands
+    # ------------------------------------------------------------------
+    def list_resource_types(
+        self,
+        search_text: str = "",
+        include_inactive: bool = False,
+        category: str = "All",
+        source: str = "All",
+        active_filter: str = "Active",
+    ) -> list[dict[str, Any]]:
+        """Return rows for the main Resource Type Library table."""
+
+        where: list[str] = []
+        params: list[Any] = []
+        if active_filter == "Active" and not include_inactive:
+            where.append("rt.is_active = 1")
+        elif active_filter == "Inactive":
+            where.append("rt.is_active = 0")
+        if category and category != "All":
+            where.append("rt.category = ?")
+            params.append(category)
+        if source and source != "All":
+            where.append("rt.source = ?")
+            params.append(source)
+        if search_text.strip():
+            like = f"%{search_text.strip().lower()}%"
+            where.append(self._resource_type_search_clause())
+            params.extend([like] * 13)
+        sql = """
+            SELECT rt.*,
+                   COALESCE((
+                       SELECT group_concat(c.name, ', ')
+                       FROM resource_type_capabilities rtc
+                       JOIN resource_capabilities c ON c.id = rtc.capability_id
+                       WHERE rtc.resource_type_id = rt.id
+                   ), '') AS capabilities,
+                   COALESCE((
+                       SELECT COUNT(*)
+                       FROM resource_type_components comp
+                       WHERE comp.parent_resource_type_id = rt.id
+                   ), 0) AS component_count
+            FROM resource_types rt
+        """
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY lower(rt.name)"
+        with self._connect() as conn:
+            return [dict(row) for row in conn.execute(sql, params).fetchall()]
+
+    def get_resource_type(self, resource_type_id: int) -> Optional[ResourceType]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM resource_types WHERE id = ?", (resource_type_id,)
+            ).fetchone()
+            return self._resource_type_from_row(conn, row) if row else None
+
+    def save_resource_type(self, resource_type: ResourceType) -> int:
+        """Create or update a resource type and its simple child records."""
+
+        self._validate_resource_type(resource_type)
+        now = _now()
+        payload = {
+            "name": resource_type.name.strip(),
+            "planning_display_name": resource_type.planning_display_name.strip(),
+            "category": resource_type.category,
+            "source": resource_type.source,
+            "owner_agency": resource_type.owner_agency.strip(),
+            "description": resource_type.description.strip(),
+            "default_unit": resource_type.default_unit.strip() or "each",
+            "typical_quantity": float(resource_type.typical_quantity),
+            "typical_team_size": resource_type.typical_team_size,
+            "is_kit_cache": int(resource_type.is_kit_cache),
+            "is_consumable": int(resource_type.is_consumable),
+            "is_active": int(resource_type.is_active),
+            "notes": resource_type.notes.strip(),
+            "updated_by": resource_type.updated_by.strip(),
+            "updated_at": now,
+        }
+        with self._connect() as conn:
+            if resource_type.id is None:
+                payload["created_by"] = resource_type.created_by.strip()
+                payload["created_at"] = now
+                columns = ", ".join(payload)
+                placeholders = ", ".join("?" for _ in payload)
+                cur = conn.execute(
+                    f"INSERT INTO resource_types ({columns}) VALUES ({placeholders})",
+                    tuple(payload.values()),
+                )
+                resource_type_id = int(cur.lastrowid)
+            else:
+                assignments = ", ".join(f"{column} = ?" for column in payload)
+                conn.execute(
+                    f"UPDATE resource_types SET {assignments} WHERE id = ?",
+                    tuple(payload.values()) + (resource_type.id,),
+                )
+                resource_type_id = int(resource_type.id)
+            self.replace_aliases(resource_type_id, resource_type.aliases, conn)
+            self.set_resource_type_capabilities(
+                resource_type_id, resource_type.capability_ids, conn
+            )
+            self.replace_fema_mappings(resource_type_id, resource_type.fema_mappings, conn)
+            return resource_type_id
+
+    def clone_resource_type(self, resource_type_id: int) -> int:
+        """Copy a resource type, including aliases/capabilities/mappings/components."""
+
+        original = self.get_resource_type(resource_type_id)
+        if original is None:
+            raise ValueError("Resource type not found")
+        original.id = None
+        original.name = self._next_copy_name(original.name)
+        original.planning_display_name = (
+            f"{original.planning_display_name} Copy".strip()
+            if original.planning_display_name
+            else original.name
+        )
+        original.created_at = ""
+        original.updated_at = ""
+        components = list(original.components)
+        original.components = []
+        new_id = self.save_resource_type(original)
+        for component in components:
+            component.id = None
+            component.parent_resource_type_id = new_id
+            self.add_component(component)
+        return new_id
+
+    def deactivate_resource_type(self, resource_type_id: int) -> None:
+        self.set_resource_type_active(resource_type_id, False)
+
+    def activate_resource_type(self, resource_type_id: int) -> None:
+        self.set_resource_type_active(resource_type_id, True)
+
+    def set_resource_type_active(self, resource_type_id: int, active: bool) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE resource_types SET is_active = ?, updated_at = ? WHERE id = ?",
+                (int(active), _now(), resource_type_id),
+            )
+
+    def replace_aliases(
+        self,
+        resource_type_id: int,
+        aliases: Iterable[str],
+        conn: sqlite3.Connection | None = None,
+    ) -> None:
+        owns_connection = conn is None
+        if conn is None:
+            conn = sqlite3.connect(str(self.db_path))
+            conn.execute("PRAGMA foreign_keys=ON")
+        try:
+            conn.execute(
+                "DELETE FROM resource_type_aliases WHERE resource_type_id = ?",
+                (resource_type_id,),
+            )
+            for alias in self._clean_strings(aliases):
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO resource_type_aliases (resource_type_id, alias)
+                    VALUES (?, ?)
+                    """,
+                    (resource_type_id, alias),
+                )
+            if owns_connection:
+                conn.commit()
+        finally:
+            if owns_connection:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # Capability queries and commands
+    # ------------------------------------------------------------------
+    def list_capabilities(
+        self, search_text: str = "", include_inactive: bool = False
+    ) -> list[dict[str, Any]]:
+        where: list[str] = []
+        params: list[Any] = []
+        if not include_inactive:
+            where.append("is_active = 1")
+        if search_text.strip():
+            like = f"%{search_text.strip().lower()}%"
+            where.append(
+                "(lower(name) LIKE ? OR lower(category) LIKE ? OR lower(description) LIKE ? OR lower(aliases) LIKE ? OR lower(notes) LIKE ?)"
+            )
+            params.extend([like] * 5)
+        sql = "SELECT * FROM resource_capabilities"
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY lower(name)"
+        with self._connect() as conn:
+            return [dict(row) for row in conn.execute(sql, params).fetchall()]
+
+    def get_capability(self, capability_id: int) -> Optional[dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM resource_capabilities WHERE id = ?", (capability_id,)
+            ).fetchone()
+            return dict(row) if row else None
+
+    def save_capability(self, capability: ResourceCapability) -> int:
+        if not capability.name.strip():
+            raise ValueError("Capability name is required")
+        now = _now()
+        payload = {
+            "name": capability.name.strip(),
+            "category": capability.category.strip(),
+            "description": capability.description.strip(),
+            "aliases": "; ".join(self._clean_strings(capability.aliases)),
+            "is_active": int(capability.is_active),
+            "notes": capability.notes.strip(),
+            "updated_at": now,
+        }
+        with self._connect() as conn:
+            if capability.id is None:
+                payload["created_at"] = now
+                columns = ", ".join(payload)
+                placeholders = ", ".join("?" for _ in payload)
+                cur = conn.execute(
+                    f"INSERT INTO resource_capabilities ({columns}) VALUES ({placeholders})",
+                    tuple(payload.values()),
+                )
+                return int(cur.lastrowid)
+            assignments = ", ".join(f"{column} = ?" for column in payload)
+            conn.execute(
+                f"UPDATE resource_capabilities SET {assignments} WHERE id = ?",
+                tuple(payload.values()) + (capability.id,),
+            )
+            return int(capability.id)
+
+    def deactivate_capability(self, capability_id: int) -> None:
+        self.set_capability_active(capability_id, False)
+
+    def activate_capability(self, capability_id: int) -> None:
+        self.set_capability_active(capability_id, True)
+
+    def set_capability_active(self, capability_id: int, active: bool) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE resource_capabilities SET is_active = ?, updated_at = ? WHERE id = ?",
+                (int(active), _now(), capability_id),
+            )
+
+    def set_resource_type_capabilities(
+        self,
+        resource_type_id: int,
+        capability_ids: Iterable[int],
+        conn: sqlite3.Connection | None = None,
+    ) -> None:
+        owns_connection = conn is None
+        if conn is None:
+            conn = sqlite3.connect(str(self.db_path))
+            conn.execute("PRAGMA foreign_keys=ON")
+        try:
+            conn.execute(
+                "DELETE FROM resource_type_capabilities WHERE resource_type_id = ?",
+                (resource_type_id,),
+            )
+            for capability_id in sorted({int(cid) for cid in capability_ids}):
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO resource_type_capabilities
+                    (resource_type_id, capability_id) VALUES (?, ?)
+                    """,
+                    (resource_type_id, capability_id),
+                )
+            if owns_connection:
+                conn.commit()
+        finally:
+            if owns_connection:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # Components and FEMA/NIMS mappings
+    # ------------------------------------------------------------------
+    def list_components(self, resource_type_id: int) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT c.*, rt.name AS component_name, rt.category AS component_category
+                FROM resource_type_components c
+                JOIN resource_types rt ON rt.id = c.component_resource_type_id
+                WHERE c.parent_resource_type_id = ?
+                ORDER BY lower(rt.name)
+                """,
+                (resource_type_id,),
+            ).fetchall()
+            return [dict(row) for row in rows]
+
+    def replace_components(
+        self, resource_type_id: int, components: Iterable[ResourceTypeComponent]
+    ) -> None:
+        """Replace all kit/cache component rows for a resource type."""
+
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM resource_type_components WHERE parent_resource_type_id = ?",
+                (resource_type_id,),
+            )
+            for component in components:
+                component.parent_resource_type_id = resource_type_id
+                self._validate_component(component)
+                if self._would_create_cycle(conn, resource_type_id, component.component_resource_type_id):
+                    raise ValueError(
+                        "Component would create a circular resource type reference"
+                    )
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO resource_type_components
+                    (parent_resource_type_id, component_resource_type_id, quantity, unit, required, notes)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        resource_type_id,
+                        component.component_resource_type_id,
+                        float(component.quantity),
+                        component.unit.strip() or "each",
+                        int(component.required),
+                        component.notes.strip(),
+                    ),
+                )
+
+    def add_component(self, component: ResourceTypeComponent) -> int:
+        self._validate_component(component)
+        with self._connect() as conn:
+            if self._would_create_cycle(
+                conn,
+                component.parent_resource_type_id,
+                component.component_resource_type_id,
+            ):
+                raise ValueError("Component would create a circular resource type reference")
+            cur = conn.execute(
+                """
+                INSERT INTO resource_type_components
+                    (parent_resource_type_id, component_resource_type_id, quantity, unit, required, notes)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(parent_resource_type_id, component_resource_type_id) DO UPDATE SET
+                    quantity = excluded.quantity,
+                    unit = excluded.unit,
+                    required = excluded.required,
+                    notes = excluded.notes
+                """,
+                (
+                    component.parent_resource_type_id,
+                    component.component_resource_type_id,
+                    float(component.quantity),
+                    component.unit.strip() or "each",
+                    int(component.required),
+                    component.notes.strip(),
+                ),
+            )
+            return int(cur.lastrowid or 0)
+
+    def remove_component(self, component_id: int) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM resource_type_components WHERE id = ?", (component_id,))
+
+    def would_create_cycle(self, parent_id: int, child_id: int) -> bool:
+        with self._connect() as conn:
+            return self._would_create_cycle(conn, parent_id, child_id)
+
+    def replace_fema_mappings(
+        self,
+        resource_type_id: int,
+        mappings: Iterable[FemaNimsMapping],
+        conn: sqlite3.Connection | None = None,
+    ) -> None:
+        owns_connection = conn is None
+        if conn is None:
+            conn = sqlite3.connect(str(self.db_path))
+            conn.execute("PRAGMA foreign_keys=ON")
+        try:
+            conn.execute(
+                "DELETE FROM resource_type_fema_mappings WHERE resource_type_id = ?",
+                (resource_type_id,),
+            )
+            for mapping in mappings:
+                conn.execute(
+                    """
+                    INSERT INTO resource_type_fema_mappings
+                    (resource_type_id, nims_name, discipline, type_code, kind, reference_url, notes, typed_level)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        resource_type_id,
+                        mapping.nims_name.strip(),
+                        mapping.discipline.strip(),
+                        mapping.type_code.strip(),
+                        mapping.kind.strip(),
+                        mapping.reference_url.strip(),
+                        mapping.notes.strip(),
+                        mapping.typed_level.strip(),
+                    ),
+                )
+            if owns_connection:
+                conn.commit()
+        finally:
+            if owns_connection:
+                conn.close()
+
+    def list_fema_mappings(self, resource_type_id: int) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM resource_type_fema_mappings
+                WHERE resource_type_id = ?
+                ORDER BY lower(nims_name), lower(type_code)
+                """,
+                (resource_type_id,),
+            ).fetchall()
+            return [dict(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Smart search support
+    # ------------------------------------------------------------------
+    def search_resource_types(self, text: str, limit: int = 20) -> list[ResourceTypeSearchResult]:
+        """Search all fields needed by the free-text ResourceTypeSearchBox."""
+
+        query = text.strip().lower()
+        if not query:
+            return []
+        like = f"%{query}%"
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT rt.id, rt.name, rt.planning_display_name,
+                       rt.category, rt.source, rt.owner_agency,
+                       CASE
+                         WHEN lower(rt.name) LIKE ? THEN 'name'
+                         WHEN lower(rt.planning_display_name) LIKE ? THEN 'display name'
+                         WHEN lower(rt.category) LIKE ? THEN 'category'
+                         WHEN lower(rt.source) LIKE ? THEN 'source'
+                         WHEN lower(rt.owner_agency) LIKE ? THEN 'owner agency'
+                         WHEN EXISTS (SELECT 1 FROM resource_type_aliases a
+                                      WHERE a.resource_type_id = rt.id AND lower(a.alias) LIKE ?) THEN 'alias'
+                         WHEN EXISTS (SELECT 1 FROM resource_type_capabilities rtc
+                                      JOIN resource_capabilities c ON c.id = rtc.capability_id
+                                      WHERE rtc.resource_type_id = rt.id
+                                        AND (lower(c.name) LIKE ? OR lower(c.category) LIKE ? OR lower(c.aliases) LIKE ?)) THEN 'capability'
+                         ELSE 'FEMA/NIMS mapping'
+                       END AS matched_on
+                FROM resource_types rt
+                WHERE rt.is_active = 1 AND """
+                + self._resource_type_search_clause()
+                + """
+                ORDER BY lower(rt.name)
+                LIMIT ?
+                """,
+                (
+                    like,
+                    like,
+                    like,
+                    like,
+                    like,
+                    like,
+                    like,
+                    like,
+                    like,
+                    *([like] * 13),
+                    limit,
+                ),
+            ).fetchall()
+        return [
+            ResourceTypeSearchResult(
+                resource_type_id=int(row["id"]),
+                resource_type_text=row["planning_display_name"] or row["name"],
+                category=row["category"],
+                source=row["source"],
+                owner_agency=row["owner_agency"],
+                matched_on=row["matched_on"],
+            )
+            for row in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _resource_type_search_clause(self) -> str:
+        return """
+        (lower(rt.name) LIKE ? OR lower(rt.planning_display_name) LIKE ?
+         OR lower(rt.category) LIKE ? OR lower(rt.source) LIKE ?
+         OR lower(rt.owner_agency) LIKE ?
+         OR EXISTS (SELECT 1 FROM resource_type_aliases a
+                    WHERE a.resource_type_id = rt.id AND lower(a.alias) LIKE ?)
+         OR EXISTS (SELECT 1 FROM resource_type_capabilities rtc
+                    JOIN resource_capabilities c ON c.id = rtc.capability_id
+                    WHERE rtc.resource_type_id = rt.id
+                      AND (lower(c.name) LIKE ? OR lower(c.category) LIKE ? OR lower(c.aliases) LIKE ?))
+         OR EXISTS (SELECT 1 FROM resource_type_fema_mappings fm
+                    WHERE fm.resource_type_id = rt.id
+                      AND (lower(fm.kind) LIKE ? OR lower(fm.type_code) LIKE ?
+                           OR lower(fm.nims_name) LIKE ? OR lower(fm.discipline) LIKE ?)))
+        """
+
+    def _resource_type_from_row(
+        self, conn: sqlite3.Connection, row: sqlite3.Row
+    ) -> ResourceType:
+        resource_type_id = int(row["id"])
+        aliases = [
+            alias_row["alias"]
+            for alias_row in conn.execute(
+                "SELECT alias FROM resource_type_aliases WHERE resource_type_id = ? ORDER BY alias",
+                (resource_type_id,),
+            ).fetchall()
+        ]
+        capability_ids = [
+            int(cap_row["capability_id"])
+            for cap_row in conn.execute(
+                "SELECT capability_id FROM resource_type_capabilities WHERE resource_type_id = ?",
+                (resource_type_id,),
+            ).fetchall()
+        ]
+        components = [
+            ResourceTypeComponent(
+                id=int(component_row["id"]),
+                parent_resource_type_id=int(component_row["parent_resource_type_id"]),
+                component_resource_type_id=int(component_row["component_resource_type_id"]),
+                quantity=float(component_row["quantity"]),
+                unit=component_row["unit"],
+                required=bool(component_row["required"]),
+                notes=component_row["notes"],
+                component_name=component_row["component_name"],
+                component_category=component_row["component_category"],
+            )
+            for component_row in conn.execute(
+                """
+                SELECT c.*, rt.name AS component_name, rt.category AS component_category
+                FROM resource_type_components c
+                JOIN resource_types rt ON rt.id = c.component_resource_type_id
+                WHERE c.parent_resource_type_id = ?
+                ORDER BY lower(rt.name)
+                """,
+                (resource_type_id,),
+            ).fetchall()
+        ]
+        mappings = [
+            FemaNimsMapping(
+                id=int(mapping_row["id"]),
+                resource_type_id=resource_type_id,
+                nims_name=mapping_row["nims_name"],
+                discipline=mapping_row["discipline"],
+                type_code=mapping_row["type_code"],
+                kind=mapping_row["kind"],
+                reference_url=mapping_row["reference_url"],
+                notes=mapping_row["notes"],
+                typed_level=mapping_row["typed_level"],
+            )
+            for mapping_row in conn.execute(
+                "SELECT * FROM resource_type_fema_mappings WHERE resource_type_id = ?",
+                (resource_type_id,),
+            ).fetchall()
+        ]
+        return ResourceType(
+            id=resource_type_id,
+            name=row["name"],
+            planning_display_name=row["planning_display_name"],
+            category=row["category"],
+            source=row["source"],
+            owner_agency=row["owner_agency"],
+            description=row["description"],
+            default_unit=row["default_unit"],
+            typical_quantity=float(row["typical_quantity"]),
+            typical_team_size=row["typical_team_size"],
+            is_kit_cache=bool(row["is_kit_cache"]),
+            is_consumable=bool(row["is_consumable"]),
+            is_active=bool(row["is_active"]),
+            notes=row["notes"],
+            aliases=aliases,
+            capability_ids=capability_ids,
+            components=components,
+            fema_mappings=mappings,
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            created_by=row["created_by"],
+            updated_by=row["updated_by"],
+        )
+
+    def _validate_resource_type(self, resource_type: ResourceType) -> None:
+        if not resource_type.name.strip():
+            raise ValueError("Name is required.")
+        if not resource_type.category or resource_type.category not in RESOURCE_CATEGORIES:
+            raise ValueError("Category is required and must be a supported value.")
+        if not resource_type.source or resource_type.source not in RESOURCE_SOURCES:
+            raise ValueError("Source is required and must be a supported value.")
+        if float(resource_type.typical_quantity) < 0:
+            raise ValueError("Typical quantity cannot be negative.")
+
+    def _validate_component(self, component: ResourceTypeComponent) -> None:
+        if component.parent_resource_type_id == component.component_resource_type_id:
+            raise ValueError("A resource type cannot contain itself as a component.")
+        if float(component.quantity) <= 0:
+            raise ValueError("Component quantity must be greater than zero.")
+
+    def _would_create_cycle(
+        self, conn: sqlite3.Connection, parent_id: int, child_id: int
+    ) -> bool:
+        if parent_id == child_id:
+            return True
+        to_visit = [child_id]
+        seen: set[int] = set()
+        while to_visit:
+            current = to_visit.pop()
+            if current == parent_id:
+                return True
+            if current in seen:
+                continue
+            seen.add(current)
+            rows = conn.execute(
+                """
+                SELECT component_resource_type_id
+                FROM resource_type_components
+                WHERE parent_resource_type_id = ?
+                """,
+                (current,),
+            ).fetchall()
+            to_visit.extend(int(row[0]) for row in rows)
+        return False
+
+    def _next_copy_name(self, base_name: str) -> str:
+        candidate = f"{base_name} Copy"
+        with self._connect() as conn:
+            existing = {
+                row["name"].lower()
+                for row in conn.execute("SELECT name FROM resource_types").fetchall()
+            }
+        if candidate.lower() not in existing:
+            return candidate
+        suffix = 2
+        while f"{candidate} {suffix}".lower() in existing:
+            suffix += 1
+        return f"{candidate} {suffix}"
+
+    @staticmethod
+    def _clean_strings(values: Iterable[str]) -> list[str]:
+        seen: set[str] = set()
+        cleaned: list[str] = []
+        for value in values:
+            item = value.strip()
+            key = item.lower()
+            if item and key not in seen:
+                seen.add(key)
+                cleaned.append(item)
+        return cleaned

--- a/modules/admin/resource_types/models/__init__.py
+++ b/modules/admin/resource_types/models/__init__.py
@@ -1,0 +1,21 @@
+"""Model exports for the Resource Type Library."""
+
+from .resource_type_models import (
+    FemaNimsMapping,
+    RESOURCE_CATEGORIES,
+    RESOURCE_SOURCES,
+    ResourceCapability,
+    ResourceType,
+    ResourceTypeComponent,
+    ResourceTypeSearchResult,
+)
+
+__all__ = [
+    "FemaNimsMapping",
+    "RESOURCE_CATEGORIES",
+    "RESOURCE_SOURCES",
+    "ResourceCapability",
+    "ResourceType",
+    "ResourceTypeComponent",
+    "ResourceTypeSearchResult",
+]

--- a/modules/admin/resource_types/models/resource_type_models.py
+++ b/modules/admin/resource_types/models/resource_type_models.py
@@ -1,0 +1,125 @@
+"""Models and constants for the Resource Type Library.
+
+These dataclasses deliberately contain no Qt code.  Keeping the data shapes
+separate from the UI makes the Resource Type Library reusable by check-in,
+logistics, tasking, planning, tests, and future services.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+# The approved category values are kept in one place so repository validation,
+# combo boxes, and future modules all use the same spelling.
+RESOURCE_CATEGORIES: tuple[str, ...] = (
+    "Personnel",
+    "Team",
+    "Vehicle",
+    "Aircraft",
+    "Equipment",
+    "Equipment Kit / Cache",
+    "Facility",
+    "Supply",
+    "Communications",
+    "Other",
+)
+
+# Source values describe where a definition came from.  They are master-data
+# metadata; they do not create any demo records by themselves.
+RESOURCE_SOURCES: tuple[str, ...] = (
+    "FEMA/NIMS",
+    "AHJ Custom",
+    "Imported",
+    "Mutual Aid",
+    "Temporary / Incident Only",
+)
+
+
+@dataclass(slots=True)
+class ResourceCapability:
+    """A reusable capability tag that can be attached to resource types."""
+
+    name: str
+    category: str = ""
+    description: str = ""
+    aliases: list[str] = field(default_factory=list)
+    is_active: bool = True
+    notes: str = ""
+    id: Optional[int] = None
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass(slots=True)
+class ResourceTypeComponent:
+    """A child resource type and quantity contained in a kit/cache resource."""
+
+    parent_resource_type_id: int
+    component_resource_type_id: int
+    quantity: float = 1.0
+    unit: str = "each"
+    notes: str = ""
+    required: bool = True
+    id: Optional[int] = None
+    component_name: str = ""
+    component_category: str = ""
+
+
+@dataclass(slots=True)
+class FemaNimsMapping:
+    """Optional FEMA/NIMS reference fields for a resource type.
+
+    The existing names ``nims_name`` and ``type_code`` are retained for backward
+    compatibility with earlier code.  The editor presents them as FEMA/NIMS
+    resource name and FEMA/NIMS type.
+    """
+
+    resource_type_id: int
+    nims_name: str = ""
+    discipline: str = ""  # Displayed as FEMA/NIMS category in the editor.
+    type_code: str = ""  # Displayed as FEMA/NIMS type in the editor.
+    kind: str = ""
+    reference_url: str = ""
+    notes: str = ""
+    typed_level: str = ""
+    id: Optional[int] = None
+
+
+@dataclass(slots=True)
+class ResourceType:
+    """Master resource type definition stored in the master database."""
+
+    name: str
+    planning_display_name: str = ""
+    category: str = "Other"
+    source: str = "AHJ Custom"
+    owner_agency: str = ""
+    description: str = ""
+    default_unit: str = "each"
+    typical_quantity: float = 1.0
+    typical_team_size: Optional[int] = None
+    is_kit_cache: bool = False
+    is_consumable: bool = False
+    is_active: bool = True
+    notes: str = ""
+    aliases: list[str] = field(default_factory=list)
+    capability_ids: list[int] = field(default_factory=list)
+    components: list[ResourceTypeComponent] = field(default_factory=list)
+    fema_mappings: list[FemaNimsMapping] = field(default_factory=list)
+    id: Optional[int] = None
+    created_at: str = ""
+    updated_at: str = ""
+    created_by: str = ""
+    updated_by: str = ""
+
+
+@dataclass(slots=True)
+class ResourceTypeSearchResult:
+    """Lightweight row returned by the smart free-text lookup widget."""
+
+    resource_type_id: Optional[int]
+    resource_type_text: str
+    category: str = ""
+    source: str = ""
+    owner_agency: str = ""
+    matched_on: str = ""

--- a/modules/admin/resource_types/tests/test_resource_type_repository.py
+++ b/modules/admin/resource_types/tests/test_resource_type_repository.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from modules.admin.resource_types.data.resource_type_repository import ResourceTypeRepository
+from modules.admin.resource_types.models.resource_type_models import (
+    FemaNimsMapping,
+    ResourceCapability,
+    ResourceType,
+    ResourceTypeComponent,
+)
+
+
+def test_resource_type_crud_search_and_free_text_contract(tmp_path):
+    repo = ResourceTypeRepository(tmp_path / "master.db")
+    capability_id = repo.save_capability(
+        ResourceCapability(
+            name="Portable communications",
+            category="Communications",
+            description="Handheld radio support",
+            aliases=["radio comms"],
+            notes="Used by radio-heavy resources",
+        )
+    )
+    resource_id = repo.save_resource_type(
+        ResourceType(
+            name="Radio Cache",
+            planning_display_name="Radio Cache (6 radios)",
+            category="Equipment Kit / Cache",
+            source="AHJ Custom",
+            owner_agency="County SAR",
+            aliases=["radio kit"],
+            is_kit_cache=True,
+            is_consumable=False,
+            capability_ids=[capability_id],
+            fema_mappings=[
+                FemaNimsMapping(
+                    resource_type_id=0,
+                    kind="Communications",
+                    type_code="COMMS-CACHE",
+                    nims_name="Radio Cache",
+                    discipline="Communications",
+                    reference_url="https://example.invalid/reference-note",
+                )
+            ],
+        )
+    )
+
+    saved = repo.get_resource_type(resource_id)
+
+    assert saved is not None
+    assert saved.name == "Radio Cache"
+    assert saved.aliases == ["radio kit"]
+    assert saved.is_kit_cache is True
+    assert saved.is_consumable is False
+    assert saved.capability_ids == [capability_id]
+    assert repo.search_resource_types("radio comms")[0].resource_type_id == resource_id
+    assert repo.search_resource_types("County SAR")[0].resource_type_text == "Radio Cache (6 radios)"
+    assert repo.search_resource_types("COMMS-CACHE")[0].matched_on == "FEMA/NIMS mapping"
+
+    rows = repo.list_resource_types(category="Equipment Kit / Cache", source="AHJ Custom")
+    assert rows[0]["capabilities"] == "Portable communications"
+    assert rows[0]["is_kit_cache"] == 1
+
+
+def test_components_allow_nested_kits_but_reject_cycles(tmp_path):
+    repo = ResourceTypeRepository(tmp_path / "master.db")
+    cache_id = repo.save_resource_type(ResourceType(name="Radio Cache", category="Equipment Kit / Cache", is_kit_cache=True))
+    radio_id = repo.save_resource_type(ResourceType(name="Handheld Radio", category="Communications"))
+    battery_id = repo.save_resource_type(ResourceType(name="Spare Battery", category="Supply", is_consumable=True))
+
+    repo.add_component(
+        ResourceTypeComponent(
+            parent_resource_type_id=cache_id,
+            component_resource_type_id=radio_id,
+            quantity=6,
+            unit="each",
+            required=True,
+        )
+    )
+    repo.add_component(
+        ResourceTypeComponent(
+            parent_resource_type_id=radio_id,
+            component_resource_type_id=battery_id,
+            quantity=2,
+            unit="each",
+            required=False,
+        )
+    )
+
+    components = repo.list_components(cache_id)
+    assert components[0]["component_name"] == "Handheld Radio"
+    assert components[0]["required"] == 1
+    assert repo.would_create_cycle(battery_id, cache_id) is True
+    with pytest.raises(ValueError, match="circular"):
+        repo.add_component(
+            ResourceTypeComponent(
+                parent_resource_type_id=battery_id,
+                component_resource_type_id=cache_id,
+            )
+        )
+
+
+def test_clone_copies_children_and_schema_migrates_existing_tables(tmp_path):
+    db_path = tmp_path / "master.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE resource_types (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            planning_display_name TEXT NOT NULL DEFAULT '',
+            category TEXT NOT NULL DEFAULT 'Other',
+            source TEXT NOT NULL DEFAULT 'AHJ Custom',
+            owner_agency TEXT NOT NULL DEFAULT '',
+            description TEXT NOT NULL DEFAULT '',
+            default_unit TEXT NOT NULL DEFAULT 'each',
+            typical_quantity REAL NOT NULL DEFAULT 1,
+            typical_team_size INTEGER,
+            is_active INTEGER NOT NULL DEFAULT 1,
+            notes TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    repo = ResourceTypeRepository(db_path)
+    cache_id = repo.save_resource_type(ResourceType(name="Radio Cache", category="Equipment Kit / Cache", is_kit_cache=True))
+    radio_id = repo.save_resource_type(ResourceType(name="Handheld Radio", category="Communications"))
+    repo.replace_aliases(cache_id, ["radio kit"])
+    repo.replace_components(
+        cache_id,
+        [
+            ResourceTypeComponent(
+                parent_resource_type_id=cache_id,
+                component_resource_type_id=radio_id,
+                quantity=6,
+            )
+        ],
+    )
+
+    clone_id = repo.clone_resource_type(cache_id)
+    clone = repo.get_resource_type(clone_id)
+
+    assert clone is not None
+    assert clone.name == "Radio Cache Copy"
+    assert clone.aliases == ["radio kit"]
+    assert clone.components[0].component_resource_type_id == radio_id

--- a/modules/admin/resource_types/widgets/__init__.py
+++ b/modules/admin/resource_types/widgets/__init__.py
@@ -1,0 +1,5 @@
+"""Widget exports for the Resource Type Library."""
+
+from .resource_type_search_box import ResourceTypeSearchBox
+
+__all__ = ["ResourceTypeSearchBox"]

--- a/modules/admin/resource_types/widgets/resource_type_search_box.py
+++ b/modules/admin/resource_types/widgets/resource_type_search_box.py
@@ -1,0 +1,127 @@
+"""Reusable smart search widget for selecting or entering resource types."""
+from __future__ import annotations
+
+from typing import Optional
+
+from PySide6.QtCore import Qt, QStringListModel, QTimer, Signal
+from PySide6.QtWidgets import QCompleter, QHBoxLayout, QLineEdit, QWidget
+
+from ..data.resource_type_repository import ResourceTypeRepository
+from ..models.resource_type_models import ResourceTypeSearchResult
+
+
+class ResourceTypeSearchBox(QWidget):
+    """One-box resource type lookup with free-text fallback.
+
+    Store both values from this widget:
+    - ``resource_type_id`` identifies a library record when the user selected one.
+    - ``resource_type_text`` preserves exactly what the user typed when no record
+      exists or when free text is appropriate for the workflow.
+    """
+
+    resourceTypeSelected = Signal(object, str)
+    textChanged = Signal(str)
+
+    def __init__(
+        self,
+        repository: Optional[ResourceTypeRepository] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.repository = repository or ResourceTypeRepository()
+        self._resource_type_id: Optional[int] = None
+        self._results: list[ResourceTypeSearchResult] = []
+        self._display_to_result: dict[str, ResourceTypeSearchResult] = {}
+
+        self.line_edit = QLineEdit(self)
+        self.line_edit.setPlaceholderText("Search or enter resource type...")
+
+        self._model = QStringListModel(self)
+        self._completer = QCompleter(self._model, self)
+        self._completer.setCaseSensitivity(Qt.CaseInsensitive)
+        self._completer.setFilterMode(Qt.MatchContains)
+        self._completer.setCompletionMode(QCompleter.PopupCompletion)
+        self.line_edit.setCompleter(self._completer)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.line_edit)
+
+        # Debouncing avoids querying SQLite on every keystroke while the user is
+        # still typing, which keeps the widget responsive in large catalogs.
+        self._timer = QTimer(self)
+        self._timer.setInterval(150)
+        self._timer.setSingleShot(True)
+        self._timer.timeout.connect(self._refresh_results)
+
+        self.line_edit.textChanged.connect(self._on_text_changed)
+        self._completer.activated[str].connect(self._on_completion_selected)
+
+    @property
+    def resource_type_id(self) -> Optional[int]:
+        """Selected resource type ID, or ``None`` for free-text entries."""
+
+        return self._resource_type_id
+
+    @property
+    def resource_type_text(self) -> str:
+        """The selected display text or user-entered free text."""
+
+        return self.line_edit.text().strip()
+
+    def set_value(self, resource_type_id: Optional[int], resource_type_text: str) -> None:
+        """Set the widget value from a stored ID/text pair."""
+
+        self._resource_type_id = resource_type_id
+        self.line_edit.setText(resource_type_text or "")
+
+    def clear(self) -> None:  # type: ignore[override]
+        self._resource_type_id = None
+        self.line_edit.clear()
+
+    def _on_text_changed(self, text: str) -> None:
+        # Typing means the previous selected ID may no longer match the visible
+        # text, so clear it until the user picks another completion.
+        self._resource_type_id = None
+        self.textChanged.emit(text)
+        self._timer.start()
+
+    def _refresh_results(self) -> None:
+        query = self.line_edit.text().strip()
+        self._results = self.repository.search_resource_types(query) if query else []
+        display_values: list[str] = []
+        self._display_to_result.clear()
+        for result in self._results:
+            label = self._format_result(result)
+            display_values.append(label)
+            self._display_to_result[label] = result
+        if query and not self._results:
+            display_values.append(f"Use free text: {query}")
+        self._model.setStringList(display_values)
+        if display_values:
+            self._completer.complete()
+
+    def _on_completion_selected(self, display_text: str) -> None:
+        result = self._display_to_result.get(display_text)
+        if result is None:
+            # Free-text completion: keep ID empty and strip helper text.
+            text = display_text.removeprefix("Use free text: ").strip()
+            self._resource_type_id = None
+            self.line_edit.blockSignals(True)
+            self.line_edit.setText(text)
+            self.line_edit.blockSignals(False)
+            self.resourceTypeSelected.emit(None, text)
+            return
+        self.line_edit.blockSignals(True)
+        self.line_edit.setText(result.resource_type_text)
+        self.line_edit.blockSignals(False)
+        self._resource_type_id = result.resource_type_id
+        self.resourceTypeSelected.emit(result.resource_type_id, result.resource_type_text)
+
+    @staticmethod
+    def _format_result(result: ResourceTypeSearchResult) -> str:
+        # Example: "Radio Cache — Equipment Kit / Cache • AHJ Custom".
+        context = " • ".join(value for value in (result.category, result.source) if value)
+        if result.matched_on and result.matched_on not in {"name", "display name"}:
+            context = f"{context} • matched {result.matched_on}" if context else f"matched {result.matched_on}"
+        return f"{result.resource_type_text} — {context}" if context else result.resource_type_text

--- a/modules/admin/resource_types/windows/__init__.py
+++ b/modules/admin/resource_types/windows/__init__.py
@@ -1,0 +1,12 @@
+"""Window exports for the Resource Type Library."""
+
+from .capability_manager_window import CapabilityManagerWindow
+from .resource_type_editor_window import ResourceTypeEditorWindow
+from .resource_type_library_window import ResourceTypeLibraryWindow, open_resource_type_library
+
+__all__ = [
+    "CapabilityManagerWindow",
+    "ResourceTypeEditorWindow",
+    "ResourceTypeLibraryWindow",
+    "open_resource_type_library",
+]

--- a/modules/admin/resource_types/windows/capability_manager_window.py
+++ b/modules/admin/resource_types/windows/capability_manager_window.py
@@ -1,0 +1,206 @@
+"""QtWidgets capability manager for Resource Type Library tags."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QHBoxLayout,
+    QHeaderView,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..data.resource_type_repository import ResourceTypeRepository
+from ..models.resource_type_models import ResourceCapability
+
+
+class CapabilityEditorDialog(QDialog):
+    """Small form used for both creating and editing a capability tag."""
+
+    def __init__(self, capability: Optional[dict[str, Any]] = None, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Capability")
+        self.capability_id = int(capability["id"]) if capability else None
+
+        self.name_edit = QLineEdit(capability.get("name", "") if capability else "")
+        self.category_edit = QLineEdit(capability.get("category", "") if capability else "")
+        self.description_edit = QTextEdit(capability.get("description", "") if capability else "")
+        self.aliases_edit = QLineEdit(capability.get("aliases", "") if capability else "")
+        self.notes_edit = QTextEdit(capability.get("notes", "") if capability else "")
+        self.active_check = QCheckBox("Active")
+        self.active_check.setChecked(bool(capability.get("is_active", 1)) if capability else True)
+
+        form = QFormLayout()
+        form.addRow("Name", self.name_edit)
+        form.addRow("Category", self.category_edit)
+        form.addRow("Description", self.description_edit)
+        form.addRow("Aliases (; separated)", self.aliases_edit)
+        form.addRow("Notes", self.notes_edit)
+        form.addRow("Status", self.active_check)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self._validate_then_accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(form)
+        layout.addWidget(buttons)
+
+    def to_model(self) -> ResourceCapability:
+        """Convert the form into the repository dataclass."""
+
+        return ResourceCapability(
+            id=self.capability_id,
+            name=self.name_edit.text(),
+            category=self.category_edit.text(),
+            description=self.description_edit.toPlainText(),
+            aliases=[item.strip() for item in self.aliases_edit.text().split(";")],
+            is_active=self.active_check.isChecked(),
+            notes=self.notes_edit.toPlainText(),
+        )
+
+    def _validate_then_accept(self) -> None:
+        if not self.name_edit.text().strip():
+            QMessageBox.warning(self, "Capability", "Name is required.")
+            return
+        self.accept()
+
+
+class CapabilityManagerWindow(QDialog):
+    """Search, create, edit, deactivate, and reactivate capability tags."""
+
+    headers = ["Name", "Category", "Aliases", "Active", "Updated At"]
+
+    def __init__(
+        self,
+        repository: Optional[ResourceTypeRepository] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.repository = repository or ResourceTypeRepository()
+        self.setWindowTitle("Capability Manager")
+        self.resize(760, 480)
+
+        self.search_edit = QLineEdit()
+        self.search_edit.setPlaceholderText("Search capabilities, aliases, descriptions, or notes...")
+        self.include_inactive_check = QCheckBox("Include inactive")
+
+        self.table = QTableWidget(0, len(self.headers))
+        self.table.setHorizontalHeaderLabels(self.headers)
+        self.table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.table.setSelectionMode(QTableWidget.SingleSelection)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table.doubleClicked.connect(self._edit_selected)
+
+        new_button = QPushButton("New")
+        edit_button = QPushButton("Edit")
+        self.toggle_active_button = QPushButton("Deactivate")
+        close_button = QPushButton("Close")
+
+        new_button.clicked.connect(self._new_capability)
+        edit_button.clicked.connect(self._edit_selected)
+        self.toggle_active_button.clicked.connect(self._toggle_selected_active)
+        close_button.clicked.connect(self.accept)
+        self.search_edit.textChanged.connect(self.refresh)
+        self.include_inactive_check.toggled.connect(self.refresh)
+        self.table.itemSelectionChanged.connect(self._update_toggle_button)
+
+        filters = QHBoxLayout()
+        filters.addWidget(self.search_edit, 1)
+        filters.addWidget(self.include_inactive_check)
+
+        actions = QHBoxLayout()
+        actions.addWidget(new_button)
+        actions.addWidget(edit_button)
+        actions.addWidget(self.toggle_active_button)
+        actions.addStretch()
+        actions.addWidget(close_button)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(filters)
+        layout.addWidget(self.table)
+        layout.addLayout(actions)
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Reload the table from the repository using the current filters."""
+
+        rows = self.repository.list_capabilities(
+            self.search_edit.text(), self.include_inactive_check.isChecked()
+        )
+        self.table.setRowCount(0)
+        for capability in rows:
+            table_row = self.table.rowCount()
+            self.table.insertRow(table_row)
+            values = [
+                capability.get("name", ""),
+                capability.get("category", ""),
+                capability.get("aliases", ""),
+                "Yes" if capability.get("is_active") else "No",
+                capability.get("updated_at", ""),
+            ]
+            for column, value in enumerate(values):
+                item = QTableWidgetItem(str(value))
+                item.setFlags(item.flags() & ~Qt.ItemIsEditable)
+                if column == 0:
+                    item.setData(Qt.UserRole, capability)
+                self.table.setItem(table_row, column, item)
+        self._update_toggle_button()
+
+    def _selected_capability(self) -> Optional[dict[str, Any]]:
+        row = self.table.currentRow()
+        if row < 0:
+            return None
+        item = self.table.item(row, 0)
+        return item.data(Qt.UserRole) if item else None
+
+    def _new_capability(self) -> None:
+        dialog = CapabilityEditorDialog(parent=self)
+        if dialog.exec() == QDialog.Accepted:
+            self._save_dialog(dialog)
+
+    def _edit_selected(self) -> None:
+        capability = self._selected_capability()
+        if not capability:
+            QMessageBox.information(self, "Capability Manager", "Select a capability to edit.")
+            return
+        dialog = CapabilityEditorDialog(capability, self)
+        if dialog.exec() == QDialog.Accepted:
+            self._save_dialog(dialog)
+
+    def _save_dialog(self, dialog: CapabilityEditorDialog) -> None:
+        try:
+            self.repository.save_capability(dialog.to_model())
+            self.refresh()
+        except Exception as exc:
+            QMessageBox.warning(self, "Capability Manager", str(exc))
+
+    def _toggle_selected_active(self) -> None:
+        capability = self._selected_capability()
+        if not capability:
+            QMessageBox.information(self, "Capability Manager", "Select a capability first.")
+            return
+        capability_id = int(capability["id"])
+        if capability.get("is_active"):
+            self.repository.deactivate_capability(capability_id)
+        else:
+            self.repository.activate_capability(capability_id)
+        self.refresh()
+
+    def _update_toggle_button(self) -> None:
+        capability = self._selected_capability()
+        if capability and not capability.get("is_active"):
+            self.toggle_active_button.setText("Reactivate")
+        else:
+            self.toggle_active_button.setText("Deactivate")

--- a/modules/admin/resource_types/windows/resource_type_editor_window.py
+++ b/modules/admin/resource_types/windows/resource_type_editor_window.py
@@ -1,0 +1,538 @@
+"""QtWidgets editor dialog for Resource Type Library records."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..data.resource_type_repository import ResourceTypeRepository
+from ..models.resource_type_models import (
+    FemaNimsMapping,
+    RESOURCE_CATEGORIES,
+    RESOURCE_SOURCES,
+    ResourceType,
+    ResourceTypeComponent,
+)
+from ..widgets.resource_type_search_box import ResourceTypeSearchBox
+from .capability_manager_window import CapabilityManagerWindow
+
+
+class ComponentEditorDialog(QDialog):
+    """Dialog for adding one component row to a kit/cache resource type."""
+
+    def __init__(
+        self,
+        repository: ResourceTypeRepository,
+        parent_resource_type_id: Optional[int],
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.repository = repository
+        self.parent_resource_type_id = parent_resource_type_id
+        self.setWindowTitle("Add Component")
+
+        self.resource_search = ResourceTypeSearchBox(repository, self)
+        self.quantity_spin = QDoubleSpinBox()
+        self.quantity_spin.setRange(0.01, 999999.0)
+        self.quantity_spin.setDecimals(2)
+        self.quantity_spin.setValue(1.0)
+        self.required_check = QCheckBox("Required component")
+        self.required_check.setChecked(True)
+        self.notes_edit = QTextEdit()
+        self.notes_edit.setPlaceholderText("Optional component notes")
+
+        form = QFormLayout()
+        form.addRow("Component resource type", self.resource_search)
+        form.addRow("Quantity", self.quantity_spin)
+        form.addRow("Required", self.required_check)
+        form.addRow("Notes", self.notes_edit)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Add | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self._validate_then_accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(form)
+        layout.addWidget(buttons)
+
+    def to_component(self) -> ResourceTypeComponent:
+        """Return the chosen component after validation has succeeded."""
+
+        return ResourceTypeComponent(
+            parent_resource_type_id=self.parent_resource_type_id or 0,
+            component_resource_type_id=int(self.resource_search.resource_type_id or 0),
+            quantity=float(self.quantity_spin.value()),
+            required=self.required_check.isChecked(),
+            notes=self.notes_edit.toPlainText(),
+            component_name=self.resource_search.resource_type_text,
+        )
+
+    def _validate_then_accept(self) -> None:
+        component_id = self.resource_search.resource_type_id
+        if component_id is None:
+            QMessageBox.warning(
+                self,
+                "Component",
+                "Select an existing resource type for kit/cache components. Free text is allowed in other workflows, but components must reference library records.",
+            )
+            return
+        if self.parent_resource_type_id and int(component_id) == self.parent_resource_type_id:
+            QMessageBox.warning(
+                self, "Component", "A resource type cannot contain itself as a component."
+            )
+            return
+        if self.parent_resource_type_id and self.repository.would_create_cycle(
+            self.parent_resource_type_id, int(component_id)
+        ):
+            QMessageBox.warning(
+                self, "Component", "This component would create a circular kit/cache reference."
+            )
+            return
+        self.accept()
+
+
+class ResourceTypeEditorWindow(QDialog):
+    """Create/edit dialog for a single resource type.
+
+    The dialog gathers data only.  The main library window calls the repository
+    to save, which keeps database logic out of UI code.
+    """
+
+    component_headers = ["Component Resource Type", "Quantity", "Required", "Notes"]
+
+    def __init__(
+        self,
+        repository: ResourceTypeRepository,
+        resource_type: Optional[ResourceType] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.repository = repository
+        self.resource_type = resource_type
+        self._assigned_capability_ids: set[int] = set(resource_type.capability_ids if resource_type else [])
+        self.setWindowTitle("Edit Resource Type" if resource_type else "New Resource Type")
+        self.resize(860, 680)
+
+        self.tabs = QTabWidget()
+        self.tabs.addTab(self._build_basic_tab(), "Basic Info")
+        self.tabs.addTab(self._build_aliases_tab(), "Aliases")
+        self.tabs.addTab(self._build_capabilities_tab(), "Capabilities")
+        self.tabs.addTab(self._build_components_tab(), "Components / Kit Contents")
+        self.tabs.addTab(self._build_fema_tab(), "FEMA/NIMS Mapping")
+        self.tabs.addTab(self._build_audit_tab(), "Audit / Metadata")
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self._validate_then_accept)
+        buttons.rejected.connect(self.reject)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.tabs)
+        layout.addWidget(buttons)
+        self._refresh_capability_lists()
+        self._update_component_tab_state()
+
+    # ------------------------------------------------------------------
+    # Tab builders
+    # ------------------------------------------------------------------
+    def _build_basic_tab(self) -> QWidget:
+        record = self.resource_type
+        widget = QWidget()
+        self.name_edit = QLineEdit(record.name if record else "")
+        self.display_edit = QLineEdit(record.planning_display_name if record else "")
+        self.category_combo = QComboBox()
+        self.category_combo.addItems(RESOURCE_CATEGORIES)
+        self.source_combo = QComboBox()
+        self.source_combo.addItems(RESOURCE_SOURCES)
+        self.owner_edit = QLineEdit(record.owner_agency if record else "")
+        self.description_edit = QTextEdit(record.description if record else "")
+        self.default_unit_edit = QLineEdit(record.default_unit if record else "each")
+        self.quantity_spin = QDoubleSpinBox()
+        self.quantity_spin.setRange(0, 999999.0)
+        self.quantity_spin.setDecimals(2)
+        self.quantity_spin.setValue(record.typical_quantity if record else 1.0)
+        self.team_size_spin = QSpinBox()
+        self.team_size_spin.setRange(0, 10000)
+        self.team_size_spin.setSpecialValueText("Not set")
+        self.team_size_spin.setValue(record.typical_team_size or 0 if record else 0)
+        self.kit_check = QCheckBox("Is kit/cache")
+        self.kit_check.setChecked(record.is_kit_cache if record else False)
+        self.consumable_check = QCheckBox("Is consumable")
+        self.consumable_check.setChecked(record.is_consumable if record else False)
+        self.active_check = QCheckBox("Active")
+        self.active_check.setChecked(record.is_active if record else True)
+        self.notes_edit = QTextEdit(record.notes if record else "")
+
+        if record:
+            self.category_combo.setCurrentText(record.category)
+            self.source_combo.setCurrentText(record.source)
+
+        self.kit_check.toggled.connect(self._update_component_tab_state)
+
+        form = QFormLayout(widget)
+        form.addRow("Name", self.name_edit)
+        form.addRow("Planning display name", self.display_edit)
+        form.addRow("Category", self.category_combo)
+        form.addRow("Source", self.source_combo)
+        form.addRow("Owner agency", self.owner_edit)
+        form.addRow("Description", self.description_edit)
+        form.addRow("Default unit", self.default_unit_edit)
+        form.addRow("Typical quantity", self.quantity_spin)
+        form.addRow("Typical team size", self.team_size_spin)
+        form.addRow("Is kit/cache", self.kit_check)
+        form.addRow("Is consumable", self.consumable_check)
+        form.addRow("Active", self.active_check)
+        form.addRow("Notes", self.notes_edit)
+        return widget
+
+    def _build_aliases_tab(self) -> QWidget:
+        widget = QWidget()
+        self.alias_list = QListWidget()
+        for alias in self.resource_type.aliases if self.resource_type else []:
+            self.alias_list.addItem(alias)
+        self.alias_edit = QLineEdit()
+        self.alias_edit.setPlaceholderText("Add another name users might search for")
+        add_button = QPushButton("Add alias")
+        remove_button = QPushButton("Remove selected alias")
+        add_button.clicked.connect(self._add_alias)
+        remove_button.clicked.connect(lambda: self.alias_list.takeItem(self.alias_list.currentRow()))
+
+        row = QHBoxLayout()
+        row.addWidget(self.alias_edit, 1)
+        row.addWidget(add_button)
+        layout = QVBoxLayout(widget)
+        layout.addWidget(QLabel("Aliases improve search without creating duplicate resource types."))
+        layout.addLayout(row)
+        layout.addWidget(self.alias_list)
+        layout.addWidget(remove_button)
+        return widget
+
+    def _build_capabilities_tab(self) -> QWidget:
+        widget = QWidget()
+        self.capability_search = QLineEdit()
+        self.capability_search.setPlaceholderText("Search capability tags...")
+        self.available_capability_list = QListWidget()
+        self.assigned_capability_list = QListWidget()
+        add_button = QPushButton("Add →")
+        remove_button = QPushButton("← Remove")
+        manager_button = QPushButton("Open Capability Manager")
+        self.capability_search.textChanged.connect(self._refresh_capability_lists)
+        add_button.clicked.connect(self._assign_selected_capability)
+        remove_button.clicked.connect(self._remove_selected_capability)
+        manager_button.clicked.connect(self._open_capability_manager)
+
+        lists = QHBoxLayout()
+        left = QVBoxLayout()
+        left.addWidget(QLabel("Available capabilities"))
+        left.addWidget(self.available_capability_list)
+        middle = QVBoxLayout()
+        middle.addStretch()
+        middle.addWidget(add_button)
+        middle.addWidget(remove_button)
+        middle.addStretch()
+        right = QVBoxLayout()
+        right.addWidget(QLabel("Assigned to this resource type"))
+        right.addWidget(self.assigned_capability_list)
+        lists.addLayout(left, 1)
+        lists.addLayout(middle)
+        lists.addLayout(right, 1)
+
+        layout = QVBoxLayout(widget)
+        layout.addWidget(self.capability_search)
+        layout.addLayout(lists)
+        layout.addWidget(manager_button)
+        return widget
+
+    def _build_components_tab(self) -> QWidget:
+        widget = QWidget()
+        self.components_note = QLabel(
+            "Use this tab for kits/caches such as a radio cache. Components must be existing resource types."
+        )
+        self.component_table = QTableWidget(0, len(self.component_headers))
+        self.component_table.setHorizontalHeaderLabels(self.component_headers)
+        self.component_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.component_table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.component_table.setSelectionMode(QTableWidget.SingleSelection)
+
+        for component in self.resource_type.components if self.resource_type else []:
+            self._add_component_row(component)
+
+        self.add_component_button = QPushButton("Add component")
+        self.remove_component_button = QPushButton("Remove selected component")
+        self.add_component_button.clicked.connect(self._prompt_add_component)
+        self.remove_component_button.clicked.connect(self._remove_selected_component)
+
+        actions = QHBoxLayout()
+        actions.addWidget(self.add_component_button)
+        actions.addWidget(self.remove_component_button)
+        actions.addStretch()
+        layout = QVBoxLayout(widget)
+        layout.addWidget(self.components_note)
+        layout.addWidget(self.component_table)
+        layout.addLayout(actions)
+        return widget
+
+    def _build_fema_tab(self) -> QWidget:
+        mapping = self.resource_type.fema_mappings[0] if self.resource_type and self.resource_type.fema_mappings else None
+        widget = QWidget()
+        self.fema_name_edit = QLineEdit(mapping.nims_name if mapping else "")
+        self.fema_category_edit = QLineEdit(mapping.discipline if mapping else "")
+        self.fema_type_edit = QLineEdit(mapping.type_code if mapping else "")
+        self.fema_kind_edit = QLineEdit(mapping.kind if mapping else "")
+        self.fema_reference_edit = QLineEdit(mapping.reference_url if mapping else "")
+        self.fema_notes_edit = QTextEdit(mapping.notes if mapping else "")
+
+        form = QFormLayout(widget)
+        form.addRow("FEMA/NIMS resource name", self.fema_name_edit)
+        form.addRow("FEMA/NIMS category", self.fema_category_edit)
+        form.addRow("FEMA/NIMS type", self.fema_type_edit)
+        form.addRow("FEMA/NIMS kind", self.fema_kind_edit)
+        form.addRow("Reference URL or notes", self.fema_reference_edit)
+        form.addRow("Mapping notes", self.fema_notes_edit)
+        return widget
+
+    def _build_audit_tab(self) -> QWidget:
+        record = self.resource_type
+        widget = QWidget()
+        form = QFormLayout(widget)
+        for label, value in (
+            ("Created at", record.created_at if record else "Saved after creation"),
+            ("Updated at", record.updated_at if record else "Saved after creation"),
+            ("Created by", record.created_by if record else ""),
+            ("Updated by", record.updated_by if record else ""),
+        ):
+            edit = QLineEdit(value)
+            edit.setReadOnly(True)
+            form.addRow(label, edit)
+        return widget
+
+    # ------------------------------------------------------------------
+    # Aliases
+    # ------------------------------------------------------------------
+    def _add_alias(self) -> None:
+        alias = self.alias_edit.text().strip()
+        if not alias:
+            QMessageBox.information(self, "Aliases", "Enter an alias first.")
+            return
+        existing = {self.alias_list.item(index).text().lower() for index in range(self.alias_list.count())}
+        if alias.lower() in existing:
+            QMessageBox.information(self, "Aliases", "That alias is already listed.")
+            return
+        self.alias_list.addItem(alias)
+        self.alias_edit.clear()
+
+    # ------------------------------------------------------------------
+    # Capabilities
+    # ------------------------------------------------------------------
+    def _refresh_capability_lists(self) -> None:
+        if not hasattr(self, "available_capability_list"):
+            return
+        search_text = self.capability_search.text() if hasattr(self, "capability_search") else ""
+        self.available_capability_list.clear()
+        self.assigned_capability_list.clear()
+        for capability in self.repository.list_capabilities(search_text, include_inactive=True):
+            item = QListWidgetItem(f"{capability['name']} ({capability['category']})")
+            item.setData(Qt.UserRole, capability)
+            if int(capability["id"]) in self._assigned_capability_ids:
+                self.assigned_capability_list.addItem(item)
+            elif capability.get("is_active"):
+                self.available_capability_list.addItem(item)
+
+    def _assign_selected_capability(self) -> None:
+        item = self.available_capability_list.currentItem()
+        if not item:
+            return
+        self._assigned_capability_ids.add(int(item.data(Qt.UserRole)["id"]))
+        self._refresh_capability_lists()
+
+    def _remove_selected_capability(self) -> None:
+        item = self.assigned_capability_list.currentItem()
+        if not item:
+            return
+        self._assigned_capability_ids.discard(int(item.data(Qt.UserRole)["id"]))
+        self._refresh_capability_lists()
+
+    def _open_capability_manager(self) -> None:
+        CapabilityManagerWindow(self.repository, self).exec()
+        self._refresh_capability_lists()
+
+    # ------------------------------------------------------------------
+    # Components
+    # ------------------------------------------------------------------
+    def _update_component_tab_state(self) -> None:
+        if not hasattr(self, "component_table"):
+            return
+        enabled = self.kit_check.isChecked()
+        self.component_table.setEnabled(enabled)
+        self.add_component_button.setEnabled(enabled)
+        self.remove_component_button.setEnabled(enabled)
+        if enabled:
+            self.components_note.setText("Add the resource types contained in this kit/cache.")
+        else:
+            self.components_note.setText("Check 'Is kit/cache' on Basic Info to enable component editing.")
+
+    def _prompt_add_component(self) -> None:
+        dialog = ComponentEditorDialog(
+            self.repository,
+            self.resource_type.id if self.resource_type else None,
+            self,
+        )
+        if dialog.exec() == QDialog.Accepted:
+            component = dialog.to_component()
+            existing_ids = {
+                int(self.component_table.item(row, 0).data(Qt.UserRole))
+                for row in range(self.component_table.rowCount())
+                if self.component_table.item(row, 0)
+            }
+            if component.component_resource_type_id in existing_ids:
+                QMessageBox.information(self, "Components", "That component is already listed.")
+                return
+            self._add_component_row(component)
+
+    def _add_component_row(self, component: ResourceTypeComponent) -> None:
+        row = self.component_table.rowCount()
+        self.component_table.insertRow(row)
+        name_item = QTableWidgetItem(component.component_name or str(component.component_resource_type_id))
+        name_item.setData(Qt.UserRole, int(component.component_resource_type_id))
+        name_item.setFlags(name_item.flags() & ~Qt.ItemIsEditable)
+        self.component_table.setItem(row, 0, name_item)
+        self.component_table.setItem(row, 1, QTableWidgetItem(str(component.quantity)))
+        required_item = QTableWidgetItem("Yes" if component.required else "No")
+        required_item.setFlags(required_item.flags() & ~Qt.ItemIsEditable)
+        self.component_table.setItem(row, 2, required_item)
+        self.component_table.setItem(row, 3, QTableWidgetItem(component.notes))
+
+    def _remove_selected_component(self) -> None:
+        row = self.component_table.currentRow()
+        if row >= 0:
+            self.component_table.removeRow(row)
+
+    # ------------------------------------------------------------------
+    # Conversion and validation
+    # ------------------------------------------------------------------
+    def to_model(self) -> ResourceType:
+        """Convert all tabs into a ResourceType dataclass."""
+
+        aliases = [self.alias_list.item(index).text() for index in range(self.alias_list.count())]
+        mappings: list[FemaNimsMapping] = []
+        if any(
+            field.text().strip()
+            for field in (
+                self.fema_name_edit,
+                self.fema_category_edit,
+                self.fema_type_edit,
+                self.fema_kind_edit,
+                self.fema_reference_edit,
+            )
+        ) or self.fema_notes_edit.toPlainText().strip():
+            mappings.append(
+                FemaNimsMapping(
+                    resource_type_id=self.resource_type.id if self.resource_type else 0,
+                    nims_name=self.fema_name_edit.text(),
+                    discipline=self.fema_category_edit.text(),
+                    type_code=self.fema_type_edit.text(),
+                    kind=self.fema_kind_edit.text(),
+                    reference_url=self.fema_reference_edit.text(),
+                    notes=self.fema_notes_edit.toPlainText(),
+                )
+            )
+        return ResourceType(
+            id=self.resource_type.id if self.resource_type else None,
+            name=self.name_edit.text(),
+            planning_display_name=self.display_edit.text(),
+            category=self.category_combo.currentText(),
+            source=self.source_combo.currentText(),
+            owner_agency=self.owner_edit.text(),
+            description=self.description_edit.toPlainText(),
+            default_unit=self.default_unit_edit.text(),
+            typical_quantity=float(self.quantity_spin.value()),
+            typical_team_size=self.team_size_spin.value() or None,
+            is_kit_cache=self.kit_check.isChecked(),
+            is_consumable=self.consumable_check.isChecked(),
+            is_active=self.active_check.isChecked(),
+            notes=self.notes_edit.toPlainText(),
+            aliases=aliases,
+            capability_ids=sorted(self._assigned_capability_ids),
+            fema_mappings=mappings,
+            created_at=self.resource_type.created_at if self.resource_type else "",
+            updated_at=self.resource_type.updated_at if self.resource_type else "",
+            created_by=self.resource_type.created_by if self.resource_type else "",
+            updated_by=self.resource_type.updated_by if self.resource_type else "",
+        )
+
+    def components(self) -> list[ResourceTypeComponent]:
+        """Return component rows currently shown in the kit/cache table."""
+
+        if not self.kit_check.isChecked():
+            return []
+        components: list[ResourceTypeComponent] = []
+        parent_id = self.resource_type.id if self.resource_type else 0
+        for row in range(self.component_table.rowCount()):
+            name_item = self.component_table.item(row, 0)
+            quantity_item = self.component_table.item(row, 1)
+            if not name_item or not quantity_item:
+                continue
+            quantity = float(quantity_item.text())
+            components.append(
+                ResourceTypeComponent(
+                    parent_resource_type_id=parent_id,
+                    component_resource_type_id=int(name_item.data(Qt.UserRole)),
+                    component_name=name_item.text(),
+                    quantity=quantity,
+                    required=(self.component_table.item(row, 2).text() == "Yes"),
+                    notes=self.component_table.item(row, 3).text() if self.component_table.item(row, 3) else "",
+                )
+            )
+        return components
+
+    def _validate_then_accept(self) -> None:
+        if not self.name_edit.text().strip():
+            QMessageBox.warning(self, "Resource Type", "Name is required.")
+            self.tabs.setCurrentIndex(0)
+            return
+        if not self.category_combo.currentText().strip():
+            QMessageBox.warning(self, "Resource Type", "Category is required.")
+            self.tabs.setCurrentIndex(0)
+            return
+        if not self.source_combo.currentText().strip():
+            QMessageBox.warning(self, "Resource Type", "Source is required.")
+            self.tabs.setCurrentIndex(0)
+            return
+        try:
+            for component in self.components():
+                if component.quantity <= 0:
+                    raise ValueError("Component quantity must be greater than zero.")
+                if self.resource_type and component.component_resource_type_id == self.resource_type.id:
+                    raise ValueError("A resource type cannot contain itself as a component.")
+                if self.resource_type and self.repository.would_create_cycle(
+                    self.resource_type.id, component.component_resource_type_id
+                ):
+                    raise ValueError("A component would create a circular kit/cache reference.")
+        except ValueError as exc:
+            QMessageBox.warning(self, "Resource Type", str(exc))
+            self.tabs.setCurrentIndex(3)
+            return
+        self.accept()

--- a/modules/admin/resource_types/windows/resource_type_editor_window.py
+++ b/modules/admin/resource_types/windows/resource_type_editor_window.py
@@ -71,7 +71,7 @@ class ComponentEditorDialog(QDialog):
         form.addRow("Required", self.required_check)
         form.addRow("Notes", self.notes_edit)
 
-        buttons = QDialogButtonBox(QDialogButtonBox.Add | QDialogButtonBox.Cancel)
+        buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self._validate_then_accept)
         buttons.rejected.connect(self.reject)
 

--- a/modules/admin/resource_types/windows/resource_type_library_window.py
+++ b/modules/admin/resource_types/windows/resource_type_library_window.py
@@ -1,0 +1,279 @@
+"""QtWidgets admin window for the Resource Type Library."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt
+from PySide6.QtWidgets import (
+    QComboBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTableView,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..data.resource_type_repository import ResourceTypeRepository
+from ..models.resource_type_models import RESOURCE_CATEGORIES, RESOURCE_SOURCES
+from .capability_manager_window import CapabilityManagerWindow
+from .resource_type_editor_window import ResourceTypeEditorWindow
+
+
+class ResourceTypeTableModel(QAbstractTableModel):
+    """Table model for the main Resource Type Library browser."""
+
+    headers = [
+        "Name",
+        "Planning Display Name",
+        "Category",
+        "Source",
+        "Owner Agency",
+        "Capabilities",
+        "Kit/Cache",
+        "Active",
+        "Updated At",
+    ]
+    keys = [
+        "name",
+        "planning_display_name",
+        "category",
+        "source",
+        "owner_agency",
+        "capabilities",
+        "is_kit_cache",
+        "is_active",
+        "updated_at",
+    ]
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._records: list[dict[str, Any]] = []
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:  # type: ignore[override]
+        return 0 if parent.isValid() else len(self._records)
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:  # type: ignore[override]
+        return 0 if parent.isValid() else len(self.headers)
+
+    def headerData(self, section: int, orientation: Qt.Orientation, role: int = Qt.DisplayRole):  # type: ignore[override]
+        if role == Qt.DisplayRole and orientation == Qt.Horizontal:
+            return self.headers[section]
+        return None
+
+    def data(self, index: QModelIndex, role: int = Qt.DisplayRole):  # type: ignore[override]
+        if not index.isValid():
+            return None
+        record = self._records[index.row()]
+        key = self.keys[index.column()]
+        if role == Qt.DisplayRole:
+            if key == "is_kit_cache":
+                count = int(record.get("component_count") or 0)
+                if record.get("is_kit_cache"):
+                    return f"Yes ({count})" if count else "Yes"
+                return "No"
+            if key == "is_active":
+                return "Yes" if record.get(key) else "No"
+            return record.get(key, "")
+        if role == Qt.ToolTipRole and key == "capabilities":
+            return record.get("capabilities", "")
+        return None
+
+    def set_records(self, records: list[dict[str, Any]]) -> None:
+        self.beginResetModel()
+        self._records = records
+        self.endResetModel()
+
+    def record_at(self, row: int) -> Optional[dict[str, Any]]:
+        if 0 <= row < len(self._records):
+            return self._records[row]
+        return None
+
+
+class ResourceTypeLibraryWindow(QWidget):
+    """Standalone modeless admin window for resource type master data."""
+
+    def __init__(
+        self,
+        repository: Optional[ResourceTypeRepository] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.repository = repository or ResourceTypeRepository()
+        self.setWindowTitle("Resource Type Library")
+        self.resize(1120, 680)
+
+        # Filters are grouped at the top so users can narrow a large library
+        # without opening a separate advanced-search dialog.
+        self.search_edit = QLineEdit()
+        self.search_edit.setPlaceholderText(
+            "Search name, display name, aliases, category, capabilities, agency, or FEMA/NIMS mapping..."
+        )
+        self.category_filter = QComboBox()
+        self.category_filter.addItems(("All",) + RESOURCE_CATEGORIES)
+        self.source_filter = QComboBox()
+        self.source_filter.addItems(("All",) + RESOURCE_SOURCES)
+        self.active_filter = QComboBox()
+        self.active_filter.addItems(("Active", "Inactive", "All"))
+
+        self.table_model = ResourceTypeTableModel(self)
+        self.table = QTableView()
+        self.table.setModel(self.table_model)
+        self.table.setSelectionBehavior(QTableView.SelectRows)
+        self.table.setSelectionMode(QTableView.SingleSelection)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table.doubleClicked.connect(self._edit_selected)
+
+        new_button = QPushButton("New")
+        edit_button = QPushButton("Edit")
+        clone_button = QPushButton("Clone")
+        self.toggle_active_button = QPushButton("Deactivate")
+        refresh_button = QPushButton("Refresh")
+        capability_button = QPushButton("Capability Manager")
+        close_button = QPushButton("Close")
+
+        new_button.clicked.connect(self._new_resource_type)
+        edit_button.clicked.connect(self._edit_selected)
+        clone_button.clicked.connect(self._clone_selected)
+        self.toggle_active_button.clicked.connect(self._toggle_selected_active)
+        refresh_button.clicked.connect(self.refresh)
+        capability_button.clicked.connect(self._open_capability_manager)
+        close_button.clicked.connect(self.close)
+
+        self.search_edit.textChanged.connect(self.refresh)
+        self.category_filter.currentTextChanged.connect(self.refresh)
+        self.source_filter.currentTextChanged.connect(self.refresh)
+        self.active_filter.currentTextChanged.connect(self.refresh)
+        self.table.selectionModel().selectionChanged.connect(self._update_toggle_button)
+
+        filters = QHBoxLayout()
+        filters.addWidget(QLabel("Search"))
+        filters.addWidget(self.search_edit, 2)
+        filters.addWidget(QLabel("Category"))
+        filters.addWidget(self.category_filter)
+        filters.addWidget(QLabel("Source"))
+        filters.addWidget(self.source_filter)
+        filters.addWidget(QLabel("Status"))
+        filters.addWidget(self.active_filter)
+
+        actions = QHBoxLayout()
+        actions.addWidget(new_button)
+        actions.addWidget(edit_button)
+        actions.addWidget(clone_button)
+        actions.addWidget(self.toggle_active_button)
+        actions.addWidget(refresh_button)
+        actions.addStretch()
+        actions.addWidget(capability_button)
+        actions.addWidget(close_button)
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(filters)
+        layout.addWidget(self.table)
+        layout.addLayout(actions)
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Reload the main table using the visible filter controls."""
+
+        self.table_model.set_records(
+            self.repository.list_resource_types(
+                search_text=self.search_edit.text(),
+                category=self.category_filter.currentText(),
+                source=self.source_filter.currentText(),
+                active_filter=self.active_filter.currentText(),
+            )
+        )
+        self._update_toggle_button()
+
+    def _selected_record(self) -> Optional[dict[str, Any]]:
+        current = self.table.currentIndex()
+        if not current.isValid():
+            return None
+        return self.table_model.record_at(current.row())
+
+    def _new_resource_type(self) -> None:
+        dialog = ResourceTypeEditorWindow(self.repository, parent=self)
+        if dialog.exec() == ResourceTypeEditorWindow.Accepted:
+            self._save_editor(dialog)
+
+    def _edit_selected(self) -> None:
+        record = self._selected_record()
+        if not record:
+            QMessageBox.information(self, "Resource Type Library", "Select a resource type to edit.")
+            return
+        resource_type = self.repository.get_resource_type(int(record["id"]))
+        if resource_type is None:
+            QMessageBox.warning(self, "Resource Type Library", "The selected resource type no longer exists.")
+            self.refresh()
+            return
+        dialog = ResourceTypeEditorWindow(self.repository, resource_type, self)
+        if dialog.exec() == ResourceTypeEditorWindow.Accepted:
+            self._save_editor(dialog)
+
+    def _save_editor(self, dialog: ResourceTypeEditorWindow) -> None:
+        try:
+            resource_type = dialog.to_model()
+            components = dialog.components()
+            resource_type_id = self.repository.save_resource_type(resource_type)
+            self.repository.replace_components(resource_type_id, components)
+            self.refresh()
+        except Exception as exc:
+            QMessageBox.warning(self, "Resource Type Library", str(exc))
+
+    def _clone_selected(self) -> None:
+        record = self._selected_record()
+        if not record:
+            QMessageBox.information(self, "Resource Type Library", "Select a resource type to clone.")
+            return
+        try:
+            new_id = self.repository.clone_resource_type(int(record["id"]))
+            self.refresh()
+            QMessageBox.information(
+                self,
+                "Resource Type Library",
+                f"Cloned resource type. New record ID: {new_id}",
+            )
+        except Exception as exc:
+            QMessageBox.warning(self, "Resource Type Library", str(exc))
+
+    def _toggle_selected_active(self) -> None:
+        record = self._selected_record()
+        if not record:
+            QMessageBox.information(self, "Resource Type Library", "Select a resource type first.")
+            return
+        if record.get("is_active"):
+            self.repository.deactivate_resource_type(int(record["id"]))
+        else:
+            self.repository.activate_resource_type(int(record["id"]))
+        self.refresh()
+
+    def _open_capability_manager(self) -> None:
+        CapabilityManagerWindow(self.repository, self).exec()
+        self.refresh()
+
+    def _update_toggle_button(self) -> None:
+        record = self._selected_record()
+        if record and not record.get("is_active"):
+            self.toggle_active_button.setText("Reactivate")
+        else:
+            self.toggle_active_button.setText("Deactivate")
+
+
+def open_resource_type_library(parent: Optional[QWidget] = None) -> ResourceTypeLibraryWindow:
+    """Open a modeless Resource Type Library window and keep it referenced.
+
+    Main-menu code can call this helper later without duplicating construction
+    and lifetime-management details.  When a parent is provided, the window is
+    stored on the parent to prevent Python garbage collection from closing it.
+    """
+
+    window = ResourceTypeLibraryWindow(parent=parent)
+    if parent is not None:
+        setattr(parent, "_resource_type_library_window", window)
+    window.show()
+    window.raise_()
+    window.activateWindow()
+    return window


### PR DESCRIPTION
### Motivation
- Introduce a reusable Resource Type Library to store and manage master resource type definitions, capabilities, components, and FEMA/NIMS mappings in the master database for reuse across incidents.
- Provide a beginner-friendly, centralized SQLite repository for persistence and lightweight schema migration to keep SQL logic out of UI code.
- Offer UI components (Qt widgets/windows) for searching, editing, and administering resource types and capability tags while deferring PySide6 imports to avoid loading Qt in headless environments.

### Description
- Add dataclasses and constants in `modules/admin/resource_types/models/resource_type_models.py` to represent `ResourceType`, `ResourceCapability`, `ResourceTypeComponent`, `FemaNimsMapping`, and `ResourceTypeSearchResult` and export them via `models/__init__.py`.
- Implement `ResourceTypeRepository` in `modules/admin/resource_types/data/resource_type_repository.py` with schema creation/migration, CRUD for resource types and capabilities, component and FEMA/NIMS mapping management, smart full-text search helpers, and cycle-detection logic for components.
- Add Qt UI components: `ResourceTypeSearchBox` widget, `CapabilityManagerWindow`, `ResourceTypeEditorWindow`, and `ResourceTypeLibraryWindow` under `widgets/` and `windows/`, and expose lazy imports in `modules/admin/resource_types/__init__.py` so UI classes are imported only when used.
- Add unit tests in `modules/admin/resource_types/tests/test_resource_type_repository.py` covering repository CRUD, free-text search contract, component nesting and cycle rejection, cloning of resource types, and schema migration handling.

### Testing
- Ran the new unit tests with `pytest modules/admin/resource_types/tests/test_resource_type_repository.py`, which exercised save/get/search/clone/component flows and schema migration, and the tests passed.
- The tests covered: capability creation and association, free-text and smart search matching, nested components and cycle detection raising `ValueError`, and cloning behavior preserving aliases/components; all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a23660d77e4832ba6db77905ad4ee37)