### PR TITLE
Add SARApp Server Console (PySide6) with settings, controller, and tests

### DIFF
--- a/docs/connectivity_architecture.md
+++ b/docs/connectivity_architecture.md
@@ -43,6 +43,14 @@ A server can be started with:
 python sarapp_server.py --host 0.0.0.0 --port 8765 --name "Incident Command Server"
 ```
 
+Dedicated server machines can also launch the PySide6 Qt Widgets Server Console:
+
+```bash
+python sarapp_server_console.py
+```
+
+The Server Console is a control panel for starting, stopping, monitoring, and configuring the same `SARAppServerManager` runtime. It is not a second desktop client and does not load incident workspace modules.
+
 ## Heartbeat Mechanism
 
 The same UDP announcement acts as a heartbeat. Clients record the latest heartbeat in `HeartbeatTracker` and derive connection health from heartbeat freshness:

--- a/docs/server_console.md
+++ b/docs/server_console.md
@@ -1,0 +1,70 @@
+# SARApp Server Console
+
+The SARApp Server Console is a lightweight PySide6 / Qt Widgets control panel for running and monitoring a SARApp incident server on a dedicated laptop, mini PC, EOC workstation, or future appliance-style deployment. It is separate from the full SARApp desktop client and does not include incident boards, forms, planning tools, operations modules, or the normal workspace menus.
+
+## Entry points
+
+SARApp now has separate launch paths:
+
+```bash
+python main.py
+python sarapp_server.py --host 0.0.0.0 --port 8765 --name "Incident Server"
+python sarapp_server_console.py
+```
+
+Use `main.py` for the desktop client. Use `sarapp_server.py` for a terminal-driven server. Use `sarapp_server_console.py` when a machine should behave like a server control panel without requiring terminal interaction.
+
+## What the console controls
+
+The console reuses the existing server runtime in `server/server_manager.py` and the networking primitives in `core/networking/`. It starts the same HTTP health server and UDP discovery broadcaster used by the command-line server. It does not duplicate the server implementation or redesign storage.
+
+The window shows:
+
+- Server status: stopped, starting, running, stopping, error, or monitoring.
+- Server name, host, port, server ID, version, started time, and discovery status.
+- Start, stop, restart, copy-address, and health-check actions.
+- Basic persistent settings.
+- A placeholder client-connections table for future connected-client metadata.
+- Runtime log and error messages.
+
+## Settings
+
+Console settings are saved in:
+
+```text
+settings/server_console.json
+```
+
+Default settings are:
+
+```json
+{
+  "server_name": "SARApp Incident Server",
+  "host": "0.0.0.0",
+  "port": 8765,
+  "discovery_enabled": true
+}
+```
+
+`server_name` is advertised to LAN clients. `host` controls the interface the HTTP server binds to; `0.0.0.0` listens on all interfaces. `port` is the HTTP health/server-info port and must be between 1 and 65535. `discovery_enabled` controls whether UDP LAN discovery broadcasts are sent while the server is running. `discovery_port` is available for networks that need a non-default UDP discovery port.
+
+Saving settings while the server is running does not silently rebind the server. The new values apply on the next start, or immediately after using Restart Server.
+
+## LAN discovery
+
+When discovery is enabled, the server sends UDP announcements containing its server ID, name, version, status, host, port, and heartbeat timestamp. SARApp desktop clients use those broadcasts to find the server automatically on the same LAN. If a network blocks broadcast traffic, clients can still use manual connection workflows.
+
+## Port conflict behavior
+
+Before starting a server, the console checks the configured port. If `/health` responds with a SARApp-compatible payload, the console warns that a SARApp server is already running and can monitor that server instead of starting a second copy. If the port is used by another service, the console shows an error and does not start the SARApp server.
+
+## Health monitoring
+
+The console periodically calls `/health` with a short timeout while running or monitoring. It displays Healthy, Error, or Stopped and logs only state changes or errors so routine successful health checks do not spam the log panel.
+
+## Troubleshooting
+
+- **Port unavailable:** Choose a different port or stop the service already using the configured port.
+- **Desktop client cannot discover the server:** Confirm discovery is enabled, both machines are on the same LAN, and local firewall rules allow UDP discovery traffic.
+- **Health check fails:** Confirm the configured host/port are correct and that the server status is Running.
+- **Settings did not affect a running server:** Use Restart Server after saving settings.

--- a/sarapp_server_console.py
+++ b/sarapp_server_console.py
@@ -1,0 +1,22 @@
+"""Entry point for the SARApp Server Console Qt Widgets application."""
+
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtWidgets import QApplication
+
+from server.server_console.console_window import ServerConsoleWindow
+
+
+def main() -> int:
+    """Start the console without assuming any specific working directory."""
+
+    app = QApplication(sys.argv)
+    window = ServerConsoleWindow()
+    window.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/server_console/__init__.py
+++ b/server/server_console/__init__.py
@@ -1,0 +1,5 @@
+"""SARApp Server Console package."""
+
+from .settings import ServerConsoleSettings, ServerConsoleSettingsStore
+
+__all__ = ["ServerConsoleSettings", "ServerConsoleSettingsStore"]

--- a/server/server_console/console_window.py
+++ b/server/server_console/console_window.py
@@ -1,0 +1,251 @@
+"""PySide6 Qt Widgets window for controlling a SARApp incident server."""
+
+from __future__ import annotations
+
+import threading
+import webbrowser
+from datetime import datetime, timezone
+from typing import Callable
+
+from PySide6.QtCore import QTimer, Qt, Signal
+from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QTableWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from core.networking.server_info import SARAPP_VERSION
+
+from .controller import ConsoleServerState, ServerConsoleController, check_port, fetch_health
+from .log_model import ConsoleLogBuffer
+from .settings import ServerConsoleSettings, ServerConsoleSettingsStore
+
+
+class ServerConsoleWindow(QMainWindow):
+    """Lightweight control panel for a dedicated SARApp server machine."""
+
+    log_line = Signal(str)
+    operation_done = Signal(str, bool)
+
+    def __init__(self, store: ServerConsoleSettingsStore | None = None) -> None:
+        super().__init__()
+        self.store = store or ServerConsoleSettingsStore()
+        self.settings = self.store.load()
+        self.controller = ServerConsoleController(self.settings)
+        self.logs = ConsoleLogBuffer()
+        self._last_health_status = "Stopped"
+        self.setWindowTitle("SARApp Server Console")
+        self.resize(900, 720)
+        self._build_ui()
+        self._load_settings_into_fields()
+        self._connect_signals()
+        self._refresh_status()
+        self._append_log("Server Console opened. Settings loaded.")
+
+        # Periodic health monitoring updates labels without blocking the UI.
+        self.health_timer = QTimer(self)
+        self.health_timer.setInterval(3000)
+        self.health_timer.timeout.connect(self._poll_health)
+        self.health_timer.start()
+
+    def _build_ui(self) -> None:
+        root = QWidget(self)
+        layout = QVBoxLayout(root)
+
+        status_box = QGroupBox("Server Status")
+        form = QFormLayout(status_box)
+        self.status_label = QLabel("Stopped")
+        self.name_label = QLabel("")
+        self.host_label = QLabel("")
+        self.port_label = QLabel("")
+        self.server_id_label = QLabel("Not started")
+        self.version_label = QLabel(SARAPP_VERSION)
+        self.started_label = QLabel("Not started")
+        self.discovery_label = QLabel("Not broadcasting")
+        self.health_label = QLabel("Stopped")
+        for title, widget in [
+            ("Server status", self.status_label), ("Server name", self.name_label),
+            ("Host", self.host_label), ("Port", self.port_label), ("Server ID", self.server_id_label),
+            ("Version", self.version_label), ("Started time", self.started_label),
+            ("Discovery status", self.discovery_label), ("Health", self.health_label),
+        ]:
+            form.addRow(title + ":", widget)
+        layout.addWidget(status_box)
+
+        controls = QHBoxLayout()
+        self.start_button = QPushButton("Start Server")
+        self.stop_button = QPushButton("Stop Server")
+        self.restart_button = QPushButton("Restart Server")
+        self.copy_button = QPushButton("Copy Server Address")
+        self.health_button = QPushButton("Open Health Check")
+        for button in [self.start_button, self.stop_button, self.restart_button, self.copy_button, self.health_button]:
+            controls.addWidget(button)
+        layout.addLayout(controls)
+
+        settings_box = QGroupBox("Settings")
+        settings_form = QFormLayout(settings_box)
+        self.name_edit = QLineEdit()
+        self.host_edit = QLineEdit()
+        self.port_spin = QSpinBox(); self.port_spin.setRange(1, 65535)
+        self.discovery_check = QCheckBox("Enable LAN discovery broadcasting")
+        self.discovery_port_spin = QSpinBox(); self.discovery_port_spin.setRange(1, 65535)
+        self.save_button = QPushButton("Save Settings")
+        settings_form.addRow("Server name:", self.name_edit)
+        settings_form.addRow("Host:", self.host_edit)
+        settings_form.addRow("Port:", self.port_spin)
+        settings_form.addRow("Discovery:", self.discovery_check)
+        settings_form.addRow("Discovery port:", self.discovery_port_spin)
+        settings_form.addRow("", self.save_button)
+        layout.addWidget(settings_box)
+
+        clients_box = QGroupBox("Client Connections")
+        clients_layout = QVBoxLayout(clients_box)
+        clients_layout.addWidget(QLabel("Connected Clients: Not implemented yet"))
+        table = QTableWidget(0, 4)
+        table.setHorizontalHeaderLabels(["Client name", "IP address", "Connected time", "Last heartbeat"])
+        table.setEditTriggers(QTableWidget.NoEditTriggers)
+        clients_layout.addWidget(table)
+        layout.addWidget(clients_box)
+
+        logs_box = QGroupBox("Server Logs / Errors")
+        logs_layout = QVBoxLayout(logs_box)
+        self.log_text = QTextEdit(); self.log_text.setReadOnly(True)
+        logs_layout.addWidget(self.log_text)
+        layout.addWidget(logs_box)
+        self.setCentralWidget(root)
+
+    def _connect_signals(self) -> None:
+        self.start_button.clicked.connect(self._start_server)
+        self.stop_button.clicked.connect(self._stop_server)
+        self.restart_button.clicked.connect(self._restart_server)
+        self.copy_button.clicked.connect(self._copy_address)
+        self.health_button.clicked.connect(self._open_health_check)
+        self.save_button.clicked.connect(self._save_settings)
+        self.log_line.connect(self._append_log_from_thread)
+        self.operation_done.connect(self._operation_finished)
+
+    def _settings_from_fields(self) -> ServerConsoleSettings:
+        settings = ServerConsoleSettings(
+            server_name=self.name_edit.text().strip(), host=self.host_edit.text().strip(),
+            port=int(self.port_spin.value()), discovery_enabled=self.discovery_check.isChecked(),
+            discovery_port=int(self.discovery_port_spin.value()),
+        )
+        settings.validate()
+        return settings
+
+    def _load_settings_into_fields(self) -> None:
+        self.name_edit.setText(self.settings.server_name)
+        self.host_edit.setText(self.settings.host)
+        self.port_spin.setValue(self.settings.port)
+        self.discovery_check.setChecked(self.settings.discovery_enabled)
+        self.discovery_port_spin.setValue(self.settings.discovery_port)
+
+    def _save_settings(self) -> None:
+        try:
+            new_settings = self._settings_from_fields()
+        except ValueError as exc:
+            QMessageBox.warning(self, "Invalid Settings", str(exc)); return
+        if self.controller.state == ConsoleServerState.RUNNING:
+            QMessageBox.information(self, "Settings Saved", "Settings were saved and will apply on next start or restart.")
+        self.store.save(new_settings)
+        self.settings = new_settings
+        if self.controller.state != ConsoleServerState.RUNNING:
+            self.controller.settings = new_settings
+        self._append_log("Settings saved.")
+        self._refresh_status()
+
+    def _run_operation(self, label: str, target: Callable[[], None]) -> None:
+        def runner() -> None:
+            try:
+                target(); self.operation_done.emit(label, True)
+            except Exception as exc:  # noqa: BLE001 - display operational errors to user
+                self.log_line.emit(f"{label} failed: {exc}"); self.operation_done.emit(label, False)
+        threading.Thread(target=runner, name=f"sarapp-console-{label.lower().replace(' ', '-')}", daemon=True).start()
+
+    def _start_server(self) -> None:
+        try:
+            self.settings = self._settings_from_fields(); self.controller.settings = self.settings
+            conflict = check_port(self.settings)
+            if conflict.sarapp_server:
+                if QMessageBox.question(self, "SARApp Server Already Running", conflict.message + " Monitor it instead?") == QMessageBox.Yes:
+                    self.controller.monitor_existing(); self._append_log("Monitoring existing SARApp server."); self._refresh_status()
+                return
+            if not conflict.available:
+                QMessageBox.critical(self, "Port Unavailable", conflict.message); self._append_log(conflict.message); return
+        except ValueError as exc:
+            QMessageBox.warning(self, "Invalid Settings", str(exc)); return
+        self._append_log("Starting server...")
+        self._run_operation("Start server", self.controller.start)
+
+    def _stop_server(self) -> None:
+        self._append_log("Stopping server...")
+        self._run_operation("Stop server", self.controller.stop)
+
+    def _restart_server(self) -> None:
+        try:
+            self.settings = self._settings_from_fields(); self.controller.settings = self.settings; self.store.save(self.settings)
+        except ValueError as exc:
+            QMessageBox.warning(self, "Invalid Settings", str(exc)); return
+        self._append_log("Restarting server with current settings...")
+        self._run_operation("Restart server", self.controller.restart)
+
+    def _copy_address(self) -> None:
+        QApplication.clipboard().setText(self.settings.base_url)
+        self._append_log(f"Copied server address: {self.settings.base_url}")
+
+    def _open_health_check(self) -> None:
+        url = f"{self.settings.base_url}/health"
+        result = fetch_health(self.settings.base_url, timeout_seconds=2.0)
+        self._append_log("Health check success." if result.ok else f"Health check failed: {result.message or result.status}")
+        webbrowser.open(url)
+
+    def _poll_health(self) -> None:
+        if self.controller.state not in {ConsoleServerState.RUNNING, ConsoleServerState.MONITORING}:
+            if self._last_health_status != "Stopped":
+                self._last_health_status = "Stopped"; self._append_log("Health status changed to Stopped.")
+            self._refresh_status(); return
+        result = fetch_health(self.settings.base_url, timeout_seconds=1.0)
+        status = result.status if result.ok else "Error"
+        if status != self._last_health_status:
+            self._last_health_status = status
+            self._append_log("Health check success." if result.ok else f"Health check error: {result.message}")
+        self.health_label.setText(status)
+        self._refresh_status()
+
+    def _refresh_status(self) -> None:
+        state = self.controller.state.value
+        self.status_label.setText(state)
+        self.name_label.setText(self.settings.server_name)
+        self.host_label.setText(self.settings.host)
+        self.port_label.setText(str(self.settings.port))
+        manager = self.controller.manager
+        self.server_id_label.setText(manager.server_info.server_id if manager else "Not started")
+        self.started_label.setText(datetime.now(timezone.utc).isoformat() if state == "Running" and self.started_label.text() == "Not started" else self.started_label.text())
+        broadcasting = state == "Running" and self.settings.discovery_enabled
+        self.discovery_label.setText("Broadcasting" if broadcasting else "Not broadcasting")
+        self.stop_button.setEnabled(state in {"Running", "Starting", "Monitoring"})
+        self.start_button.setEnabled(state in {"Stopped", "Error"})
+
+    def _operation_finished(self, label: str, success: bool) -> None:
+        self._append_log(f"{label} completed." if success else f"{label} did not complete.")
+        if label.startswith("Stop"):
+            self.started_label.setText("Not started")
+        self._refresh_status()
+
+    def _append_log(self, message: str) -> None:
+        self._append_log_from_thread(self.logs.add(message))
+
+    def _append_log_from_thread(self, line: str) -> None:
+        self.log_text.append(line)

--- a/server/server_console/controller.py
+++ b/server/server_console/controller.py
@@ -1,0 +1,136 @@
+"""Testable server-control logic for the SARApp Server Console."""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from server.server_manager import SARAppServerManager
+
+from .settings import ServerConsoleSettings
+
+
+class ConsoleServerState(str, Enum):
+    """Runtime state labels displayed by the console window."""
+
+    STOPPED = "Stopped"
+    STARTING = "Starting"
+    RUNNING = "Running"
+    STOPPING = "Stopping"
+    ERROR = "Error"
+    MONITORING = "Monitoring"
+
+
+@dataclass(slots=True)
+class PortCheckResult:
+    """Result of checking a configured host/port before server startup."""
+
+    available: bool
+    sarapp_server: bool = False
+    message: str = ""
+    payload: dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class HealthCheckResult:
+    """Normalized health-check response for UI and tests."""
+
+    status: str
+    ok: bool = False
+    payload: dict[str, Any] | None = None
+    message: str = ""
+
+
+def fetch_health(base_url: str, *, timeout_seconds: float = 1.0) -> HealthCheckResult:
+    """Call /health with a timeout so monitoring never blocks indefinitely."""
+
+    try:
+        with urllib.request.urlopen(f"{base_url.rstrip('/')}/health", timeout=timeout_seconds) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        return HealthCheckResult(status="Error", message=str(exc))
+    is_sarapp = isinstance(payload, dict) and isinstance(payload.get("server"), dict)
+    return HealthCheckResult(status="Healthy" if payload.get("ok") and is_sarapp else "Error", ok=bool(payload.get("ok") and is_sarapp), payload=payload)
+
+
+def check_port(settings: ServerConsoleSettings, *, timeout_seconds: float = 0.75) -> PortCheckResult:
+    """Identify whether the configured port is free, SARApp, or another service."""
+
+    health = fetch_health(settings.base_url, timeout_seconds=timeout_seconds)
+    if health.ok:
+        return PortCheckResult(False, True, "A SARApp server is already running on this port.", health.payload)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout_seconds)
+        if sock.connect_ex((settings.health_host, settings.port)) == 0:
+            return PortCheckResult(False, False, "The configured port is already in use by another service.")
+    return PortCheckResult(True, False, "Port is available.")
+
+
+class ServerConsoleController:
+    """Owns the in-process server manager while keeping long work off the UI thread."""
+
+    def __init__(self, settings: ServerConsoleSettings) -> None:
+        self.settings = settings
+        self.state = ConsoleServerState.STOPPED
+        self.manager: SARAppServerManager | None = None
+        self.last_error = ""
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        """Start the existing SARApp server engine with console settings."""
+
+        with self._lock:
+            self.settings.validate()
+            conflict = check_port(self.settings)
+            if not conflict.available:
+                self.state = ConsoleServerState.ERROR
+                self.last_error = conflict.message
+                raise RuntimeError(conflict.message)
+            self.state = ConsoleServerState.STARTING
+            self.manager = SARAppServerManager(
+                host=self.settings.host,
+                port=self.settings.port,
+                server_name=self.settings.server_name,
+                discovery_enabled=self.settings.discovery_enabled,
+                discovery_port=self.settings.discovery_port,
+            )
+            try:
+                self.manager.start()
+            except OSError as exc:
+                self.state = ConsoleServerState.ERROR
+                self.last_error = str(exc)
+                raise
+            self.state = ConsoleServerState.RUNNING
+            self.last_error = ""
+
+    def stop(self) -> None:
+        """Stop the managed server cleanly without assuming it exists."""
+
+        with self._lock:
+            if self.manager is None:
+                self.state = ConsoleServerState.STOPPED
+                return
+            self.state = ConsoleServerState.STOPPING
+            self.manager.stop()
+            self.manager = None
+            self.state = ConsoleServerState.STOPPED
+
+    def restart(self, settings: ServerConsoleSettings | None = None) -> None:
+        """Apply optional settings and restart the server engine."""
+
+        self.stop()
+        if settings is not None:
+            self.settings = settings
+        self.start()
+
+    def monitor_existing(self) -> None:
+        """Mark this console as monitoring an already-running compatible server."""
+
+        self.manager = None
+        self.state = ConsoleServerState.MONITORING

--- a/server/server_console/log_model.py
+++ b/server/server_console/log_model.py
@@ -1,0 +1,25 @@
+"""Small log buffer used by the SARApp Server Console UI."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime
+
+
+class ConsoleLogBuffer:
+    """Stores timestamped runtime messages without depending on Qt widgets."""
+
+    def __init__(self, *, max_entries: int = 500) -> None:
+        self._entries: deque[str] = deque(maxlen=max_entries)
+
+    def add(self, message: str) -> str:
+        """Append a message with a local timestamp and return the formatted line."""
+
+        line = f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {message}"
+        self._entries.append(line)
+        return line
+
+    def lines(self) -> list[str]:
+        """Return a copy of buffered log lines for display or tests."""
+
+        return list(self._entries)

--- a/server/server_console/settings.py
+++ b/server/server_console/settings.py
@@ -1,0 +1,103 @@
+"""Settings helpers for the SARApp Server Console."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from core.networking.server_info import DEFAULT_DISCOVERY_PORT, DEFAULT_SERVER_PORT
+
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "settings" / "server_console.json"
+
+
+@dataclass(slots=True)
+class ServerConsoleSettings:
+    """Persistent settings used when the console starts the server process."""
+
+    server_name: str = "SARApp Incident Server"
+    host: str = "0.0.0.0"
+    port: int = DEFAULT_SERVER_PORT
+    discovery_enabled: bool = True
+    discovery_port: int = DEFAULT_DISCOVERY_PORT
+
+    @property
+    def health_host(self) -> str:
+        """Return a loopback-safe host for local health checks and browser URLs."""
+
+        return "127.0.0.1" if self.host in {"", "0.0.0.0", "::"} else self.host
+
+    @property
+    def base_url(self) -> str:
+        """Return the HTTP address copied by the console and used for checks."""
+
+        return f"http://{self.health_host}:{self.port}"
+
+    def validate(self) -> None:
+        """Validate settings before saving or starting networking components."""
+
+        validate_port(self.port, field_name="port")
+        validate_port(self.discovery_port, field_name="discovery_port")
+        if not self.server_name.strip():
+            raise ValueError("Server name is required.")
+        if not self.host.strip():
+            raise ValueError("Host is required.")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize settings to a JSON-compatible dictionary."""
+
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ServerConsoleSettings":
+        """Load settings from a dictionary while tolerating older config files."""
+
+        defaults = cls()
+        settings = cls(
+            server_name=str(payload.get("server_name") or defaults.server_name),
+            host=str(payload.get("host") or defaults.host),
+            port=int(payload.get("port") or DEFAULT_SERVER_PORT),
+            discovery_enabled=bool(payload.get("discovery_enabled", True)),
+            discovery_port=int(payload.get("discovery_port") or DEFAULT_DISCOVERY_PORT),
+        )
+        settings.validate()
+        return settings
+
+
+def validate_port(value: int | str, *, field_name: str = "port") -> int:
+    """Validate a TCP/UDP port value and return it as an integer."""
+
+    try:
+        port = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer between 1 and 65535.") from exc
+    if not 1 <= port <= 65535:
+        raise ValueError(f"{field_name} must be between 1 and 65535.")
+    return port
+
+
+class ServerConsoleSettingsStore:
+    """JSON-backed settings store that is independent of the process cwd."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or DEFAULT_CONFIG_PATH
+
+    def load(self) -> ServerConsoleSettings:
+        """Load settings, returning defaults when no console config exists yet."""
+
+        if not self.path.exists():
+            return ServerConsoleSettings()
+        with self.path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        return ServerConsoleSettings.from_dict(dict(payload))
+
+    def save(self, settings: ServerConsoleSettings) -> None:
+        """Persist validated settings for future console launches."""
+
+        settings.validate()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as handle:
+            json.dump(settings.to_dict(), handle, indent=2, sort_keys=True)
+            handle.write("\n")

--- a/server/server_manager.py
+++ b/server/server_manager.py
@@ -17,7 +17,14 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
 from core.networking.discovery import DiscoveryBroadcaster
-from core.networking.server_info import DEFAULT_SERVER_PORT, SARAPP_VERSION, ServerInfo, ServerStatus, utc_now
+from core.networking.server_info import (
+    DEFAULT_DISCOVERY_PORT,
+    DEFAULT_SERVER_PORT,
+    SARAPP_VERSION,
+    ServerInfo,
+    ServerStatus,
+    utc_now,
+)
 
 
 def _default_server_id() -> str:
@@ -37,9 +44,12 @@ class SARAppServerManager:
         server_id: str | None = None,
         server_name: str | None = None,
         version: str = SARAPP_VERSION,
+        discovery_enabled: bool = True,
+        discovery_port: int = DEFAULT_DISCOVERY_PORT,
     ) -> None:
         self.host = host
         self.port = port
+        self.discovery_enabled = discovery_enabled
         self.server_info = ServerInfo(
             server_id=server_id or _default_server_id(),
             server_name=server_name or f"SARApp Server on {socket.gethostname()}",
@@ -50,7 +60,7 @@ class SARAppServerManager:
         )
         self._httpd: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
-        self._broadcaster = DiscoveryBroadcaster(self.server_info)
+        self._broadcaster = DiscoveryBroadcaster(self.server_info, port=discovery_port)
 
     def start(self) -> None:
         """Start HTTP health endpoints and LAN heartbeat advertisements."""
@@ -70,13 +80,19 @@ class SARAppServerManager:
         self.server_info.last_heartbeat = utc_now()
         self._thread = threading.Thread(target=self._httpd.serve_forever, name="sarapp-server", daemon=True)
         self._thread.start()
-        self._broadcaster.server_info = self.server_info
-        self._broadcaster.start()
+        # Discovery is optional for the Server Console settings, but remains
+        # enabled by default so the existing command-line entry point continues
+        # to advertise exactly as before.
+        if self.discovery_enabled:
+            self._broadcaster.server_info = self.server_info
+            self._broadcaster.start()
 
     def stop(self) -> None:
         """Stop discovery first, then the health server."""
 
         self.server_info.status = ServerStatus.STOPPING
+        # Stop UDP discovery before HTTP shutdown so clients stop seeing this
+        # server as soon as the process begins leaving service.
         self._broadcaster.stop()
         if self._httpd is not None:
             self._httpd.shutdown()

--- a/tests/server_console/test_controller.py
+++ b/tests/server_console/test_controller.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import socket
+
+from server.server_console.controller import ServerConsoleController, check_port, fetch_health
+from server.server_console.settings import ServerConsoleSettings
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def test_server_manager_can_start_and_stop_from_console_controller_code() -> None:
+    settings = ServerConsoleSettings(host="127.0.0.1", port=_free_port(), server_name="Controller Test", discovery_enabled=False)
+    controller = ServerConsoleController(settings)
+
+    controller.start()
+    try:
+        assert controller.manager is not None
+        assert controller.manager.port == settings.port
+        assert controller.state.value == "Running"
+    finally:
+        controller.stop()
+
+    assert controller.state.value == "Stopped"
+
+
+def test_health_check_succeeds_while_server_is_running() -> None:
+    settings = ServerConsoleSettings(host="127.0.0.1", port=_free_port(), server_name="Health Test", discovery_enabled=False)
+    controller = ServerConsoleController(settings)
+
+    controller.start()
+    try:
+        assert controller.manager is not None
+        result = fetch_health(f"http://127.0.0.1:{controller.manager.port}", timeout_seconds=1.0)
+    finally:
+        controller.stop()
+
+    assert result.ok is True
+    assert result.payload is not None
+    assert result.payload["server"]["server_name"] == "Health Test"
+
+
+def test_port_conflict_detection_identifies_running_sarapp_server() -> None:
+    settings = ServerConsoleSettings(host="127.0.0.1", port=_free_port(), server_name="Conflict Test", discovery_enabled=False)
+    controller = ServerConsoleController(settings)
+
+    controller.start()
+    try:
+        assert controller.manager is not None
+        conflict_settings = ServerConsoleSettings(host="127.0.0.1", port=controller.manager.port)
+        result = check_port(conflict_settings, timeout_seconds=1.0)
+    finally:
+        controller.stop()
+
+    assert result.available is False
+    assert result.sarapp_server is True

--- a/tests/server_console/test_settings.py
+++ b/tests/server_console/test_settings.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from server.server_console.settings import ServerConsoleSettings, ServerConsoleSettingsStore, validate_port
+
+
+def test_server_console_settings_load_defaults_when_no_config_exists(tmp_path) -> None:
+    store = ServerConsoleSettingsStore(tmp_path / "missing" / "server_console.json")
+
+    settings = store.load()
+
+    assert settings.server_name == "SARApp Incident Server"
+    assert settings.host == "0.0.0.0"
+    assert settings.port == 8765
+    assert settings.discovery_enabled is True
+
+
+def test_server_console_settings_save_and_reload(tmp_path) -> None:
+    path = tmp_path / "settings" / "server_console.json"
+    store = ServerConsoleSettingsStore(path)
+    expected = ServerConsoleSettings(
+        server_name="ICP Server",
+        host="127.0.0.1",
+        port=9876,
+        discovery_enabled=False,
+        discovery_port=45455,
+    )
+
+    store.save(expected)
+    loaded = store.load()
+
+    assert loaded == expected
+
+
+@pytest.mark.parametrize("value", [0, 65536, "not-a-port"])
+def test_invalid_port_validation_fails_cleanly(value) -> None:
+    with pytest.raises(ValueError, match="port"):
+        validate_port(value)


### PR DESCRIPTION
### Motivation
- Provide a lightweight, dedicated UI for running and monitoring the existing SARApp server runtime without duplicating server logic or changing storage, suitable for dedicated server machines and appliances.
- Make discovery broadcasting controllable from a console while preserving the current command-line server behavior and APIs (`/health`, `/server-info`).

### Description
- Add a PySide6 Qt Widgets entry point `sarapp_server_console.py` and a window implementation `server/server_console/console_window.py` that shows server status, controls (Start, Stop, Restart, Copy Address, Open Health Check), editable settings, a placeholder client table, and a read-only log panel, with periodic health polling using `QTimer` and threaded operations so the UI is never blocked.
- Add testable non-UI logic in `server/server_console/controller.py` implementing `ServerConsoleController`, `fetch_health`, and `check_port` to start/stop the in-process `SARAppServerManager`, detect port conflicts (including existing SARApp instances), and support monitoring an existing server.
- Add persistent JSON-backed settings support in `server/server_console/settings.py` with defaults and validation, saving to `settings/server_console.json` and helper properties `base_url`/`health_host` for loopback-safe checks.
- Add a small `ConsoleLogBuffer` (`server/server_console/log_model.py`) for timestamped runtime messages and wire the console to these logs.
- Make discovery optional in the existing server runtime by adding `discovery_enabled` and `discovery_port` to `SARAppServerManager` (`server/server_manager.py`) while preserving the prior default behavior so CLI usage is unchanged.
- Documentation: add `docs/server_console.md` and update `docs/connectivity_architecture.md` to mention the new console launch path and role.
- Tests: add unit tests in `tests/server_console/` that cover settings defaults/save/reload/validation, controller start/stop behavior, health checks, and port-conflict detection, and keep existing connectivity tests exercising `SARAppServerManager` integration.

### Testing
- Ran the targeted test suite `python -m pytest tests/server_console tests/core/test_connectivity.py`, which passed (`13 passed`).
- Ran bytecode compilation for new modules with `python -m compileall server/server_console sarapp_server_console.py server/server_manager.py`, which succeeded.
- Ran the full test collection (`python -m pytest`) and observed unrelated environment/repo collection errors (missing system `libGL.so.1` affecting PySide6 imports and duplicate test-module basenames causing import mismatch), so full-suite failures are due to CI/environment issues rather than the console changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2cd98e534c832bb059ef67828964e5)