### PR TITLE
Package SARApp Server Console as standalone executable

### DIFF
--- a/build_server_console.bat
+++ b/build_server_console.bat
@@ -1,0 +1,52 @@
+@echo off
+setlocal
+
+set APP_NAME=SARAppServerConsole
+set SPEC_FILE=packaging\SARAppServerConsole.spec
+set EXE_PATH=dist\%APP_NAME%\%APP_NAME%.exe
+
+echo Building SARApp Server Console...
+
+if not exist "%SPEC_FILE%" (
+    echo ERROR: PyInstaller spec file not found: %SPEC_FILE%
+    goto :fail
+)
+
+python -c "import PyInstaller" >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: PyInstaller is not installed in this Python environment.
+    echo Install it with: python -m pip install pyinstaller
+    goto :fail
+)
+
+echo Cleaning old build files...
+if exist "build\%APP_NAME%" rmdir /s /q "build\%APP_NAME%"
+if exist "dist\%APP_NAME%" rmdir /s /q "dist\%APP_NAME%"
+
+echo Running PyInstaller...
+pyinstaller --noconfirm --clean "%SPEC_FILE%"
+if errorlevel 1 goto :fail
+
+if not exist "%EXE_PATH%" (
+    echo ERROR: Build finished but expected executable was not found:
+    echo %EXE_PATH%
+    goto :fail
+)
+
+echo Build complete:
+echo %EXE_PATH%
+echo.
+echo Run "%EXE_PATH%" to launch the Server Console.
+goto :done
+
+:fail
+echo.
+echo SARApp Server Console build failed.
+if /i "%SARAPP_NO_PAUSE%"=="1" exit /b 1
+pause
+exit /b 1
+
+:done
+if /i "%SARAPP_NO_PAUSE%"=="1" exit /b 0
+pause
+exit /b 0

--- a/docs/server_console_packaging.md
+++ b/docs/server_console_packaging.md
@@ -1,0 +1,158 @@
+# SARApp Server Console Packaging
+
+This document describes how to build and test the standalone Windows executable for the SARApp Server Console. The Server Console package is separate from the main SARApp desktop client package and uses `sarapp_server_console.py` as its entry point.
+
+## What gets built
+
+The dedicated PyInstaller spec at `packaging/SARAppServerConsole.spec` builds a windowed executable named `SARAppServerConsole.exe`.
+
+Expected output:
+
+```text
+dist/SARAppServerConsole/SARAppServerConsole.exe
+```
+
+The build is intentionally scoped to the Server Console, `server/`, and `core/networking/` support modules. It does not package the main desktop client build and does not include demo data.
+
+## Prerequisites
+
+From a Windows command prompt or PowerShell session in the repository root:
+
+```bat
+python -m pip install -r requirements.txt
+python -m pip install pyinstaller
+```
+
+PySide6 must be importable in the same Python environment used for the build.
+
+## Build the executable
+
+Run the dedicated batch file from the repository root:
+
+```bat
+build_server_console.bat
+```
+
+The script will:
+
+1. Check that the Server Console spec file exists.
+2. Check that PyInstaller is installed.
+3. Remove previous `build\SARAppServerConsole` and `dist\SARAppServerConsole` artifacts.
+4. Run PyInstaller with `packaging\SARAppServerConsole.spec`.
+5. Confirm that `dist\SARAppServerConsole\SARAppServerConsole.exe` exists.
+
+For non-interactive automation, set `SARAPP_NO_PAUSE=1` before running the script so it exits without pausing:
+
+```bat
+set SARAPP_NO_PAUSE=1
+build_server_console.bat
+```
+
+## Run the Server Console
+
+After a successful build, launch:
+
+```bat
+dist\SARAppServerConsole\SARAppServerConsole.exe
+```
+
+The executable opens the SARApp Server Console window without requiring users to run Python manually. The app stores editable console settings in a writable settings folder next to the packaged executable:
+
+```text
+dist/SARAppServerConsole/settings/server_console.json
+```
+
+If the settings file does not exist, the console starts with defaults and creates the file when settings are saved or the server is restarted.
+
+## Server Console validation
+
+Manual validation on Windows:
+
+1. Start `dist\SARAppServerConsole\SARAppServerConsole.exe`.
+2. Confirm the Server Console window opens and does not immediately crash.
+3. Click **Start Server**.
+4. Confirm **Server status** changes to **Running**.
+5. Confirm **Discovery status** changes to **Broadcasting** when discovery is enabled.
+6. Open `http://127.0.0.1:8765/health` or click **Open Health Check**.
+7. Confirm the health response includes `"ok": true` and a `server` object.
+8. Click **Stop Server**.
+9. Confirm **Server status** returns to **Stopped**.
+10. Close the console and confirm only the server instance owned by this console is stopped.
+
+A simple post-build artifact check is also available:
+
+```bat
+python tools\smoke_test_server_console.py
+```
+
+This smoke test only verifies that the expected executable path exists; it does not require external network access.
+
+## Test with the main SARApp desktop app
+
+Use this procedure to confirm the desktop client can discover and connect to the standalone Server Console server:
+
+1. Start `dist\SARAppServerConsole\SARAppServerConsole.exe`.
+2. In the Server Console, leave discovery enabled and click **Start Server**.
+3. Verify `http://127.0.0.1:8765/health` responds successfully.
+4. Launch the main SARApp desktop app separately, either from source with `python main.py` or from its own existing desktop executable.
+5. Confirm the desktop app discovers the Server Console server on the LAN.
+6. Confirm the desktop app connects to the discovered server and does not fall back to offline mode while the server is running.
+7. Stop the server from the Server Console after testing.
+
+## Troubleshooting
+
+### PyInstaller is not installed
+
+Symptom: `build_server_console.bat` prints that PyInstaller is not installed.
+
+Fix:
+
+```bat
+python -m pip install pyinstaller
+```
+
+Then rerun `build_server_console.bat`.
+
+### PySide6 is missing
+
+Symptom: PyInstaller or the built executable reports that `PySide6` cannot be imported.
+
+Fix:
+
+```bat
+python -m pip install -r requirements.txt
+```
+
+Make sure the same Python environment is used for both dependency installation and the build.
+
+### Port already in use
+
+Symptom: The Server Console reports that the configured port is unavailable.
+
+Fix: Stop the other process using the port or change the Server Console port in the Settings section. The default server port is `8765`.
+
+### Windows firewall blocks discovery
+
+Symptom: The health endpoint works locally, but other machines or the desktop client cannot discover the server.
+
+Fix: Allow `SARAppServerConsole.exe` through Windows Defender Firewall for the appropriate network profile. Discovery uses UDP broadcast on the configured discovery port; the default discovery port is `45454`.
+
+### Server starts but the client does not discover it
+
+Checklist:
+
+- Confirm **Discovery** is enabled in the Server Console settings.
+- Confirm **Discovery status** says **Broadcasting** after the server starts.
+- Confirm the desktop client and Server Console are on the same LAN or broadcast domain.
+- Confirm Windows firewall or endpoint security is not blocking UDP broadcast traffic.
+- Try manually connecting the desktop client to the Server Console host and port if broadcast discovery is blocked.
+
+### Health endpoint is not responding
+
+Checklist:
+
+- Confirm the Server Console status is **Running**.
+- Confirm the configured host and port are correct.
+- For a default local check, open `http://127.0.0.1:8765/health`.
+- If the port was changed, use the configured port in the URL.
+- If another service is using the port, stop it or choose a different Server Console port.

--- a/packaging/SARAppServerConsole.spec
+++ b/packaging/SARAppServerConsole.spec
@@ -1,0 +1,63 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller build specification for the standalone SARApp Server Console."""
+
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_submodules
+
+
+project_root = Path(SPECPATH).resolve().parent.parent
+
+hiddenimports = [
+    *collect_submodules("PySide6"),
+    *collect_submodules("server"),
+    *collect_submodules("core.networking"),
+]
+
+
+a = Analysis(
+    [str(project_root / "sarapp_server_console.py")],
+    pathex=[str(project_root)],
+    binaries=[],
+    datas=[],
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        "PySide6.QtQml",
+        "PySide6.QtQuick",
+        "PySide6.QtQuickControls2",
+        "PySide6.QtQuickWidgets",
+    ],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="SARAppServerConsole",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="SARAppServerConsole",
+)

--- a/server/server_console/settings.py
+++ b/server/server_console/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -10,7 +11,15 @@ from typing import Any
 from core.networking.server_info import DEFAULT_DISCOVERY_PORT, DEFAULT_SERVER_PORT
 
 
-DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "settings" / "server_console.json"
+def _default_config_path() -> Path:
+    """Return a writable settings path for source and PyInstaller launches."""
+
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent / "settings" / "server_console.json"
+    return Path(__file__).resolve().parents[2] / "settings" / "server_console.json"
+
+
+DEFAULT_CONFIG_PATH = _default_config_path()
 
 
 @dataclass(slots=True)

--- a/tests/server_console/test_settings.py
+++ b/tests/server_console/test_settings.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
-from server.server_console.settings import ServerConsoleSettings, ServerConsoleSettingsStore, validate_port
+from server.server_console.settings import (
+    ServerConsoleSettings,
+    ServerConsoleSettingsStore,
+    _default_config_path,
+    validate_port,
+)
 
 
 def test_server_console_settings_load_defaults_when_no_config_exists(tmp_path) -> None:
@@ -31,6 +38,14 @@ def test_server_console_settings_save_and_reload(tmp_path) -> None:
     loaded = store.load()
 
     assert loaded == expected
+
+
+def test_server_console_frozen_default_settings_live_next_to_exe(monkeypatch, tmp_path) -> None:
+    exe_path = tmp_path / "SARAppServerConsole.exe"
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(exe_path))
+
+    assert _default_config_path() == tmp_path / "settings" / "server_console.json"
 
 
 @pytest.mark.parametrize("value", [0, 65536, "not-a-port"])

--- a/tools/smoke_test_server_console.py
+++ b/tools/smoke_test_server_console.py
@@ -1,0 +1,23 @@
+"""Smoke checks for the SARApp Server Console PyInstaller output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+EXE_PATH = Path("dist") / "SARAppServerConsole" / "SARAppServerConsole.exe"
+
+
+def main() -> int:
+    if not EXE_PATH.exists():
+        print(f"Missing expected executable: {EXE_PATH}")
+        return 1
+    if not EXE_PATH.is_file():
+        print(f"Expected a file but found something else: {EXE_PATH}")
+        return 1
+    print(f"Found SARApp Server Console executable: {EXE_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a standalone, windowed Windows EXE for the SARApp Server Console so it can be run independently for testing without requiring users to run Python manually. 
- Keep the Server Console packaging separate from the main desktop client and avoid QML or desktop-app redesigns. 
- Ensure the packaged console can persist settings in a writable location when run as a frozen executable.

### Description

- Add a dedicated PyInstaller spec at `packaging/SARAppServerConsole.spec` that uses `sarapp_server_console.py` as the entry point, collects `PySide6`, `server`, and `core.networking` hidden imports, and excludes Qt Quick/QML modules. 
- Add a Windows build script `build_server_console.bat` that cleans prior artifacts, runs PyInstaller with the new spec, verifies output at `dist\SARAppServerConsole\SARAppServerConsole.exe`, and prints clear success/failure messages, plus a simple smoke-check script `tools/smoke_test_server_console.py`. 
- Make settings resolution handle frozen runs by writing `settings/server_console.json` next to the packaged executable while preserving the existing repo-based settings path when running from source (`server/server_console/settings.py`). 
- Add packaging documentation `docs/server_console_packaging.md` describing prerequisites, build/run steps, validation steps, and troubleshooting, and add a unit test exercising the frozen-settings path (`tests/server_console/test_settings.py`).

### Testing

- Ran unit tests: `python -m pytest tests/server_console/test_settings.py tests/server_console/test_controller.py` and all tests passed (`9 passed`).
- Verified new and modified modules compile: `python -m py_compile sarapp_server_console.py server/server_console/settings.py tools/smoke_test_server_console.py` completed without errors.
- Added the packaging spec, build script, smoke test, documentation, settings-path behavior, and unit test to the repository; the Windows EXE build is covered by the script and docs for validation on Windows environments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2cdd9c4160832bb06b8935b65ceb2d)