### PR TITLE
Add incident organization management foundation

### DIFF
--- a/modules/command/incident_organization/__init__.py
+++ b/modules/command/incident_organization/__init__.py
@@ -1,0 +1,29 @@
+"""Incident Organization Management module."""
+from __future__ import annotations
+
+from .controller import IncidentOrganizationController
+
+__all__ = [
+    "IncidentOrganizationController",
+    "IncidentOrganizationPanel",
+    "get_incident_organization_panel",
+]
+
+
+def __getattr__(name: str):
+    if name == "IncidentOrganizationPanel":
+        from .panels.incident_organization_panel import IncidentOrganizationPanel
+
+        return IncidentOrganizationPanel
+    raise AttributeError(name)
+
+
+def get_incident_organization_panel(incident_id: str | None = None):
+    """Return the Qt Widgets panel for incident organization management."""
+
+    from .panels.incident_organization_panel import IncidentOrganizationPanel
+
+    panel = IncidentOrganizationPanel()
+    if incident_id:
+        panel.load(incident_id)
+    return panel

--- a/modules/command/incident_organization/controller.py
+++ b/modules/command/incident_organization/controller.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+"""Controller for incident organization management."""
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Iterable
+
+from .personnel_repo import PersonnelPoolRepository
+from .models import (
+    GeneratedFormSnapshot,
+    OrganizationPosition,
+    OrganizationWarning,
+    PositionAssignment,
+    PositionStatusSummary,
+)
+from .repository import IncidentOrganizationRepository
+
+
+DEFAULT_SPAN_OF_CONTROL_LIMIT = 7
+MIN_FILLED_ASSIGNMENTS = 1
+
+
+class IncidentOrganizationController:
+    """Coordinates position structure, staffing, warnings, and form payloads."""
+
+    def __init__(self, incident_id: str):
+        self.incident_id = str(incident_id)
+        self.repo = IncidentOrganizationRepository(self.incident_id)
+        self.personnel_repo = PersonnelPoolRepository()
+
+    # ------------------------------------------------------------------
+    def add_position(self, values: dict[str, object]) -> int:
+        """Create a position or organizational node from user-provided values."""
+
+        position = OrganizationPosition(
+            id=None,
+            incident_id=self.incident_id,
+            title=str(values.get("title", "")).strip(),
+            classification=str(values.get("classification", "position")).strip() or "position",
+            parent_position_id=self._optional_int(values.get("parent_position_id")),
+            operational_period=self._optional_text(values.get("operational_period")),
+            required_qualifications=self._qualification_list(values.get("required_qualifications")),
+            is_critical=bool(values.get("is_critical", False)),
+            is_custom=bool(values.get("is_custom", False)),
+            status=str(values.get("status", "active") or "active"),
+            sort_order=int(values.get("sort_order", 0) or 0),
+            notes=self._optional_text(values.get("notes")),
+        )
+        if not position.title:
+            raise ValueError("Position title is required")
+        return self.repo.upsert_position(position)
+
+    def update_position(self, position_id: int, values: dict[str, object]) -> int:
+        current = self.repo.get_position(position_id)
+        if current is None:
+            raise ValueError(f"Position {position_id} was not found")
+        updated = OrganizationPosition(
+            id=current.id,
+            incident_id=self.incident_id,
+            title=str(values.get("title", current.title)).strip(),
+            classification=str(values.get("classification", current.classification)).strip()
+            or current.classification,
+            parent_position_id=self._optional_int(
+                values.get("parent_position_id", current.parent_position_id)
+            ),
+            operational_period=self._optional_text(
+                values.get("operational_period", current.operational_period)
+            ),
+            required_qualifications=self._qualification_list(
+                values.get("required_qualifications", current.required_qualifications)
+            ),
+            is_critical=bool(values.get("is_critical", current.is_critical)),
+            is_custom=bool(values.get("is_custom", current.is_custom)),
+            status=str(values.get("status", current.status) or current.status),
+            sort_order=int(values.get("sort_order", current.sort_order) or 0),
+            notes=self._optional_text(values.get("notes", current.notes)),
+        )
+        if not updated.title:
+            raise ValueError("Position title is required")
+        return self.repo.upsert_position(updated)
+
+    def move_position(self, position_id: int, parent_position_id: int | None) -> None:
+        self.repo.move_position(position_id, parent_position_id)
+
+    def deactivate_position(self, position_id: int) -> None:
+        self.repo.deactivate_position(position_id)
+
+    def list_positions(self, include_inactive: bool = False) -> list[OrganizationPosition]:
+        return self.repo.list_positions(include_inactive=include_inactive)
+
+    def get_position(self, position_id: int) -> OrganizationPosition | None:
+        return self.repo.get_position(position_id)
+
+    # ------------------------------------------------------------------
+    def assign_person(self, position_id: int, values: dict[str, object]) -> tuple[int, list[OrganizationWarning]]:
+        """Assign personnel while preserving history and returning warnings.
+
+        Qualification issues are intentionally non-blocking so AHJ-specific
+        staffing decisions can proceed while still being visible to users.
+        """
+
+        assignment = PositionAssignment(
+            id=None,
+            incident_id=self.incident_id,
+            position_id=position_id,
+            personnel_id=self._optional_text(values.get("personnel_id")),
+            display_name=str(values.get("display_name", "")).strip(),
+            assignment_type=str(values.get("assignment_type", "primary") or "primary"),
+            start_time=self._optional_text(values.get("start_time")),
+            end_time=None,
+            operational_period=self._optional_text(values.get("operational_period")),
+            assigned_by=self._optional_text(values.get("assigned_by")),
+            notes=self._optional_text(values.get("notes")),
+        )
+        if not assignment.display_name:
+            raise ValueError("Assigned personnel name is required")
+        assignment_id = self.repo.add_assignment(assignment)
+        return assignment_id, self.qualification_warnings(position_id, assignment)
+
+    def remove_assignment(
+        self,
+        assignment_id: int,
+        *,
+        changed_by: str | None = None,
+        notes: str | None = None,
+    ) -> None:
+        self.repo.end_assignment(assignment_id, changed_by=changed_by, notes=notes)
+
+    def list_assignments(
+        self, position_id: int | None = None, *, active_only: bool = True
+    ) -> list[PositionAssignment]:
+        return self.repo.list_assignments(position_id, active_only=active_only)
+
+    def list_assignment_history(self, position_id: int | None = None):
+        return self.repo.list_assignment_history(position_id)
+
+    # ------------------------------------------------------------------
+    def staffing_summary(self) -> dict[int, PositionStatusSummary]:
+        positions = self.list_positions()
+        assignments = self.list_assignments(active_only=True)
+        by_position: dict[int, list[PositionAssignment]] = defaultdict(list)
+        for assignment in assignments:
+            by_position[assignment.position_id].append(assignment)
+
+        summary: dict[int, PositionStatusSummary] = {}
+        for position in positions:
+            current = by_position.get(position.id or 0, [])
+            warnings = self.position_warnings(position, current, positions)
+            if not current:
+                status = "vacant"
+            elif len(current) < MIN_FILLED_ASSIGNMENTS:
+                status = "partially filled"
+            elif (
+                any(a.assignment_type == "trainee" for a in current)
+                and len(current) == 1
+            ):
+                status = "partially filled"
+            else:
+                status = "filled"
+            summary[position.id or 0] = PositionStatusSummary(
+                position_id=position.id or 0,
+                staffing_status=status,
+                warnings=warnings,
+            )
+        return summary
+
+    def position_warnings(
+        self,
+        position: OrganizationPosition,
+        assignments: Iterable[PositionAssignment] | None = None,
+        positions: Iterable[OrganizationPosition] | None = None,
+    ) -> list[OrganizationWarning]:
+        assignment_list = list(
+            assignments if assignments is not None else self.list_assignments(position.id)
+        )
+        position_list = list(positions if positions is not None else self.list_positions())
+        warnings: list[OrganizationWarning] = []
+        if position.is_critical and not assignment_list:
+            warnings.append(
+                OrganizationWarning(
+                    level="warning",
+                    code="critical_vacancy",
+                    message=f"Critical position is vacant: {position.title}",
+                    position_id=position.id,
+                )
+            )
+        child_count = sum(
+            1 for item in position_list if item.parent_position_id == position.id
+        )
+        if child_count > DEFAULT_SPAN_OF_CONTROL_LIMIT:
+            warnings.append(
+                OrganizationWarning(
+                    level="warning",
+                    code="span_of_control",
+                    message=(
+                        f"{position.title} supervises {child_count} positions; "
+                        f"recommended maximum is {DEFAULT_SPAN_OF_CONTROL_LIMIT}."
+                    ),
+                    position_id=position.id,
+                )
+            )
+        for assignment in assignment_list:
+            warnings.extend(
+                self.qualification_warnings(position.id or 0, assignment, position)
+            )
+        return warnings
+
+    def qualification_warnings(
+        self,
+        position_id: int,
+        assignment: PositionAssignment,
+        position: OrganizationPosition | None = None,
+    ) -> list[OrganizationWarning]:
+        position = position or self.repo.get_position(position_id)
+        if position is None or not position.required_qualifications:
+            return []
+        # The current personnel catalog has inconsistent qualification storage.
+        # Until a common qualifications table is available, assignments are
+        # allowed and flagged for review instead of blocked.
+        return [
+            OrganizationWarning(
+                level="warning",
+                code="qualification_review",
+                message=(
+                    f"Review qualifications for {assignment.display_name}: "
+                    f"{', '.join(position.required_qualifications)} required."
+                ),
+                position_id=position_id,
+            )
+        ]
+
+    # ------------------------------------------------------------------
+    def personnel_pool(self, query: str) -> list[dict[str, object | None]]:
+        return self.personnel_repo.search_people(query)
+
+    def build_ics203_payload(self, operational_period: str | None = None) -> dict[str, object]:
+        """Return structured data ready for later ICS 203 rendering."""
+
+        return self._build_generated_payload("ICS_203", operational_period)
+
+    def build_ics207_payload(self, operational_period: str | None = None) -> dict[str, object]:
+        """Return nodes and edges ready for later ICS 207 chart rendering."""
+
+        payload = self._build_generated_payload("ICS_207", operational_period)
+        positions = payload["positions"]
+        payload["edges"] = [
+            {"parent_position_id": item["parent_position_id"], "position_id": item["id"]}
+            for item in positions
+            if item["parent_position_id"] is not None
+        ]
+        return payload
+
+    def save_generated_snapshot(self, form_type: str, payload: dict[str, object]) -> int:
+        snapshot = GeneratedFormSnapshot(
+            id=None,
+            incident_id=self.incident_id,
+            form_type=form_type,
+            generated_at=datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            operational_period=payload.get("operational_period"),
+            source_version=None,
+            payload=payload,
+        )
+        return self.repo.save_generated_snapshot(snapshot)
+
+    def _build_generated_payload(self, form_type: str, operational_period: str | None) -> dict[str, object]:
+        positions = self.list_positions()
+        if operational_period:
+            positions = [
+                item
+                for item in positions
+                if item.operational_period in (None, "", operational_period)
+            ]
+        assignments = self.list_assignments(active_only=True)
+        assignments_by_position: dict[int, list[dict[str, object | None]]] = defaultdict(list)
+        for assignment in assignments:
+            assignments_by_position[assignment.position_id].append(
+                {
+                    "id": assignment.id,
+                    "personnel_id": assignment.personnel_id,
+                    "display_name": assignment.display_name,
+                    "assignment_type": assignment.assignment_type,
+                    "start_time": assignment.start_time,
+                    "end_time": assignment.end_time,
+                    "operational_period": assignment.operational_period,
+                    "notes": assignment.notes,
+                }
+            )
+        return {
+            "form_type": form_type,
+            "incident_id": self.incident_id,
+            "operational_period": operational_period,
+            "positions": [
+                {
+                    "id": position.id,
+                    "title": position.title,
+                    "classification": position.classification,
+                    "parent_position_id": position.parent_position_id,
+                    "required_qualifications": position.required_qualifications,
+                    "is_critical": position.is_critical,
+                    "is_custom": position.is_custom,
+                    "status": position.status,
+                    "assignments": assignments_by_position.get(position.id or 0, []),
+                }
+                for position in positions
+            ],
+        }
+
+    @staticmethod
+    def _optional_int(value: object) -> int | None:
+        if value in (None, ""):
+            return None
+        return int(value)
+
+    @staticmethod
+    def _optional_text(value: object) -> str | None:
+        if value in (None, ""):
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @staticmethod
+    def _qualification_list(value: object) -> list[str]:
+        if value in (None, ""):
+            return []
+        if isinstance(value, (list, tuple, set)):
+            return [str(item).strip() for item in value if str(item).strip()]
+        return [item.strip() for item in str(value).split(",") if item.strip()]

--- a/modules/command/incident_organization/models.py
+++ b/modules/command/incident_organization/models.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+"""Data objects for incident organization management.
+
+The incident organization is the source of truth. ICS 203 and ICS 207 are
+produced later from these records instead of being stored as form-first data.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+ACTIVE_ASSIGNMENT_TYPES = {"primary", "deputy", "assistant", "trainee", "relief"}
+POSITION_STATUSES = {"active", "inactive"}
+
+
+@dataclass(slots=True)
+class OrganizationPosition:
+    """A position or organizational node in the incident structure."""
+
+    id: Optional[int]
+    incident_id: str
+    title: str
+    classification: str
+    parent_position_id: Optional[int] = None
+    operational_period: Optional[str] = None
+    required_qualifications: list[str] = field(default_factory=list)
+    is_critical: bool = False
+    is_custom: bool = False
+    status: str = "active"
+    sort_order: int = 0
+    notes: Optional[str] = None
+
+
+@dataclass(slots=True)
+class PositionAssignment:
+    """Personnel assignment to an organization position."""
+
+    id: Optional[int]
+    incident_id: str
+    position_id: int
+    personnel_id: Optional[str]
+    display_name: str
+    assignment_type: str = "primary"
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    operational_period: Optional[str] = None
+    assigned_by: Optional[str] = None
+    notes: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+@dataclass(slots=True)
+class AssignmentHistoryEntry:
+    """Audit-style assignment history record."""
+
+    id: Optional[int]
+    incident_id: str
+    assignment_id: Optional[int]
+    position_id: int
+    personnel_id: Optional[str]
+    display_name: str
+    assignment_type: str
+    action: str
+    effective_time: Optional[str]
+    operational_period: Optional[str]
+    changed_by: Optional[str]
+    notes: Optional[str] = None
+
+
+@dataclass(slots=True)
+class PositionRequirement:
+    """Qualification or staffing requirement attached to a position."""
+
+    id: Optional[int]
+    incident_id: str
+    position_id: int
+    qualification: str
+    is_required: bool = True
+    notes: Optional[str] = None
+
+
+@dataclass(slots=True)
+class OrganizationWarning:
+    """Non-blocking warning shown to planners and staffing users."""
+
+    level: str
+    code: str
+    message: str
+    position_id: Optional[int] = None
+
+
+@dataclass(slots=True)
+class PositionStatusSummary:
+    """Calculated status for a position."""
+
+    position_id: int
+    staffing_status: str
+    warnings: list[OrganizationWarning] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class GeneratedFormSnapshot:
+    """Metadata for generated ICS outputs derived from the organization."""
+
+    id: Optional[int]
+    incident_id: str
+    form_type: str
+    generated_at: str
+    operational_period: Optional[str]
+    source_version: Optional[str]
+    payload: dict[str, Any]

--- a/modules/command/incident_organization/panels/__init__.py
+++ b/modules/command/incident_organization/panels/__init__.py
@@ -1,0 +1,6 @@
+"""Qt Widgets panels for incident organization management."""
+from __future__ import annotations
+
+from .incident_organization_panel import IncidentOrganizationPanel
+
+__all__ = ["IncidentOrganizationPanel"]

--- a/modules/command/incident_organization/panels/incident_organization_panel.py
+++ b/modules/command/incident_organization/panels/incident_organization_panel.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+"""Qt Widgets foundation for Incident Organization Management."""
+
+from collections import defaultdict
+from typing import Optional
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QTextEdit,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from styles.colors import MUTED_TEXT
+from utils.app_signals import app_signals
+from utils.state import AppState
+
+from ..controller import IncidentOrganizationController
+from ..models import OrganizationPosition, PositionAssignment
+
+
+class PositionDialog(QDialog):
+    """Small editor for custom AHJ-defined organization positions."""
+
+    CLASSIFICATIONS = ["command", "section", "branch", "division", "group", "unit", "position"]
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        position: OrganizationPosition | None = None,
+        parent_position_id: int | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Position")
+        layout = QFormLayout(self)
+        self.title_edit = QLineEdit(position.title if position else "", self)
+        layout.addRow("Title", self.title_edit)
+        self.classification_combo = QComboBox(self)
+        self.classification_combo.addItems(self.CLASSIFICATIONS)
+        selected = position.classification if position else "position"
+        self.classification_combo.setCurrentText(selected if selected in self.CLASSIFICATIONS else "position")
+        layout.addRow("Classification", self.classification_combo)
+        self.parent_edit = QLineEdit(
+            str(position.parent_position_id if position else parent_position_id or ""), self
+        )
+        layout.addRow("Parent position ID", self.parent_edit)
+        self.period_edit = QLineEdit(position.operational_period if position else "", self)
+        layout.addRow("Operational period", self.period_edit)
+        quals = ", ".join(position.required_qualifications) if position else ""
+        self.qualifications_edit = QLineEdit(quals, self)
+        layout.addRow("Required qualifications", self.qualifications_edit)
+        self.critical_check = QCheckBox("Critical position", self)
+        self.critical_check.setChecked(bool(position.is_critical) if position else False)
+        layout.addRow("", self.critical_check)
+        self.custom_check = QCheckBox("Custom AHJ-defined title/structure", self)
+        self.custom_check.setChecked(True if position is None else bool(position.is_custom))
+        layout.addRow("", self.custom_check)
+        self.notes_edit = QTextEdit(position.notes if position and position.notes else "", self)
+        self.notes_edit.setMaximumHeight(80)
+        layout.addRow("Notes", self.notes_edit)
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+
+    def values(self) -> dict[str, object]:
+        parent_text = self.parent_edit.text().strip()
+        return {
+            "title": self.title_edit.text().strip(),
+            "classification": self.classification_combo.currentText(),
+            "parent_position_id": int(parent_text) if parent_text else None,
+            "operational_period": self.period_edit.text().strip(),
+            "required_qualifications": self.qualifications_edit.text().strip(),
+            "is_critical": self.critical_check.isChecked(),
+            "is_custom": self.custom_check.isChecked(),
+            "notes": self.notes_edit.toPlainText().strip(),
+        }
+
+
+class AssignmentDialog(QDialog):
+    """Dialog for assigning personnel to a selected position."""
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        personnel: dict[str, object | None] | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Assign Personnel")
+        layout = QFormLayout(self)
+        self.personnel_id_edit = QLineEdit(str((personnel or {}).get("id") or ""), self)
+        layout.addRow("Personnel ID", self.personnel_id_edit)
+        self.name_edit = QLineEdit(str((personnel or {}).get("name") or ""), self)
+        layout.addRow("Name", self.name_edit)
+        self.type_combo = QComboBox(self)
+        self.type_combo.addItems(["primary", "deputy", "assistant", "trainee", "relief"])
+        layout.addRow("Assignment type", self.type_combo)
+        self.period_edit = QLineEdit("", self)
+        layout.addRow("Operational period", self.period_edit)
+        self.assigned_by_edit = QLineEdit("", self)
+        layout.addRow("Assigned by", self.assigned_by_edit)
+        self.notes_edit = QTextEdit("", self)
+        self.notes_edit.setMaximumHeight(80)
+        layout.addRow("Notes", self.notes_edit)
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+
+    def values(self) -> dict[str, object]:
+        return {
+            "personnel_id": self.personnel_id_edit.text().strip(),
+            "display_name": self.name_edit.text().strip(),
+            "assignment_type": self.type_combo.currentText(),
+            "operational_period": self.period_edit.text().strip(),
+            "assigned_by": self.assigned_by_edit.text().strip(),
+            "notes": self.notes_edit.toPlainText().strip(),
+        }
+
+
+class IncidentOrganizationPanel(QWidget):
+    """Tree, detail, staffing, and generator support for incident organization."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("IncidentOrganizationPanel")
+        self.incident_id: Optional[str] = None
+        self.controller: Optional[IncidentOrganizationController] = None
+        self._positions_by_id: dict[int, OrganizationPosition] = {}
+        self._pool_rows: list[dict[str, object | None]] = []
+
+        root_layout = QVBoxLayout(self)
+        root_layout.setContentsMargins(6, 6, 6, 6)
+
+        toolbar = QHBoxLayout()
+        self.btn_add_position = QPushButton("Add Position…", self)
+        self.btn_add_position.clicked.connect(self._add_position)
+        toolbar.addWidget(self.btn_add_position)
+        self.btn_edit_position = QPushButton("Edit Position…", self)
+        self.btn_edit_position.clicked.connect(self._edit_position)
+        toolbar.addWidget(self.btn_edit_position)
+        self.btn_deactivate_position = QPushButton("Deactivate", self)
+        self.btn_deactivate_position.clicked.connect(self._deactivate_position)
+        toolbar.addWidget(self.btn_deactivate_position)
+        toolbar.addStretch(1)
+        self.btn_ics203 = QPushButton("Prepare ICS 203", self)
+        self.btn_ics203.clicked.connect(lambda: self._prepare_form("ICS_203"))
+        toolbar.addWidget(self.btn_ics203)
+        self.btn_ics207 = QPushButton("Prepare ICS 207", self)
+        self.btn_ics207.clicked.connect(lambda: self._prepare_form("ICS_207"))
+        toolbar.addWidget(self.btn_ics207)
+        root_layout.addLayout(toolbar)
+
+        splitter = QSplitter(Qt.Horizontal, self)
+        root_layout.addWidget(splitter, stretch=1)
+
+        self.tree = QTreeWidget(self)
+        self.tree.setHeaderLabels(["Organization", "Status"])
+        self.tree.itemSelectionChanged.connect(self._handle_tree_selection)
+        splitter.addWidget(self.tree)
+
+        center = QWidget(self)
+        center_layout = QVBoxLayout(center)
+        center_layout.setContentsMargins(0, 0, 0, 0)
+        self.detail_title = QLabel("Select a position", center)
+        self.detail_title.setStyleSheet("font-size: 16px; font-weight: 600;")
+        center_layout.addWidget(self.detail_title)
+        self.detail_meta = QLabel("", center)
+        self.detail_meta.setStyleSheet(f"color: {MUTED_TEXT};")
+        center_layout.addWidget(self.detail_meta)
+        self.status_label = QLabel("", center)
+        center_layout.addWidget(self.status_label)
+        self.warning_label = QLabel("", center)
+        self.warning_label.setWordWrap(True)
+        center_layout.addWidget(self.warning_label)
+        center_layout.addWidget(QLabel("Assigned Personnel", center))
+        self.assignments_table = QTableWidget(center)
+        self.assignments_table.setColumnCount(5)
+        self.assignments_table.setHorizontalHeaderLabels(
+            ["Name", "Type", "Start", "Operational Period", "Notes"]
+        )
+        self.assignments_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.assignments_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.assignments_table.horizontalHeader().setStretchLastSection(True)
+        center_layout.addWidget(self.assignments_table, stretch=1)
+        assignment_buttons = QHBoxLayout()
+        self.btn_assign_selected = QPushButton("Assign Selected", center)
+        self.btn_assign_selected.clicked.connect(self._assign_selected_person)
+        assignment_buttons.addWidget(self.btn_assign_selected)
+        self.btn_remove_assignment = QPushButton("Remove Assignment", center)
+        self.btn_remove_assignment.clicked.connect(self._remove_selected_assignment)
+        assignment_buttons.addWidget(self.btn_remove_assignment)
+        assignment_buttons.addStretch(1)
+        center_layout.addLayout(assignment_buttons)
+        splitter.addWidget(center)
+
+        right = QWidget(self)
+        right_layout = QVBoxLayout(right)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.addWidget(QLabel("Personnel Assignment Pool", right))
+        filter_row = QHBoxLayout()
+        self.personnel_search = QLineEdit(right)
+        self.personnel_search.setPlaceholderText("Search checked-in/available/qualified personnel")
+        filter_row.addWidget(self.personnel_search, stretch=1)
+        self.btn_search_personnel = QPushButton("Search", right)
+        self.btn_search_personnel.clicked.connect(self._search_personnel)
+        filter_row.addWidget(self.btn_search_personnel)
+        right_layout.addLayout(filter_row)
+        self.filter_checked_in = QCheckBox("Checked-in", right)
+        self.filter_available = QCheckBox("Available", right)
+        self.filter_qualified = QCheckBox("Qualified", right)
+        for checkbox in (self.filter_checked_in, self.filter_available, self.filter_qualified):
+            checkbox.setEnabled(False)
+            right_layout.addWidget(checkbox)
+        self.pool_table = QTableWidget(right)
+        self.pool_table.setColumnCount(4)
+        self.pool_table.setHorizontalHeaderLabels(["Name", "Callsign", "Agency", "Phone"])
+        self.pool_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.pool_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.pool_table.horizontalHeader().setStretchLastSection(True)
+        right_layout.addWidget(self.pool_table, stretch=1)
+        splitter.addWidget(right)
+        splitter.setStretchFactor(0, 2)
+        splitter.setStretchFactor(1, 3)
+        splitter.setStretchFactor(2, 2)
+
+        self._set_enabled(False)
+        self._init_incident_tracking()
+
+    # ------------------------------------------------------------------
+    def load(self, incident_id: str) -> None:
+        self.incident_id = str(incident_id)
+        self.controller = IncidentOrganizationController(self.incident_id)
+        self._refresh()
+        self._set_enabled(True)
+
+    def _ensure_controller(self) -> IncidentOrganizationController:
+        if self.controller is None:
+            if not self.incident_id:
+                raise RuntimeError("Incident must be loaded before managing organization")
+            self.controller = IncidentOrganizationController(self.incident_id)
+        return self.controller
+
+    def _init_incident_tracking(self) -> None:
+        active = self._active_incident_from_state()
+        if active:
+            self.load(active)
+        app_signals.incidentChanged.connect(self._handle_incident_changed)
+
+    @staticmethod
+    def _active_incident_from_state() -> str | None:
+        active = AppState.get_active_incident()
+        return str(active) if active else None
+
+    def _handle_incident_changed(self, incident_id: str) -> None:
+        if incident_id:
+            self.load(str(incident_id))
+
+    def _set_enabled(self, enabled: bool) -> None:
+        for button in (
+            self.btn_add_position,
+            self.btn_edit_position,
+            self.btn_deactivate_position,
+            self.btn_ics203,
+            self.btn_ics207,
+            self.btn_assign_selected,
+            self.btn_remove_assignment,
+            self.btn_search_personnel,
+        ):
+            button.setEnabled(enabled)
+
+    # ------------------------------------------------------------------
+    def _refresh(self) -> None:
+        self._refresh_tree()
+        self._handle_tree_selection()
+
+    def _refresh_tree(self) -> None:
+        controller = self._ensure_controller()
+        positions = controller.list_positions()
+        summary = controller.staffing_summary()
+        self._positions_by_id = {position.id or 0: position for position in positions}
+        children: dict[int | None, list[OrganizationPosition]] = defaultdict(list)
+        for position in positions:
+            children[position.parent_position_id].append(position)
+        self.tree.clear()
+
+        def add_items(parent_item: QTreeWidget | QTreeWidgetItem, parent_id: int | None) -> None:
+            for position in children.get(parent_id, []):
+                item_summary = summary.get(position.id or 0)
+                status = item_summary.staffing_status if item_summary else "unknown"
+                item = QTreeWidgetItem([position.title, status])
+                item.setData(0, Qt.UserRole, position.id)
+                if item_summary and item_summary.warnings:
+                    item.setToolTip(0, "\n".join(w.message for w in item_summary.warnings))
+                parent_item.addChild(item)
+                add_items(item, position.id)
+
+        add_items(self.tree.invisibleRootItem(), None)
+        self.tree.expandAll()
+
+    def _selected_position_id(self) -> int | None:
+        items = self.tree.selectedItems()
+        if not items:
+            return None
+        value = items[0].data(0, Qt.UserRole)
+        return int(value) if value else None
+
+    def _handle_tree_selection(self) -> None:
+        position_id = self._selected_position_id()
+        self.btn_edit_position.setEnabled(bool(position_id and self.incident_id))
+        self.btn_deactivate_position.setEnabled(bool(position_id and self.incident_id))
+        self.btn_assign_selected.setEnabled(bool(position_id and self.incident_id))
+        self.btn_remove_assignment.setEnabled(bool(position_id and self.incident_id))
+        if not position_id or self.controller is None:
+            self.detail_title.setText("Select a position")
+            self.detail_meta.setText("")
+            self.status_label.setText("")
+            self.warning_label.setText("")
+            self.assignments_table.setRowCount(0)
+            return
+        position = self.controller.get_position(position_id)
+        if position is None:
+            return
+        assignments = self.controller.list_assignments(position_id)
+        summary = self.controller.staffing_summary().get(position_id)
+        self.detail_title.setText(position.title)
+        self.detail_meta.setText(
+            f"{position.classification} | Parent: {position.parent_position_id or 'top level'} | "
+            f"Operational period: {position.operational_period or 'any'}"
+        )
+        critical = "Critical" if position.is_critical else "Standard"
+        self.status_label.setText(
+            f"Status: {(summary.staffing_status if summary else 'unknown')} | {critical} | "
+            f"Required: {', '.join(position.required_qualifications) or 'none'}"
+        )
+        warnings = summary.warnings if summary else []
+        self.warning_label.setText("\n".join(w.message for w in warnings))
+        self._populate_assignments(assignments)
+
+    def _populate_assignments(self, assignments: list[PositionAssignment]) -> None:
+        self.assignments_table.setRowCount(len(assignments))
+        for row, assignment in enumerate(assignments):
+            values = [
+                assignment.display_name,
+                assignment.assignment_type,
+                assignment.start_time or "",
+                assignment.operational_period or "",
+                assignment.notes or "",
+            ]
+            for col, value in enumerate(values):
+                item = QTableWidgetItem(value)
+                item.setData(Qt.UserRole, assignment.id)
+                self.assignments_table.setItem(row, col, item)
+
+    # ------------------------------------------------------------------
+    def _add_position(self) -> None:
+        if not self.incident_id:
+            QMessageBox.warning(
+                self,
+                "Incident Required",
+                "Load an incident before managing organization.",
+            )
+            return
+        dialog = PositionDialog(self, parent_position_id=self._selected_position_id())
+        if dialog.exec() == QDialog.Accepted:
+            try:
+                self._ensure_controller().add_position(dialog.values())
+            except ValueError as exc:
+                QMessageBox.warning(self, "Position", str(exc))
+                return
+            self._refresh()
+
+    def _edit_position(self) -> None:
+        position_id = self._selected_position_id()
+        if not position_id:
+            return
+        position = self._ensure_controller().get_position(position_id)
+        if position is None:
+            return
+        dialog = PositionDialog(self, position=position)
+        if dialog.exec() == QDialog.Accepted:
+            try:
+                self._ensure_controller().update_position(position_id, dialog.values())
+            except ValueError as exc:
+                QMessageBox.warning(self, "Position", str(exc))
+                return
+            self._refresh()
+
+    def _deactivate_position(self) -> None:
+        position_id = self._selected_position_id()
+        if not position_id:
+            return
+        self._ensure_controller().deactivate_position(position_id)
+        self._refresh()
+
+    def _search_personnel(self) -> None:
+        if self.controller is None:
+            return
+        self._pool_rows = self.controller.personnel_pool(self.personnel_search.text())
+        self.pool_table.setRowCount(len(self._pool_rows))
+        for row, person in enumerate(self._pool_rows):
+            values = [
+                str(person.get("name") or ""),
+                str(person.get("callsign") or ""),
+                str(person.get("agency") or ""),
+                str(person.get("phone") or ""),
+            ]
+            for col, value in enumerate(values):
+                item = QTableWidgetItem(value)
+                item.setData(Qt.UserRole, person.get("id"))
+                self.pool_table.setItem(row, col, item)
+
+    def _assign_selected_person(self) -> None:
+        position_id = self._selected_position_id()
+        if not position_id:
+            return
+        personnel = None
+        selected = self.pool_table.selectedItems()
+        if selected:
+            row = selected[0].row()
+            if 0 <= row < len(self._pool_rows):
+                personnel = self._pool_rows[row]
+        dialog = AssignmentDialog(self, personnel=personnel)
+        if dialog.exec() == QDialog.Accepted:
+            try:
+                _, warnings = self._ensure_controller().assign_person(
+                    position_id, dialog.values()
+                )
+            except ValueError as exc:
+                QMessageBox.warning(self, "Assignment", str(exc))
+                return
+            if warnings:
+                QMessageBox.warning(
+                    self,
+                    "Qualification Review",
+                    "\n".join(w.message for w in warnings),
+                )
+            self._refresh()
+
+    def _remove_selected_assignment(self) -> None:
+        selected = self.assignments_table.selectedItems()
+        if not selected:
+            return
+        assignment_id = selected[0].data(Qt.UserRole)
+        if assignment_id:
+            self._ensure_controller().remove_assignment(int(assignment_id))
+            self._refresh()
+
+    def _prepare_form(self, form_type: str) -> None:
+        controller = self._ensure_controller()
+        payload = (
+            controller.build_ics207_payload()
+            if form_type == "ICS_207"
+            else controller.build_ics203_payload()
+        )
+        controller.save_generated_snapshot(form_type, payload)
+        QMessageBox.information(
+            self,
+            "Generated Output Prepared",
+            f"{form_type.replace('_', ' ')} data was prepared from the incident organization.",
+        )

--- a/modules/command/incident_organization/personnel_repo.py
+++ b/modules/command/incident_organization/personnel_repo.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Read-only personnel lookup for organization assignments."""
+
+import sqlite3
+from typing import Callable, Iterable, Sequence
+
+from utils.db import get_master_conn
+
+
+class PersonnelPoolRepository:
+    """Searches existing personnel data without owning personnel records."""
+
+    def __init__(self, connection_factory: Callable[[], sqlite3.Connection] | None = None):
+        self._factory = connection_factory
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._factory is not None:
+            return self._factory()
+        return get_master_conn()
+
+    @staticmethod
+    def _personnel_columns(conn: sqlite3.Connection) -> set[str]:
+        try:
+            rows = conn.execute("PRAGMA table_info(personnel)").fetchall()
+        except sqlite3.OperationalError:
+            return set()
+        return {str(row[1]).lower() for row in rows}
+
+    @staticmethod
+    def _searchable_columns(columns: Iterable[str]) -> list[str]:
+        preferred = ["name", "callsign", "home_unit", "unit", "agency", "contact", "id"]
+        lowered = {column.lower() for column in columns}
+        return [column for column in preferred if column.lower() in lowered]
+
+    @staticmethod
+    def _row_to_result(row: sqlite3.Row) -> dict[str, object | None]:
+        lowered = {str(key).lower(): row[key] for key in row.keys()}
+
+        def coalesce(options: Sequence[str]) -> object | None:
+            fallback: object | None = None
+            for name in options:
+                key = name.lower()
+                if key in lowered:
+                    value = lowered[key]
+                    if value not in (None, ""):
+                        return value
+                    if fallback is None:
+                        fallback = value
+            return fallback
+
+        return {
+            "id": coalesce(("id", "person_id", "personnel_id")),
+            "name": coalesce(("name", "full_name", "display_name")),
+            "callsign": coalesce(("callsign", "call_sign")),
+            "phone": coalesce(("phone", "contact", "phone_number")),
+            "agency": coalesce(("home_unit", "unit", "agency", "department")),
+        }
+
+    def search_people(self, query: str, limit: int = 25) -> list[dict[str, object | None]]:
+        term = query.strip()
+        if len(term) < 2:
+            return []
+        like = f"%{term.lower()}%"
+        try:
+            with self._connect() as conn:
+                conn.row_factory = sqlite3.Row
+                columns = self._personnel_columns(conn)
+                if not columns:
+                    return []
+                search_columns = self._searchable_columns(columns)
+                if not search_columns:
+                    return []
+                order_column = "name" if "name" in columns else search_columns[0]
+                conditions = [
+                    f"LOWER(COALESCE(CAST({column} AS TEXT), '')) LIKE ?"
+                    for column in search_columns
+                ]
+                rows = conn.execute(
+                    f"SELECT * FROM personnel WHERE {' OR '.join(conditions)} "
+                    f"ORDER BY {order_column} LIMIT ?",
+                    [like] * len(search_columns) + [limit],
+                ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+        return [self._row_to_result(row) for row in rows]

--- a/modules/command/incident_organization/repository.py
+++ b/modules/command/incident_organization/repository.py
@@ -1,0 +1,535 @@
+from __future__ import annotations
+
+"""SQLite repository for incident organization management."""
+
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from .models import (
+    ACTIVE_ASSIGNMENT_TYPES,
+    AssignmentHistoryEntry,
+    GeneratedFormSnapshot,
+    OrganizationPosition,
+    PositionAssignment,
+)
+
+
+def _data_dir() -> Path:
+    return Path(os.environ.get("CHECKIN_DATA_DIR", "data"))
+
+
+def _incident_db_path(incident_id: str) -> Path:
+    safe_id = str(incident_id).strip().replace("/", "-")
+    if not safe_id:
+        raise ValueError("incident identifier must not be empty")
+    base = _data_dir() / "incidents"
+    base.mkdir(parents=True, exist_ok=True)
+    return base / f"{safe_id}.db"
+
+
+def get_incident_connection(incident_id: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(_incident_db_path(incident_id))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _qualification_text(values: Sequence[str] | str | None) -> str:
+    if values is None:
+        return "[]"
+    if isinstance(values, str):
+        values = [v.strip() for v in values.split(",") if v.strip()]
+    return json.dumps(list(values))
+
+
+def _qualification_list(value: str | None) -> list[str]:
+    if not value:
+        return []
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return [part.strip() for part in value.split(",") if part.strip()]
+    return [str(item) for item in parsed if str(item).strip()]
+
+
+class IncidentOrganizationRepository:
+    """Persists the incident organization as structured data."""
+
+    def __init__(self, incident_id: str):
+        self.incident_id = str(incident_id)
+        self.ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        return get_incident_connection(self.incident_id)
+
+    def ensure_schema(self) -> None:
+        """Create organization management tables for the incident database."""
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS organization_positions (
+                    id INTEGER PRIMARY KEY,
+                    incident_id TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    classification TEXT NOT NULL DEFAULT 'position',
+                    parent_position_id INTEGER,
+                    operational_period TEXT,
+                    required_qualifications TEXT NOT NULL DEFAULT '[]',
+                    is_critical INTEGER NOT NULL DEFAULT 0,
+                    is_custom INTEGER NOT NULL DEFAULT 0,
+                    status TEXT NOT NULL DEFAULT 'active',
+                    sort_order INTEGER NOT NULL DEFAULT 0,
+                    notes TEXT,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY(parent_position_id)
+                        REFERENCES organization_positions(id) ON DELETE SET NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_org_positions_incident_parent
+                ON organization_positions(incident_id, parent_position_id, status)
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS position_assignments (
+                    id INTEGER PRIMARY KEY,
+                    incident_id TEXT NOT NULL,
+                    position_id INTEGER NOT NULL,
+                    personnel_id TEXT,
+                    display_name TEXT NOT NULL,
+                    assignment_type TEXT NOT NULL DEFAULT 'primary',
+                    start_time TEXT,
+                    end_time TEXT,
+                    operational_period TEXT,
+                    assigned_by TEXT,
+                    notes TEXT,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY(position_id)
+                        REFERENCES organization_positions(id) ON DELETE CASCADE
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_position_assignments_active
+                ON position_assignments(incident_id, position_id, end_time)
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS position_assignment_history (
+                    id INTEGER PRIMARY KEY,
+                    incident_id TEXT NOT NULL,
+                    assignment_id INTEGER,
+                    position_id INTEGER NOT NULL,
+                    personnel_id TEXT,
+                    display_name TEXT NOT NULL,
+                    assignment_type TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    effective_time TEXT,
+                    operational_period TEXT,
+                    changed_by TEXT,
+                    notes TEXT,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_position_assignment_history_position
+                ON position_assignment_history(incident_id, position_id, created_at)
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS position_requirements (
+                    id INTEGER PRIMARY KEY,
+                    incident_id TEXT NOT NULL,
+                    position_id INTEGER NOT NULL,
+                    qualification TEXT NOT NULL,
+                    is_required INTEGER NOT NULL DEFAULT 1,
+                    notes TEXT,
+                    FOREIGN KEY(position_id)
+                        REFERENCES organization_positions(id) ON DELETE CASCADE
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS organization_templates (
+                    id INTEGER PRIMARY KEY,
+                    incident_id TEXT,
+                    name TEXT NOT NULL,
+                    description TEXT,
+                    payload TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS generated_form_snapshots (
+                    id INTEGER PRIMARY KEY,
+                    incident_id TEXT NOT NULL,
+                    form_type TEXT NOT NULL,
+                    generated_at TEXT NOT NULL,
+                    operational_period TEXT,
+                    source_version TEXT,
+                    payload TEXT NOT NULL
+                )
+                """
+            )
+
+    # ------------------------------------------------------------------
+    def upsert_position(self, position: OrganizationPosition) -> int:
+        qualifications = _qualification_text(position.required_qualifications)
+        now = _utc_now()
+        with self._connect() as conn:
+            if position.id is None:
+                cur = conn.execute(
+                    """
+                    INSERT INTO organization_positions (
+                        incident_id, title, classification, parent_position_id,
+                        operational_period, required_qualifications, is_critical,
+                        is_custom, status, sort_order, notes, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        self.incident_id,
+                        position.title,
+                        position.classification,
+                        position.parent_position_id,
+                        position.operational_period,
+                        qualifications,
+                        int(position.is_critical),
+                        int(position.is_custom),
+                        position.status,
+                        position.sort_order,
+                        position.notes,
+                        now,
+                        now,
+                    ),
+                )
+                return int(cur.lastrowid)
+            conn.execute(
+                """
+                UPDATE organization_positions
+                SET title=?, classification=?, parent_position_id=?,
+                    operational_period=?, required_qualifications=?, is_critical=?,
+                    is_custom=?, status=?, sort_order=?, notes=?, updated_at=?
+                WHERE id=? AND incident_id=?
+                """,
+                (
+                    position.title,
+                    position.classification,
+                    position.parent_position_id,
+                    position.operational_period,
+                    qualifications,
+                    int(position.is_critical),
+                    int(position.is_custom),
+                    position.status,
+                    position.sort_order,
+                    position.notes,
+                    now,
+                    position.id,
+                    self.incident_id,
+                ),
+            )
+            return int(position.id)
+
+    def list_positions(self, include_inactive: bool = False) -> list[OrganizationPosition]:
+        sql = "SELECT * FROM organization_positions WHERE incident_id=?"
+        params: list[object] = [self.incident_id]
+        if not include_inactive:
+            sql += " AND status='active'"
+        sql += " ORDER BY parent_position_id IS NOT NULL, sort_order, title"
+        with self._connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [self._row_to_position(row) for row in rows]
+
+    def get_position(self, position_id: int) -> OrganizationPosition | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM organization_positions WHERE id=? AND incident_id=?",
+                (position_id, self.incident_id),
+            ).fetchone()
+        return self._row_to_position(row) if row else None
+
+    def move_position(self, position_id: int, parent_position_id: int | None) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE organization_positions
+                SET parent_position_id=?, updated_at=?
+                WHERE id=? AND incident_id=?
+                """,
+                (parent_position_id, _utc_now(), position_id, self.incident_id),
+            )
+
+    def deactivate_position(self, position_id: int) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE organization_positions
+                SET status='inactive', updated_at=?
+                WHERE id=? AND incident_id=?
+                """,
+                (_utc_now(), position_id, self.incident_id),
+            )
+
+    # ------------------------------------------------------------------
+    def add_assignment(self, assignment: PositionAssignment) -> int:
+        assignment_type = assignment.assignment_type.lower().strip() or "primary"
+        if assignment_type not in ACTIVE_ASSIGNMENT_TYPES:
+            raise ValueError(f"Unsupported assignment type: {assignment.assignment_type}")
+        now = _utc_now()
+        start_time = assignment.start_time or now
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO position_assignments (
+                    incident_id, position_id, personnel_id, display_name,
+                    assignment_type, start_time, end_time, operational_period,
+                    assigned_by, notes, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self.incident_id,
+                    assignment.position_id,
+                    assignment.personnel_id,
+                    assignment.display_name,
+                    assignment_type,
+                    start_time,
+                    assignment.end_time,
+                    assignment.operational_period,
+                    assignment.assigned_by,
+                    assignment.notes,
+                    now,
+                    now,
+                ),
+            )
+            assignment_id = int(cur.lastrowid)
+            self._insert_history(
+                conn,
+                AssignmentHistoryEntry(
+                    id=None,
+                    incident_id=self.incident_id,
+                    assignment_id=assignment_id,
+                    position_id=assignment.position_id,
+                    personnel_id=assignment.personnel_id,
+                    display_name=assignment.display_name,
+                    assignment_type=assignment_type,
+                    action="assigned",
+                    effective_time=start_time,
+                    operational_period=assignment.operational_period,
+                    changed_by=assignment.assigned_by,
+                    notes=assignment.notes,
+                ),
+            )
+            return assignment_id
+
+    def end_assignment(
+        self,
+        assignment_id: int,
+        *,
+        end_time: str | None = None,
+        changed_by: str | None = None,
+        notes: str | None = None,
+    ) -> None:
+        effective = end_time or _utc_now()
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM position_assignments WHERE id=? AND incident_id=?",
+                (assignment_id, self.incident_id),
+            ).fetchone()
+            if row is None:
+                return
+            conn.execute(
+                """
+                UPDATE position_assignments
+                SET end_time=?, updated_at=?, notes=COALESCE(?, notes)
+                WHERE id=? AND incident_id=?
+                """,
+                (effective, _utc_now(), notes, assignment_id, self.incident_id),
+            )
+            self._insert_history(
+                conn,
+                AssignmentHistoryEntry(
+                    id=None,
+                    incident_id=self.incident_id,
+                    assignment_id=assignment_id,
+                    position_id=int(row["position_id"]),
+                    personnel_id=row["personnel_id"],
+                    display_name=row["display_name"],
+                    assignment_type=row["assignment_type"],
+                    action="removed",
+                    effective_time=effective,
+                    operational_period=row["operational_period"],
+                    changed_by=changed_by,
+                    notes=notes,
+                ),
+            )
+
+    def list_assignments(
+        self, position_id: int | None = None, *, active_only: bool = True
+    ) -> list[PositionAssignment]:
+        sql = "SELECT * FROM position_assignments WHERE incident_id=?"
+        params: list[object] = [self.incident_id]
+        if position_id is not None:
+            sql += " AND position_id=?"
+            params.append(position_id)
+        if active_only:
+            sql += " AND end_time IS NULL"
+        sql += " ORDER BY position_id, start_time, id"
+        with self._connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [self._row_to_assignment(row) for row in rows]
+
+    def list_assignment_history(
+        self, position_id: int | None = None
+    ) -> list[AssignmentHistoryEntry]:
+        sql = "SELECT * FROM position_assignment_history WHERE incident_id=?"
+        params: list[object] = [self.incident_id]
+        if position_id is not None:
+            sql += " AND position_id=?"
+            params.append(position_id)
+        sql += " ORDER BY created_at, id"
+        with self._connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [self._row_to_history(row) for row in rows]
+
+    def replace_requirements(self, position_id: int, qualifications: Iterable[str]) -> None:
+        clean = [q.strip() for q in qualifications if q and q.strip()]
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM position_requirements WHERE incident_id=? AND position_id=?",
+                (self.incident_id, position_id),
+            )
+            for qualification in clean:
+                conn.execute(
+                    """
+                    INSERT INTO position_requirements (
+                        incident_id, position_id, qualification, is_required
+                    ) VALUES (?, ?, ?, 1)
+                    """,
+                    (self.incident_id, position_id, qualification),
+                )
+            conn.execute(
+                """
+                UPDATE organization_positions
+                SET required_qualifications=?, updated_at=?
+                WHERE id=? AND incident_id=?
+                """,
+                (_qualification_text(clean), _utc_now(), position_id, self.incident_id),
+            )
+
+    def save_generated_snapshot(self, snapshot: GeneratedFormSnapshot) -> int:
+        with self._connect() as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO generated_form_snapshots (
+                    incident_id, form_type, generated_at, operational_period,
+                    source_version, payload
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    self.incident_id,
+                    snapshot.form_type,
+                    snapshot.generated_at,
+                    snapshot.operational_period,
+                    snapshot.source_version,
+                    json.dumps(snapshot.payload),
+                ),
+            )
+            return int(cur.lastrowid)
+
+    # ------------------------------------------------------------------
+    def _insert_history(self, conn: sqlite3.Connection, entry: AssignmentHistoryEntry) -> None:
+        conn.execute(
+            """
+            INSERT INTO position_assignment_history (
+                incident_id, assignment_id, position_id, personnel_id,
+                display_name, assignment_type, action, effective_time,
+                operational_period, changed_by, notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                self.incident_id,
+                entry.assignment_id,
+                entry.position_id,
+                entry.personnel_id,
+                entry.display_name,
+                entry.assignment_type,
+                entry.action,
+                entry.effective_time,
+                entry.operational_period,
+                entry.changed_by,
+                entry.notes,
+            ),
+        )
+
+    @staticmethod
+    def _row_to_position(row: sqlite3.Row) -> OrganizationPosition:
+        return OrganizationPosition(
+            id=int(row["id"]),
+            incident_id=row["incident_id"],
+            title=row["title"],
+            classification=row["classification"],
+            parent_position_id=row["parent_position_id"],
+            operational_period=row["operational_period"],
+            required_qualifications=_qualification_list(row["required_qualifications"]),
+            is_critical=bool(row["is_critical"]),
+            is_custom=bool(row["is_custom"]),
+            status=row["status"],
+            sort_order=int(row["sort_order"] or 0),
+            notes=row["notes"],
+        )
+
+    @staticmethod
+    def _row_to_assignment(row: sqlite3.Row) -> PositionAssignment:
+        return PositionAssignment(
+            id=int(row["id"]),
+            incident_id=row["incident_id"],
+            position_id=int(row["position_id"]),
+            personnel_id=row["personnel_id"],
+            display_name=row["display_name"],
+            assignment_type=row["assignment_type"],
+            start_time=row["start_time"],
+            end_time=row["end_time"],
+            operational_period=row["operational_period"],
+            assigned_by=row["assigned_by"],
+            notes=row["notes"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    @staticmethod
+    def _row_to_history(row: sqlite3.Row) -> AssignmentHistoryEntry:
+        return AssignmentHistoryEntry(
+            id=int(row["id"]),
+            incident_id=row["incident_id"],
+            assignment_id=row["assignment_id"],
+            position_id=int(row["position_id"]),
+            personnel_id=row["personnel_id"],
+            display_name=row["display_name"],
+            assignment_type=row["assignment_type"],
+            action=row["action"],
+            effective_time=row["effective_time"],
+            operational_period=row["operational_period"],
+            changed_by=row["changed_by"],
+            notes=row["notes"],
+        )

--- a/modules/command/windows.py
+++ b/modules/command/windows.py
@@ -2,7 +2,7 @@ from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from .panels.incident_dashboard_panel import IncidentDashboardPanel
 from .panels.incident_objectives_panel import IncidentObjectivesPanel
-from .ics203 import get_ics203_panel
+from .incident_organization import get_incident_organization_panel
 
 __all__ = [
     "get_incident_dashboard_panel",
@@ -10,6 +10,7 @@ __all__ = [
     "get_iap_builder_panel",
     "get_objectives_panel",
     "get_staff_org_panel",
+    "get_incident_organization_management_panel",
     "get_sitrep_panel",
 ]
 
@@ -54,9 +55,24 @@ def get_objectives_panel(incident_id: object | None = None) -> QWidget:
     return IncidentObjectivesPanel()
 
 
+def get_incident_organization_management_panel(
+    incident_id: object | None = None,
+) -> QWidget:
+    """Return the Incident Organization Management panel.
+
+    The organization module owns the structured incident organization; ICS 203
+    and ICS 207 are generated outputs from that structure.
+    """
+
+    return get_incident_organization_panel(
+        str(incident_id) if incident_id is not None else None
+    )
+
+
 def get_staff_org_panel(incident_id: object | None = None) -> QWidget:
-    """Return the QtWidgets-based ICS-203 panel."""
-    return get_ics203_panel(str(incident_id) if incident_id is not None else None)
+    """Return the Incident Organization Management panel for staff organization."""
+
+    return get_incident_organization_management_panel(incident_id)
 
 
 def get_sitrep_panel(incident_id: object | None = None) -> QWidget:

--- a/tests/test_incident_organization_module.py
+++ b/tests/test_incident_organization_module.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import utils.db as utils_db
+
+from modules.command.incident_organization.controller import IncidentOrganizationController
+from modules.command.incident_organization.repository import IncidentOrganizationRepository
+from utils.state import AppState
+
+
+@pytest.fixture()
+def data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    base = tmp_path / "data"
+    monkeypatch.setenv("CHECKIN_DATA_DIR", str(base))
+    monkeypatch.setattr(utils_db, "_DATA_DIR", base)
+    return base
+
+
+@pytest.fixture(scope="session")
+def qt_app():
+    qt_widgets = pytest.importorskip("PySide6.QtWidgets", exc_type=ImportError)
+    QApplication = qt_widgets.QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+@pytest.fixture(autouse=True)
+def reset_app_state():
+    previous = AppState.get_active_incident()
+    AppState.set_active_incident(None)
+    try:
+        yield
+    finally:
+        AppState.set_active_incident(previous)
+
+
+def test_repository_creates_incident_organization_tables(data_dir: Path) -> None:
+    repo = IncidentOrganizationRepository("org-schema")
+
+    with sqlite3.connect(data_dir / "incidents" / "org-schema.db") as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+
+    assert "organization_positions" in tables
+    assert "position_assignments" in tables
+    assert "position_assignment_history" in tables
+    assert "position_requirements" in tables
+    assert "organization_templates" in tables
+    assert "generated_form_snapshots" in tables
+
+
+def test_assignment_history_is_preserved(data_dir: Path) -> None:
+    controller = IncidentOrganizationController("org-history")
+    position_id = controller.add_position(
+        {
+            "title": "Operations Section Chief",
+            "classification": "section",
+            "is_critical": True,
+        }
+    )
+    assignment_id, warnings = controller.assign_person(
+        position_id,
+        {
+            "personnel_id": "101",
+            "display_name": "Alex Rivera",
+            "assignment_type": "primary",
+            "assigned_by": "Planner",
+        },
+    )
+
+    assert assignment_id > 0
+    assert warnings == []
+    controller.remove_assignment(assignment_id, changed_by="Planner", notes="Shift ended")
+
+    assert controller.list_assignments(position_id) == []
+    all_assignments = controller.list_assignments(position_id, active_only=False)
+    assert all_assignments[0].end_time is not None
+    history = controller.list_assignment_history(position_id)
+    assert [entry.action for entry in history] == ["assigned", "removed"]
+    assert history[-1].notes == "Shift ended"
+
+
+def test_staffing_and_span_warnings_are_calculated(data_dir: Path) -> None:
+    controller = IncidentOrganizationController("org-warnings")
+    command_id = controller.add_position(
+        {
+            "title": "Incident Commander",
+            "classification": "command",
+            "is_critical": True,
+        }
+    )
+    for index in range(8):
+        controller.add_position(
+            {
+                "title": f"Branch Director {index}",
+                "classification": "branch",
+                "parent_position_id": command_id,
+            }
+        )
+
+    summary = controller.staffing_summary()[command_id]
+
+    assert summary.staffing_status == "vacant"
+    assert {warning.code for warning in summary.warnings} == {
+        "critical_vacancy",
+        "span_of_control",
+    }
+
+
+def test_qualification_warning_does_not_block_assignment(data_dir: Path) -> None:
+    controller = IncidentOrganizationController("org-quals")
+    position_id = controller.add_position(
+        {
+            "title": "Planning Section Chief",
+            "classification": "section",
+            "required_qualifications": ["PSC3"],
+        }
+    )
+
+    assignment_id, warnings = controller.assign_person(
+        position_id,
+        {
+            "display_name": "Taylor Morgan",
+            "assignment_type": "trainee",
+        },
+    )
+
+    assert assignment_id > 0
+    assert [warning.code for warning in warnings] == ["qualification_review"]
+    assert controller.list_assignments(position_id)[0].display_name == "Taylor Morgan"
+
+
+def test_ics203_and_ics207_payloads_are_generated_from_structure(data_dir: Path) -> None:
+    controller = IncidentOrganizationController("org-forms")
+    parent_id = controller.add_position(
+        {"title": "Logistics Section Chief", "classification": "section"}
+    )
+    child_id = controller.add_position(
+        {
+            "title": "Communications Unit Leader",
+            "classification": "unit",
+            "parent_position_id": parent_id,
+        }
+    )
+    controller.assign_person(child_id, {"display_name": "Sam Lee"})
+
+    ics203 = controller.build_ics203_payload()
+    ics207 = controller.build_ics207_payload()
+
+    assert ics203["form_type"] == "ICS_203"
+    assert any(
+        item["title"] == "Communications Unit Leader"
+        for item in ics203["positions"]
+    )
+    assert ics207["form_type"] == "ICS_207"
+    assert {"parent_position_id": parent_id, "position_id": child_id} in ics207["edges"]
+    snapshot_id = controller.save_generated_snapshot("ICS_203", ics203)
+    assert snapshot_id > 0
+
+
+def test_panel_loads_with_windows_entrypoint(qt_app, data_dir: Path) -> None:
+    AppState.set_active_incident("org-ui")
+    from modules.command.incident_organization import IncidentOrganizationPanel
+    from modules.command.windows import get_staff_org_panel
+
+    panel = get_staff_org_panel("org-ui")
+    try:
+        assert isinstance(panel, IncidentOrganizationPanel)
+        assert panel.incident_id == "org-ui"
+        assert panel.btn_ics203.text() == "Prepare ICS 203"
+        assert panel.btn_ics207.text() == "Prepare ICS 207"
+    finally:
+        panel.deleteLater()


### PR DESCRIPTION
### Motivation
- Replace form-first ICS-203 editing with a structured Incident Organization Management model that owns positions, assignments, history, warnings, and prepares data for ICS-203/ICS-207 generation.
- Preserve existing data patterns and personnel lookup while keeping ICS forms as generated outputs rather than the primary model.
- Provide a Qt Widgets UI foundation (tree, detail pane, personnel pool) compatible with existing app patterns and without adding QML or demo data.

### Description
- Added a new incident organization module under `modules/command/incident_organization` providing dataclasses, repository, controller, personnel lookup, and a Qt Widgets panel (`IncidentOrganizationPanel`) for building and managing the incident organization; new files: `models.py`, `repository.py`, `controller.py`, `personnel_repo.py`, `panels/incident_organization_panel.py`, `panels/__init__.py`, and module `__init__.py`.
- Persisted organization state and history to incident-scoped SQLite tables: `organization_positions`, `position_assignments`, `position_assignment_history`, `position_requirements`, `organization_templates`, and `generated_form_snapshots`; repository preserves assignment history instead of overwriting prior assignments (`add_assignment` / `end_assignment`).
- Implemented controller features: add/update/move/deactivate positions, assignment creation/removal with audit history, staffing summary calculation, critical vacancy and span-of-control warnings, non-blocking qualification review warnings, personnel pool search, and payload builders for `ICS_203` and `ICS_207` (ready for later rendering).
- Added a Qt Widgets panel with tree-style organization view, position detail and assignment table, personnel assignment pool, and actions to `Prepare ICS 203`/`Prepare ICS 207` (no QML added); wired the existing command window entry point to return this new panel via `get_staff_org_panel` (keeps existing public API while routing to the new module).
- Tests and test scaffolding: added `tests/test_incident_organization_module.py` to exercise schema creation, preserved assignment history, warnings, generated payloads, and panel integration; updated `tests/conftest.py` fixtures to safely import Qt in CI.

### Testing
- Ran the new module tests and legacy ICS-203 tests with Qt offscreen: `QT_QPA_PLATFORM=offscreen pytest --import-mode=importlib tests/test_incident_organization_module.py tests/test_ics203_module.py`, resulting in all tests passing for the targeted suites (`18 passed`, `1 warning`).
- Verified module compilation with `python -m compileall modules/command/incident_organization modules/command/windows.py tests/test_incident_organization_module.py` with no syntax errors.
- Performed lightweight checks to ensure no QML usage or disallowed terms were introduced (`rg` checks) and confirmed no files were added under `backend/` and no demo data was created.
- Note: running the entire test suite in this environment required installing additional system libraries for Qt/audio; the targeted new-module and ICS-203 test suites passed and the new code compiles and imports correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a24a8fef874832ba8ad6023b4ea046b)